### PR TITLE
Allow for general prime coefficients in VietorisRipsPersistence (#15)

### DIFF
--- a/giotto/externals/python/ripser_interface.py
+++ b/giotto/externals/python/ripser_interface.py
@@ -15,7 +15,7 @@ def DRFDM(DParam, maxHomDim, thresh=-1, coeff=2, do_cocycles=1):
 
 def DRFDMSparse(I, J, V, N, maxHomDim, thresh=-1, coeff=2, do_cocycles=1):
     print('DRFDMSparse')
-    ret = rips_dm_sparse(I, J, V, I.size, coeff, maxHomDim, thresh, do_cocycles)
+    ret = rips_dm_sparse(I, J, V, I.size, N, coeff, maxHomDim, thresh, do_cocycles)
     ret_rips = {}
     ret_rips.update({"births_and_deaths_by_dim": ret.births_and_deaths_by_dim})
     ret_rips.update({"num_edges": ret.num_edges})


### PR DESCRIPTION
- Fix call to rips_dm_sparse as suggested by Julian
- Add coeff parameter in VietorisRipsPersistence constructor and use it in call to _ripser_diagram
- Finalise documentation