### PR TITLE
diffusion modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ data/*
 examples/*
 !examples/README.rst
 !examples/Lorenz_Attractor.ipynb
+!examples/Graph_classification.ipynb
 
 # Built docs
 doc/build

--- a/examples/Classifying_shapes.ipynb
+++ b/examples/Classifying_shapes.ipynb
@@ -395,7 +395,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/examples/Graph_classification.ipynb
+++ b/examples/Graph_classification.ipynb
@@ -1,0 +1,614 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Case study : Classification of graph entities - nodes and edges\n",
+    "\n",
+    "##### License: Apache 2.0\n",
+    "\n",
+    "\n",
+    "The following notebook shows how it is possible to use the diffusion modules to classify nodes and edges of different generated graphs by taking into account their structural similarity. The idea is studied in the paper $\\href{https://arxiv.org/abs/1710.10321}{Learning Structural Node Embeddings Via Diffusion Wavelets}$ where the authors propose a method called GraphWave which exploits heat diffusion processes on graphs to embed nodes into a multidimensional euclidean space. The following procedure is a modification and extension version of GraphWave which allows to embed, and then classify, higher order graph structures like edges by exploiting concepts of Topological Data Analysis. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-05-20T15:47:57.579995Z",
+     "start_time": "2019-05-20T15:47:56.691344Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np \n",
+    "import networkx as nx\n",
+    "\n",
+    "from giotto.graphs.create_clique_complex import CreateCliqueComplex, CreateLaplacianMatrices, CreateBoundaryMatrices\n",
+    "from giotto.graphs.heat_diffusion import HeatDiffusion\n",
+    "from giotto.graphs.graph_entropy import GraphEntropy\n",
+    "from sklearn.decomposition import PCA\n",
+    "from sklearn.cluster import KMeans\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Plotting Functions #"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib\n",
+    "import matplotlib.pyplot as plt\n",
+    "from plotting import plot_network_diffusion, plot_entropies"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example 1 : The Barbell Graph#"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The first graph analyzed is the Barbell Graph which is studied also in the GraphWave paper. We generate here the graph and plot it. The graph is made of two fully connected clusters linked by a chain of nodes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g = nx.barbell_graph(9,7)\n",
+    "#Layout for the plotted graph\n",
+    "pos = nx.shell_layout(g)\n",
+    "plt.figure(figsize=(20,8))\n",
+    "plot_network_diffusion(g, pos)\n",
+    "_ = plt.axis('off')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create Complex and Laplacians #"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this phase the clique complex of the graph is computed and returned as a dictionary. Once the dictionary $cd$ is computed, the relative zero and one laplacian matrices are computed by using $CreateLaplacianMatrices$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-05-20T15:48:02.921096Z",
+     "start_time": "2019-05-20T15:48:02.878821Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "cc = CreateCliqueComplex(g)\n",
+    "cd = cc.create_complex_from_graph()\n",
+    "laplacians = CreateLaplacianMatrices().fit_transform(cd, (0,1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Find Embedding for nodes and edges#"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First of all it is necessery to set the hyperparameters of the algorithm that in this case are the points in time at which sampling node and edge diffusions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-05-20T15:48:04.101586Z",
+     "start_time": "2019-05-20T15:48:04.097570Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#Hyperparameters \n",
+    "\n",
+    "#Temporal instants to take for node diffusions\n",
+    "taus_n = np.linspace(0, 2, 40)\n",
+    "\n",
+    "#Temporal instants to take for edge diffusions\n",
+    "taus_e = np.linspace(0, 2, 40)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Heat Diffusion process is here computed for nodes and edges. Given that the parameter $\\textit{initial_condition}$ is not passed to the $\\textit{HeatDiffusion}$ object, the identity matrix is taken. This means that for each node (edge) there is a heat diffusion process with inititial condition a delta on that node (edge)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "heat_vectors_n = HeatDiffusion().fit_transform(laplacians[0], taus=taus_n)\n",
+    "heat_vectors_e = HeatDiffusion().fit_transform(laplacians[1], taus=taus_e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we have sampled the heat processes, given a fixed simplex (be either a node or an edge) and point in time, we treat the heat values as a probability distribution over the graph of which entropy is computed. The entropy values computed at different point in time represent the structural features of the simplex."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mh_n = GraphEntropy().fit_transform(heat_vectors_n).T\n",
+    "mh_e = GraphEntropy().fit_transform(heat_vectors_e).T"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Clusters of nodes (0-simplices) based on structural embedding #"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this step we cluster the points related to each node by using the KMeans algorithm. We can then represent each node with the centroid of its corresponding class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-05-20T15:48:06.971995Z",
+     "start_time": "2019-05-20T15:48:06.876571Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#Simple K-mean\n",
+    "kmeans = KMeans(n_clusters=6)\n",
+    "kmeans.fit(np.transpose(mh_n))\n",
+    "y_kmeans_n = kmeans.predict(np.transpose(mh_n))\n",
+    "\n",
+    "#Just for Visualization, plot 2D PCA embedding with points colored by classes\n",
+    "pca = PCA(n_components=2)\n",
+    "principalComponents = pca.fit_transform(np.transpose(mh_n))\n",
+    "#Colors for classes (at most 8)\n",
+    "col = ['blue', 'yellow', 'black', 'grey', 'green', 'brown', 'red', 'orange']\n",
+    "barbell_node_cols = [col[e] for e in y_kmeans_n]\n",
+    "_ = plt.scatter(np.ravel(principalComponents[:,0]),np.ravel(principalComponents[:,1]),  c=barbell_node_cols, s=100)\n",
+    "_ = plt.title(\"2D-PCA representation of nodes in structural space\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now plot the graph by coloring nodes with respect to their classes. We can see that different structural nodes, that is nodes with different structures in the neighborhood, are colored differently."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Plot the diffusion starting from a specific node at a specific time as a function defined over the nodes of the graph.\n",
+    "plt.figure(figsize=(20,8))\n",
+    "plot_network_diffusion(g, pos ,node_vector=barbell_node_cols)\n",
+    "_ = plt.axis('off')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cluster the 1-simplexes based on the embedding space #"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition to the node classfication we are able to provide a similar edge analisys thanks to the topological properties of higher order laplacians and heat diffusion processes defined over higher order structures."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-05-20T15:48:11.714799Z",
+     "start_time": "2019-05-20T15:48:11.696484Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#Simple K-mean\n",
+    "kmeans = KMeans(n_clusters=6)\n",
+    "kmeans.fit(np.transpose(mh_e))\n",
+    "y_kmeans_e = kmeans.predict(np.transpose(mh_e))\n",
+    "\n",
+    "#Just for Visualization\n",
+    "pca = PCA(n_components=2)\n",
+    "principalComponents = pca.fit_transform(np.transpose(mh_e))\n",
+    "#Associate colors to each nodes w.r.t. its class\n",
+    "barbell_edge_cols = [col[e] for e in y_kmeans_e]\n",
+    "_ = plt.scatter(np.ravel(principalComponents[:,0]),np.ravel(principalComponents[:,1]),  c=barbell_edge_cols, s=80)\n",
+    "_ = plt.title(\"2D-PCA representation of edges in structural space\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Plot the diffusion starting from a specific node at a specific time as a function defined over the nodes of the graph.\n",
+    "plt.figure(figsize=(20,8))\n",
+    "plot_network_diffusion(g, pos, edge_vector=barbell_edge_cols)\n",
+    "_ = plt.axis('off')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example 2: Torus #"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We run exactly the same experiment with a graph which is a triangulation of a torus."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g = nx.triangular_lattice_graph(10, 10, periodic=True)\n",
+    "# Needed for the specific nx.grid_2d_graph labeling\n",
+    "mapping = dict(zip(list(g.nodes), range(0, nx.number_of_nodes(g))))\n",
+    "g = nx.relabel_nodes(g, mapping)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(20,8))\n",
+    "pos = nx.spring_layout(g, iterations=1000)\n",
+    "plot_network_diffusion(g, pos)\n",
+    "_ = plt.axis('off')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By this experiment we want to highlight the fact that, from the point of neighborhood structural similarity, all nodes of a torus are equivalent. Our method is able to capture this fact."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cc = CreateCliqueComplex(g)\n",
+    "cd = cc.create_complex_from_graph()\n",
+    "laplacians = CreateLaplacianMatrices().fit_transform(cd, (0,1))\n",
+    "\n",
+    "heat_vectors_n = HeatDiffusion().fit_transform(laplacians[0], taus=taus_n)\n",
+    "heat_vectors_e = HeatDiffusion().fit_transform(laplacians[1], taus=taus_e)\n",
+    "mh_n = GraphEntropy().fit_transform(heat_vectors_n).T\n",
+    "mh_e = GraphEntropy().fit_transform(heat_vectors_e).T\n",
+    "\n",
+    "#Simple K-mean\n",
+    "kmeans = KMeans(n_clusters=1)\n",
+    "kmeans.fit(np.transpose(mh_n))\n",
+    "y_kmeans_n = kmeans.predict(np.transpose(mh_n))\n",
+    "\n",
+    "#Just for Visualization, plot 2D PCA embedding with points colored by classes\n",
+    "pca = PCA(n_components=2)\n",
+    "principalComponents = pca.fit_transform(np.transpose(mh_n))\n",
+    "torus_node_cols = [col[e] for e in y_kmeans_n]\n",
+    "_ = plt.scatter(np.ravel(principalComponents[:,0]),np.ravel(principalComponents[:,1]),  c=torus_node_cols, s=80)\n",
+    "_ = plt.title(\"2D-PCA representation of nodes in structural space\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All nodes have the same color given that they represent the same structural class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Plot the diffusion starting from a specific node at a specific time as a function defined over the nodes of the graph.\n",
+    "plt.figure(figsize=(20,8))\n",
+    "plot_network_diffusion(g,pos,node_vector=torus_node_cols)\n",
+    "_ = plt.axis('off')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Again it is interesting to see that, in the edge space, the 1-simplices can be grouped into two different classes corresponding to the direction of the two representative vector of the 1-homology class. Indeed in this specific triangulation of the torus there are exactly 2 1-dimensional holes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Simple K-mean\n",
+    "kmeans = KMeans(n_clusters=2)\n",
+    "kmeans.fit(np.transpose(mh_e))\n",
+    "y_kmeans_e = kmeans.predict(np.transpose(mh_e))\n",
+    "\n",
+    "#Just for Visualization\n",
+    "pca = PCA(n_components=2)\n",
+    "principalComponents = pca.fit_transform(np.transpose(mh_e))\n",
+    "#Associate colors to each nodes w.r.t. its class\n",
+    "torus_edge_cols = [col[e] for e in y_kmeans_e]\n",
+    "_ = plt.scatter(np.ravel(principalComponents[:,0]),np.ravel(principalComponents[:,1]),  c=torus_edge_cols)\n",
+    "_ = plt.title(\"2D-PCA representation of edges in structural space\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Plot the diffusion starting from a specific node at a specific time as a function defined over the nodes of the graph.\n",
+    "plt.figure(figsize=(20,8))\n",
+    "plot_network_diffusion(g, pos, edge_vector=torus_edge_cols)\n",
+    "_ = plt.axis('off')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Node Heat Diffusion Process #\n",
+    "\n",
+    "Here we want to give a glimpse on the behaviour of the heat diffusion process on graph nodes. The following plots represent 3 snapshots of the process taken at 3 different points in time.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plotting\n",
+    "plt.figure(figsize=(20,6))\n",
+    "for i in range(3):\n",
+    "    plt.subplot(1,3,i+1)\n",
+    "    plot_network_diffusion(g, pos, node_vector=heat_vectors_n[:,15,i*5])\n",
+    "    plt.axis('off')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example 3 : 2-D grid graph #"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "g = nx.triangular_lattice_graph(10,10, periodic=False)\n",
+    "mapping = dict(zip(list(g.nodes), range(0, nx.number_of_nodes(g))))\n",
+    "g = nx.relabel_nodes(g, mapping)\n",
+    "pos =nx.spring_layout(g, iterations=2000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cc = CreateCliqueComplex(g)\n",
+    "cd = cc.create_complex_from_graph()\n",
+    "laplacians = CreateLaplacianMatrices().fit_transform(cd, (0,1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "heat_vectors_n = HeatDiffusion().fit_transform(laplacians[0], taus=taus_n)\n",
+    "heat_vectors_e = HeatDiffusion().fit_transform(laplacians[1], taus=taus_e)\n",
+    "mh_n = GraphEntropy().fit_transform(heat_vectors_n).T\n",
+    "mh_e = GraphEntropy().fit_transform(heat_vectors_e).T"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Simple K-mean\n",
+    "kmeans = KMeans(n_clusters=6)\n",
+    "kmeans.fit(np.transpose(mh_n))\n",
+    "y_kmeans_n = kmeans.predict(np.transpose(mh_n))\n",
+    "\n",
+    "#Just for Visualization, plot 2D PCA embedding with points colored by classes\n",
+    "pca = PCA(n_components=2)\n",
+    "principalComponents = pca.fit_transform(np.transpose(mh_n))\n",
+    "\n",
+    "grid_nodes_cols = [col[e] for e in y_kmeans_n]\n",
+    "_ = plt.scatter(np.ravel(principalComponents[:,0]),np.ravel(principalComponents[:,1]),  c=grid_nodes_cols)\n",
+    "_ = plt.title(\"2D-PCA representation of nodes in structural space\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Plot the diffusion starting from a specific node at a specific time as a function defined over the nodes of the graph.\n",
+    "plt.figure(figsize=(20,8))\n",
+    "plot_network_diffusion(g, pos, node_vector=grid_nodes_cols)\n",
+    "_ = plt.axis('off')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Simple K-mean\n",
+    "kmeans = KMeans(n_clusters=5)\n",
+    "kmeans.fit(np.transpose(mh_e))\n",
+    "y_kmeans_e = kmeans.predict(np.transpose(mh_e))\n",
+    "\n",
+    "#Just for Visualization\n",
+    "pca = PCA(n_components=2)\n",
+    "principalComponents = pca.fit_transform(np.transpose(mh_e))\n",
+    "#Associate colors to each nodes w.r.t. its class\n",
+    "grid_edge_cols = [col[e] for e in y_kmeans_e]\n",
+    "plt.scatter(np.ravel(principalComponents[:,0]),np.ravel(principalComponents[:,1]),  c=grid_edge_cols)\n",
+    "_ = plt.title(\"2D-PCA representation of edges in structural space\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Plot the diffusion starting from a specific node at a specific time as a function defined over the nodes of the graph.\n",
+    "plt.figure(figsize=(20,8))\n",
+    "plot_network_diffusion(g, pos, edge_vector=grid_edge_cols)\n",
+    "_ = plt.axis('off')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "thesis",
+   "language": "python",
+   "name": "thesis"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/Graph_classification.ipynb
+++ b/examples/Graph_classification.ipynb
@@ -550,9 +550,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "thesis",
+   "display_name": "Python (py35)",
    "language": "python",
-   "name": "thesis"
+   "name": "py35"
   },
   "language_info": {
    "codemirror_mode": {
@@ -564,7 +564,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.5.6"
   },
   "toc": {
    "base_numbering": 1,

--- a/examples/plotting.py
+++ b/examples/plotting.py
@@ -4,6 +4,9 @@ import numpy as np
 import plotly.graph_objs as gobj
 from giotto.diagrams._utils import _subdiagrams
 
+import matplotlib.pyplot as plt
+import networkx as nx
+
 
 def plot_point_cloud(point_cloud, dimension=None):
     """Plot the first 2 or 3 coordinates of the point cloud.
@@ -391,3 +394,57 @@ def plot_betti_surfaces(betti_curves, samplings=None,
                                        connectgaps=True, hoverinfo='none'))
             
             fig.show()
+
+def plot_entropies(entropies, s_list):
+
+    """
+    Utility function to plot entropies as a function of time steps
+    """
+
+    fig1 = plt.figure(figsize=(7,4))
+    a1 = fig1.add_subplot(111)
+    colors = ['blue', 'red', 'black', 'yellow', 'orange', 'green', 'grey',
+              'brown']
+
+    for i in s_list:
+        # plot entropies Vs temporal indexes
+        hs1 = entropies[:, i]
+        a1.plot(hs1, label="simplex " + str(i), color=colors[i % len(colors)])
+
+    plt.xticks()
+    a1.set_title('Entropy profiles of different simplices')
+    a1.legend()
+
+    return
+
+
+def plot_network_diffusion(G, pos, node_vector=None, edge_vector=None,
+                           node_labels=False, edge_labels=False):
+
+    # Find edge labels
+    l_e = list(G.edges)
+    e = dict((tuple(sorted(l_e[x])), x) for x in range(0, len(l_e)))
+    e_labels = {tuple(x): 'e' + str(y) for x, y in e.items()}
+
+    if edge_vector is not None:
+        colors_edge = np.squeeze(np.asarray(edge_vector))
+        _ = nx.draw_networkx_edges(G, pos, edge_color=colors_edge,
+                                   width=3, with_labels=False)
+    else:
+        _ = nx.draw_networkx_edges(G, pos, edge_color="gray",
+                                   width=2, with_labels=False)
+
+    if node_vector is not None:
+        colors_node = np.squeeze(np.asarray(node_vector))
+        _ = nx.draw_networkx_nodes(G, pos, node_color=colors_node,
+                                   with_labels=False, node_size=500)
+    else:
+        _ = nx.draw_networkx_nodes(G, pos, node_color="blue",
+                                   with_labels=False)
+
+    if edge_labels:
+        _ = nx.draw_networkx_edge_labels(G, pos, e_labels, alpha=1)
+    if node_labels:
+        _ = nx.draw_networkx_labels(G, pos)
+
+    return 

--- a/giotto/graphs/__init__.py
+++ b/giotto/graphs/__init__.py
@@ -2,13 +2,13 @@
 extract metric spaces from graphs.
 """
 
-from giotto.graphs.geodesic_distance import GraphGeodesicDistance
-from giotto.graphs.kneighbors import KNeighborsGraph
-from giotto.graphs.transition import TransitionGraph
-from giotto.graphs.create_clique_complex import CreateCliqueComplex, \
+from .geodesic_distance import GraphGeodesicDistance
+from .kneighbors import KNeighborsGraph
+from .transition import TransitionGraph
+from .create_clique_complex import CreateCliqueComplex, \
     CreateBoundaryMatrices, CreateLaplacianMatrices
-from giotto.graphs.heat_diffusion import HeatDiffusion
-from giotto.graphs.graph_entropy import GraphEntropy
+from .heat_diffusion import HeatDiffusion
+from .graph_entropy import GraphEntropy
 
 __all__ = [
     'TransitionGraph',

--- a/giotto/graphs/__init__.py
+++ b/giotto/graphs/__init__.py
@@ -5,7 +5,8 @@ extract metric spaces from graphs.
 from giotto.graphs.geodesic_distance import GraphGeodesicDistance
 from giotto.graphs.kneighbors import KNeighborsGraph
 from giotto.graphs.transition import TransitionGraph
-from giotto.graphs.create_clique_complex import CreateCliqueComplex, CreateBoundaryMatrices, CreateLaplacianMatrices
+from giotto.graphs.create_clique_complex import CreateCliqueComplex, \
+    CreateBoundaryMatrices, CreateLaplacianMatrices
 from giotto.graphs.heat_diffusion import HeatDiffusion
 from giotto.graphs.graph_entropy import GraphEntropy
 

--- a/giotto/graphs/__init__.py
+++ b/giotto/graphs/__init__.py
@@ -5,9 +5,17 @@ extract metric spaces from graphs.
 from giotto.graphs.geodesic_distance import GraphGeodesicDistance
 from giotto.graphs.kneighbors import KNeighborsGraph
 from giotto.graphs.transition import TransitionGraph
+from giotto.graphs.create_clique_complex import CreateCliqueComplex, CreateBoundaryMatrices, CreateLaplacianMatrices
+from giotto.graphs.heat_diffusion import HeatDiffusion
+from giotto.graphs.graph_entropy import GraphEntropy
 
 __all__ = [
     'TransitionGraph',
     'KNeighborsGraph',
     'GraphGeodesicDistance'
+    'CreateCliqueComplex'
+    'CreateBoundaryMatrices'
+    'CreateLaplacianMatrices'
+    'HeatDiffusion'
+    'GraphEntropy'
 ]

--- a/giotto/graphs/__init__.py
+++ b/giotto/graphs/__init__.py
@@ -12,10 +12,10 @@ from giotto.graphs.graph_entropy import GraphEntropy
 __all__ = [
     'TransitionGraph',
     'KNeighborsGraph',
-    'GraphGeodesicDistance'
-    'CreateCliqueComplex'
-    'CreateBoundaryMatrices'
-    'CreateLaplacianMatrices'
-    'HeatDiffusion'
+    'GraphGeodesicDistance',
+    'CreateCliqueComplex',
+    'CreateBoundaryMatrices',
+    'CreateLaplacianMatrices',
+    'HeatDiffusion',
     'GraphEntropy'
 ]

--- a/giotto/graphs/create_clique_complex.py
+++ b/giotto/graphs/create_clique_complex.py
@@ -162,9 +162,6 @@ class CreateBoundaryMatrices(BaseEstimator, TransformerMixin):
 
     """
 
-    def __init__(self):
-        return
-
     def fit(self, X, orders, y=None):
         """Do nothing and return the estimator unchanged.
 
@@ -297,8 +294,6 @@ class CreateLaplacianMatrices(BaseEstimator, TransformerMixin):
 
 
     """
-    def __init__(self):
-        return
 
     def fit(self, X, orders, y=None):
         """Set the orders paramteres.

--- a/giotto/graphs/create_clique_complex.py
+++ b/giotto/graphs/create_clique_complex.py
@@ -375,7 +375,7 @@ class CreateLaplacianMatrices(BaseEstimator, TransformerMixin):
             if x > 0:
                 lap = csr_matrix.transpose(boundaries[self.order_id_[x]]) *\
                       boundaries[self.order_id_[x]]
-                if x < len(X):
+                if x < len(X)-1:
                     lap += boundaries[self.order_id_[x+1]] *\
                         csr_matrix.transpose(boundaries[self.order_id_[x+1]])
             else:

--- a/giotto/graphs/create_clique_complex.py
+++ b/giotto/graphs/create_clique_complex.py
@@ -7,7 +7,8 @@ import networkx as nx
 from scipy.spatial import distance_matrix
 from scipy.sparse import csr_matrix, lil_matrix
 from itertools import combinations
-from sklearn.utils.validation import check_symmetric, check_is_fitted, check_array
+from sklearn.utils.validation import check_symmetric, check_is_fitted,\
+    check_array
 from sklearn.base import BaseEstimator, TransformerMixin
 
 
@@ -41,7 +42,7 @@ class CreateCliqueComplex:
         Type of raw data to be preprocessed. If set to 'graph'
         the Input 'graph' has to be a netowrkx graph object.
         If set to 'cloud' the data is to be interpreted as a collection
-        of points where row index represents sample ID and columns the features.
+        of points where row index represents sample ID and columns the features
         If set to 'matrix' the data is to be interpreted as a
         distance matrix (symmetric) collecting element-wise distances
         between the elements.
@@ -101,19 +102,22 @@ class CreateCliqueComplex:
     def _find_lists(self):
 
         """
-        Collect all cliques of a graph and create dictionary with all simplices.
+        Collect all cliques of a graph and create dictionary with all simplices
         """
 
         # Index for edges and nodes, arbitrary id to edges
         sim_complex = dict()
 
-        sim_complex[1] = dict(zip(np.arange(nx.number_of_edges(self.graph)), self.graph.edges))
+        sim_complex[1] = dict(zip(np.arange(
+            nx.number_of_edges(self.graph)), self.graph.edges))
         sim_complex[0] = dict(zip(self.graph.nodes, self.graph.nodes))
 
-        # Dictionary containing simplexes orders as indexes, list of tuplas with node id forming the simplexes
+        # Dictionary containing simplexes orders as indexes,
+        # list of tuplas with node id forming the simplexes
         cliques = list(nx.enumerate_all_cliques(self.graph))
 
-        for x in range(nx.number_of_nodes(self.graph) + nx.number_of_edges(self.graph), len(cliques)):
+        for x in range(nx.number_of_nodes(self.graph) +
+                       nx.number_of_edges(self.graph), len(cliques)):
             if sim_complex.get(len(cliques[x]) - 1) is None:
                 i = 0
                 sim_complex[(len(cliques[x]) - 1)] = dict()
@@ -126,15 +130,18 @@ class CreateCliqueComplex:
         self.complex_dict = sim_complex
 
     def _create_graph(self):
-        distance_to_adjacent = np.vectorize(lambda x: 1 if x < self.alpha else 0)
+        distance_to_adjacent = np.vectorize(lambda x:
+                                            1 if x < self.alpha else 0)
 
         if self.data_type == 'cloud':
-            self.adjacent_matrix = distance_to_adjacent(distance_matrix(self.data, self.data, p=2))
+            self.adjacent_matrix = distance_to_adjacent(
+                distance_matrix(self.data, self.data, p=2))
         else:
             check_symmetric(self.data)
             self.adjacent_matrix = distance_to_adjacent(self.data)
 
-        self.adjacent_matrix = self.adjacent_matrix - np.identity(self.data.shape[0])
+        self.adjacent_matrix = self.adjacent_matrix - np.identity(
+            self.data.shape[0])
         return nx.from_numpy_matrix(self.adjacent_matrix)
 
     def get_adjacent_matrix(self):
@@ -182,10 +189,10 @@ class CreateBoundaryMatrices(BaseEstimator, TransformerMixin):
         self : object
 
         """
-        self.sizes = dict()
+        self.sizes_ = dict()
         for ele in X:
-            self.sizes[ele] = len(X[ele])
-        self.orders = sorted(orders)
+            self.sizes_[ele] = len(X[ele])
+        self.orders_ = sorted(orders)
 
         return self
 
@@ -211,17 +218,19 @@ class CreateBoundaryMatrices(BaseEstimator, TransformerMixin):
             List containing the boundary matrices for all orders specified
             in tuple 'orders'.
         """
-        check_is_fitted(self, ['sizes', 'orders'])
+        check_is_fitted(self, ['sizes_', 'orders_'])
         boundaries = list()
         incidence = self._create_incidence_from_dict(X)
 
         for order, order_inc in incidence.items():
-            if isinstance(self.orders, int):
-                orders = [self.orders]
-            if order in self.orders:
-                # Temporary sparse matrix, useful for dynamic creation of sparse matrices
+            if isinstance(self.orders_, int):
+                orders = [self.orders_]
+            if order in self.orders_:
+                # Temporary sparse matrix, useful for dynamic
+                # creation of sparse matrices
                 # This is the boundary matrix from order to order-1 simplexes
-                temp_mat = lil_matrix((self.sizes[order - 1], self.sizes[order]))
+                temp_mat = lil_matrix(
+                    (self.sizes_[order - 1], self.sizes_[order]))
                 for k, v in order_inc.items():
                     for x in v:
                         temp_mat[k, x[0]] = np.sign(x[1])
@@ -254,15 +263,17 @@ class CreateBoundaryMatrices(BaseEstimator, TransformerMixin):
         for order, order_list in complex_dict.items():
             if order > 1:
 
-                # To check if this simplex has been already put into the dictionary
-                compare = dict((tuple(np.sort(y)), x) for x, y in complex_dict[order - 1].items())
+                # To check if this simplex has been already
+                # put into the dictionary
+                compare = dict((tuple(np.sort(y)), x) for x, y in
+                               complex_dict[order - 1].items())
                 # Create new dict for incidence from order-1 to order simplexes
                 incidence[order] = dict()
                 # Start from zero to label simplexes
                 idx = 0
 
                 for y, c in order_list.items():
-                    # Order the set of vertices to impose the right orientations
+                    # Order the set of vertices to impose the orientations
                     c = np.sort(c)
                     complex_dict[order][idx] = tuple(c)
                     # Keep track of the (-1) exponent
@@ -270,7 +281,8 @@ class CreateBoundaryMatrices(BaseEstimator, TransformerMixin):
                     # Find all faces of c (c contains order+1 vertices)
                     for x in combinations(c, order):
                         if incidence[order].get(compare[x]) is not None:
-                            incidence[order][compare[x]].append((idx, (-1) ** i))
+                            incidence[order][compare[x]].append(
+                                (idx, (-1) ** i))
                         else:
                             incidence[order][compare[x]] = [(idx, (-1) ** i)]
                         i += 1
@@ -316,22 +328,23 @@ class CreateLaplacianMatrices(BaseEstimator, TransformerMixin):
         """
         # Check if there is only one index
         if isinstance(orders, int):
-            self.orders = [orders]
+            self.orders_ = [orders]
         else:
-            self.orders = sorted(orders)
+            self.orders_ = sorted(orders)
 
-        self.bound_orders = tuple(sorted((set(self.orders) - {0}).union(set([x + 1 for x in self.orders]))))
-        self.order_id = dict()
-        for x, y in enumerate(self.bound_orders):
-            self.order_id[y] = x
+        self.bound_orders_ = tuple(sorted((set(self.orders_) - {0}).union(
+            set([x + 1 for x in self.orders_]))))
+        self.order_id_ = dict()
+        for x, y in enumerate(self.bound_orders_):
+            self.order_id_[y] = x
 
         return self
 
     def transform(self, X, y=None):
         """Compute laplacians of complex.
 
-        Compute laplacians starting from a Graph Object up to certain order applying the formula
-        from the boundary matrices
+        Compute laplacians starting from a Graph Object up to certain
+        order applying the formula from the boundary matrices
 
         Parameters
         ----------
@@ -350,20 +363,24 @@ class CreateLaplacianMatrices(BaseEstimator, TransformerMixin):
             in tuple 'orders'.
 
         """
-        check_is_fitted(self, ['orders', 'bound_orders', 'order_id'])
+        check_is_fitted(self, ['orders_', 'bound_orders_', 'order_id_'])
         laplacians = list()
 
-        cb = CreateBoundaryMatrices().fit(X, self.bound_orders)
+        cb = CreateBoundaryMatrices().fit(X, self.bound_orders_)
         boundaries = cb.transform(X)
 
-        for x in self.orders:
-            # if maximal order, don't use the x+1 boundary, if minimal don't use 0 boundaries
+        for x in self.orders_:
+            # if maximal order, don't use the x+1 boundary,
+            # if minimal don't use 0 boundaries
             if x > 0:
-                lap = csr_matrix.transpose(boundaries[self.order_id[x]]) * boundaries[self.order_id[x]]
+                lap = csr_matrix.transpose(boundaries[self.order_id_[x]]) *\
+                      boundaries[self.order_id_[x]]
                 if x < len(X)-1:
-                    lap += boundaries[self.order_id[x+1]] * csr_matrix.transpose(boundaries[self.order_id[x+1]])
+                    lap += boundaries[self.order_id_[x+1]] *\
+                        csr_matrix.transpose(boundaries[self.order_id_[x+1]])
             else:
-                lap = boundaries[self.order_id[x+1]] * csr_matrix.transpose(boundaries[self.order_id[x+1]])
+                lap = boundaries[self.order_id_[x+1]] *\
+                      csr_matrix.transpose(boundaries[self.order_id_[x+1]])
 
             laplacians.append(lap)
 

--- a/giotto/graphs/create_clique_complex.py
+++ b/giotto/graphs/create_clique_complex.py
@@ -22,17 +22,17 @@ class CreateCliqueComplex:
     Parameters
     ----------
     graph : nx.graph, optional, default: ``None``
-        Graph of which computing the clique complex.
+        Graph from which to compute the clique complex
 
     data : ndarray, shape (n_points, n_dimensions) or \
         (n_points, n_points)
         If ``data_type == 'cloud'``, the input should be an
-        ndarray whose each entry along axis 0 is a vector with
+        ndarray, where each entry along axis 0 is a vector with
         the features of the relative point. Otherwise when
         'matrix' is passed as data_type the object should be a symmetric
         square matrix with distances between points.
 
-    alpha : float
+    alpha : float, optional, default: ``None``
         Real value to be used as a threshold while constructing
         the alpha-neighboring graph. For a point 'x' there will be an edge
         to each point 'y' if dist(x,y) < alpha, where here the
@@ -67,9 +67,8 @@ class CreateCliqueComplex:
         self.complex_dict = dict()
 
         if data_type == 'graph':
-            # check type graph
             if not isinstance(graph, nx.Graph):
-                raise ValueError("The parameter graph should be "
+                raise ValueError("The parameter 'graph' should be "
                                 "a networkx Graph object")
             self.graph = graph
             self.adjacent_matrix = nx.adjacency_matrix(self.graph)
@@ -77,29 +76,29 @@ class CreateCliqueComplex:
             check_array(data)
             if self.alpha is None:
                 raise ValueError("If 'data_type' is not 'graph' the parameter"
-                                "alpha must be a float number.")
+                                "alpha must be a float.")
             self.graph = self._create_graph()
             self.adjacent_matrix = csr_matrix(self.adjacent_matrix)
 
     def create_complex_from_graph(self):
         """
-        Functions that computes the Cliques Complex starting from
-        the related networkx graph object.
+        Function that computes the Clique complex from the associated
+        networkx Graph object.
 
         Returns
         -------
-        self.complex_dict : dictionary
+        self.complex_dict : dict
             Dictionary containing all simplices of the clique
             complex identified with arbitrary ID. Each entry 'K' of the
-            dictionary is again a dictionary contaning all K-simplexes.
+            dictionary is a dictionary contaning all K-simplexes.
 
         """
 
-        self._find_lists()
+        self._create_cliques_dict()
 
         return self.complex_dict
 
-    def _find_lists(self):
+    def _create_cliques_dict(self):
 
         """
         Collect all cliques of a graph and create dictionary with all simplices

--- a/giotto/graphs/create_clique_complex.py
+++ b/giotto/graphs/create_clique_complex.py
@@ -389,3 +389,4 @@ class CreateLaplacianMatrices(BaseEstimator, TransformerMixin):
 
 
 
+

--- a/giotto/graphs/create_clique_complex.py
+++ b/giotto/graphs/create_clique_complex.py
@@ -1,0 +1,375 @@
+# -*- coding: utf-8 -*-
+# License: Apache 2.0
+
+import numpy as np
+import networkx as nx
+
+from scipy.spatial import distance_matrix
+from scipy.sparse import csr_matrix, lil_matrix
+from itertools import combinations
+from sklearn.utils.validation import check_symmetric, check_is_fitted, check_array
+from sklearn.base import BaseEstimator, TransformerMixin
+
+
+class CreateCliqueComplex:
+    """Pre-processing step from unstructured data to graph and complex.
+
+    Useful in graph analysis to convert general point clouds or distance
+    matrices (numpy objects) into graphs (networkx objects) and clique
+    complex (described as a dictionary).
+
+    Parameters
+    ----------
+    graph : nx.graph, optional, default: ``None``
+        Graph of which computing the clique complex.
+
+    data : ndarray, shape (n_points, n_dimensions) or \
+        (n_points, n_points)
+        If ``data_type == 'cloud'``, the input should be an
+        ndarray whose each entry along axis 0 is a vector with
+        the features of the relative point. Otherwise when
+        'matrix' is passed as data_type the object should be a symmetric
+        square matrix with distances between points.
+
+    alpha : float
+        Real value to be used as a threshold while constructing
+        the alpha-neighboring graph. For a point 'x' there will be an edge
+        to each point 'y' if dist(x,y) < alpha, where here the
+        distance is the euclidean.
+
+    data_type : string, optional, default: ``'graph'``
+        Type of raw data to be preprocessed. If set to 'graph'
+        the Input 'graph' has to be a netowrkx graph object.
+        If set to 'cloud' the data is to be interpreted as a collection
+        of points where row index represents sample ID and columns the features.
+        If set to 'matrix' the data is to be interpreted as a
+        distance matrix (symmetric) collecting element-wise distances
+        between the elements.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> import networkx as nx
+    >>> X = np.random.random((20,2))
+    >>> plt.scatter(X[:,0], X[:,1])
+    >>> cc = CreateCliqueComplex(X, 0.5)
+    >>> cd = cc.create_complex_from_graph()
+    >>> nx.draw(cc.get_graph())
+
+    """
+
+    def __init__(self, graph=None, data=None, alpha=None, data_type='graph'):
+        self.data = data
+        self.alpha = alpha
+        self.data_type = data_type
+        self.complex_dict = dict()
+
+        if data_type == 'graph':
+            # check type graph
+            if not isinstance(graph, nx.Graph):
+                raise ValueError("The parameter graph should be "
+                                "a networkx Graph object")
+            self.graph = graph
+            self.adjacent_matrix = nx.adjacency_matrix(self.graph)
+        else:
+            check_array(data)
+            if self.alpha is None:
+                raise ValueError("If 'data_type' is not 'graph' the parameter"
+                                "alpha must be a float number.")
+            self.graph = self._create_graph()
+            self.adjacent_matrix = csr_matrix(self.adjacent_matrix)
+
+    def create_complex_from_graph(self):
+        """
+        Functions that computes the Cliques Complex starting from
+        the related networkx graph object.
+
+        Returns
+        -------
+        self.complex_dict : dictionary
+            Dictionary containing all simplices of the clique
+            complex identified with arbitrary ID. Each entry 'K' of the
+            dictionary is again a dictionary contaning all K-simplexes.
+
+        """
+
+        self._find_lists()
+
+        return self.complex_dict
+
+    def _find_lists(self):
+
+        """
+        Collect all cliques of a graph and create dictionary with all simplices.
+        """
+
+        # Index for edges and nodes, arbitrary id to edges
+        sim_complex = dict()
+
+        sim_complex[1] = dict(zip(np.arange(nx.number_of_edges(self.graph)), self.graph.edges))
+        sim_complex[0] = dict(zip(self.graph.nodes, self.graph.nodes))
+
+        # Dictionary containing simplexes orders as indexes, list of tuplas with node id forming the simplexes
+        cliques = list(nx.enumerate_all_cliques(self.graph))
+
+        for x in range(nx.number_of_nodes(self.graph) + nx.number_of_edges(self.graph), len(cliques)):
+            if sim_complex.get(len(cliques[x]) - 1) is None:
+                i = 0
+                sim_complex[(len(cliques[x]) - 1)] = dict()
+                sim_complex[len(cliques[x]) - 1][i] = tuple(cliques[x])
+                i += 1
+            else:
+                sim_complex[len(cliques[x]) - 1][i] = tuple(cliques[x])
+                i += 1
+
+        self.complex_dict = sim_complex
+
+    def _create_graph(self):
+        distance_to_adjacent = np.vectorize(lambda x: 1 if x < self.alpha else 0)
+
+        if self.data_type == 'cloud':
+            self.adjacent_matrix = distance_to_adjacent(distance_matrix(self.data, self.data, p=2))
+        else:
+            check_symmetric(self.data)
+            self.adjacent_matrix = distance_to_adjacent(self.data)
+
+        self.adjacent_matrix = self.adjacent_matrix - np.identity(self.data.shape[0])
+        return nx.from_numpy_matrix(self.adjacent_matrix)
+
+    def get_adjacent_matrix(self):
+        return self.adjacent_matrix
+
+    def get_graph(self):
+        return self.graph
+
+    def get_complex_dict(self):
+        return self.complex_dict
+
+
+class CreateBoundaryMatrices(BaseEstimator, TransformerMixin):
+    """Construction of Boundary Matrices from dictionary complex.
+
+    This step computes the boundary matrices that can be used both to
+    analyse the complex and compute the laplacian matrices.
+
+    """
+
+    def __init__(self):
+        return
+
+    def fit(self, X, orders, y=None):
+        """Do nothing and return the estimator unchanged.
+
+        This method is here to implement the usual scikit-learn API and hence
+        work in pipelines.
+
+        Parameters
+        ----------
+        X : dictionary
+            Dictionary containing information on the Clique Complex of which
+            computing the boundary matrices.
+
+        orders : tuple
+            Order of boundary matrixces
+
+        y : None
+            There is no need for a target in a transformer, yet the pipeline
+            API requires this parameter.
+
+        Returns
+        -------
+        self : object
+
+        """
+        self.sizes = dict()
+        for ele in X:
+            self.sizes[ele] = len(X[ele])
+        self.orders = sorted(orders)
+
+        return self
+
+    def transform(self, X, y=None):
+        """Compute boundary matrices.
+
+        It computes the boundary matrices of specified orders. The
+        orders are taken as element of the tuple 'orders'.
+
+        Parameters
+        ----------
+        X : dictionary
+            Dictionary containing information on the Clique Complex of which
+            computing the boundary matrices.
+
+        y : None
+            There is no need for a target in a transformer, yet the pipeline
+            API requires this parameter.
+
+        Returns
+        -------
+        boundaries : list
+            List containing the boundary matrices for all orders specified
+            in tuple 'orders'.
+        """
+        check_is_fitted(self, ['sizes', 'orders'])
+        boundaries = list()
+        incidence = self._create_incidence_from_dict(X)
+
+        for order, order_inc in incidence.items():
+            if isinstance(self.orders, int):
+                orders = [self.orders]
+            if order in self.orders:
+                # Temporary sparse matrix, useful for dynamic creation of sparse matrices
+                # This is the boundary matrix from order to order-1 simplexes
+                temp_mat = lil_matrix((self.sizes[order - 1], self.sizes[order]))
+                for k, v in order_inc.items():
+                    for x in v:
+                        temp_mat[k, x[0]] = np.sign(x[1])
+                boundaries.append(csr_matrix(temp_mat))
+
+        return boundaries
+
+    def _create_incidence_from_dict(self, complex_dict):
+
+        # store incidence values
+        incidence = dict()
+
+        # edges
+        incidence[1] = dict()
+        # ID of edges (1-simplexes)
+        idx = 0
+        # Create incidence nodes to edges
+        for x, y in complex_dict[1].items():
+            i = 1
+            for c in np.sort(y):
+
+                if incidence[1].get(c) is not None:
+                    incidence[1][c].append((idx, (-1) ** i))
+                else:
+                    incidence[1][c] = [(idx, (-1) ** i)]
+                i -= 1
+            idx += 1
+
+        # Find incidence matrix for higher structures
+        for order, order_list in complex_dict.items():
+            if order > 1:
+
+                # To check if this simplex has been already put into the dictionary
+                compare = dict((tuple(np.sort(y)), x) for x, y in complex_dict[order - 1].items())
+                # Create new dict for incidence from order-1 to order simplexes
+                incidence[order] = dict()
+                # Start from zero to label simplexes
+                idx = 0
+
+                for y, c in order_list.items():
+                    # Order the set of vertices to impose the right orientations
+                    c = np.sort(c)
+                    complex_dict[order][idx] = tuple(c)
+                    # Keep track of the (-1) exponent
+                    i = 0
+                    # Find all faces of c (c contains order+1 vertices)
+                    for x in combinations(c, order):
+                        if incidence[order].get(compare[x]) is not None:
+                            incidence[order][compare[x]].append((idx, (-1) ** i))
+                        else:
+                            incidence[order][compare[x]] = [(idx, (-1) ** i)]
+                        i += 1
+                    idx += 1
+
+        return incidence
+
+
+class CreateLaplacianMatrices(BaseEstimator, TransformerMixin):
+    """Compute laplacian matrices.
+
+    This step computes the Laplacian matrices that can be used both to
+    analyse the complex and compute the heat diffusion.
+
+
+    """
+    def __init__(self):
+        return
+
+    def fit(self, X, orders, y=None):
+        """Set the orders paramteres.
+
+        This method is here to implement the usual scikit-learn API and hence
+        work in pipelines.
+
+        Paraneter
+        ---------
+        X : dictionary
+            Dictionary containing information on the Clique Complex of which
+            computing the boundary matrices.
+
+        orders : tuple
+            Tuple containing the orders of Laplcian matrices to be computed
+
+        y : None
+            There is no need for a target in a transformer, yet the pipeline
+            API requires this parameter.
+
+        Returns
+        -------
+        self : object
+
+        """
+        # Check if there is only one index
+        if isinstance(orders, int):
+            self.orders = [orders]
+        else:
+            self.orders = sorted(orders)
+
+        self.bound_orders = tuple(sorted((set(self.orders) - {0}).union(set([x + 1 for x in self.orders]))))
+        self.order_id = dict()
+        for x, y in enumerate(self.bound_orders):
+            self.order_id[y] = x
+
+        return self
+
+    def transform(self, X, y=None):
+        """Compute laplacians of complex.
+
+        Compute laplacians starting from a Graph Object up to certain order applying the formula
+        from the boundary matrices
+
+        Parameters
+        ----------
+         X : dictionary
+            Dictionary containing information on the Clique Complex of which
+            computing the boundary matrices.
+
+        y : None
+            There is no need for a target in a transformer, yet the pipeline
+            API requires this parameter.
+
+        Returns
+        -------
+        laplacians : list
+            List containing the laplacian matrices for all orders specified
+            in tuple 'orders'.
+
+        """
+        check_is_fitted(self, ['orders', 'bound_orders', 'order_id'])
+        laplacians = list()
+
+        cb = CreateBoundaryMatrices().fit(X, self.bound_orders)
+        boundaries = cb.transform(X)
+
+        for x in self.orders:
+            # if maximal order, don't use the x+1 boundary, if minimal don't use 0 boundaries
+            if x > 0:
+                lap = csr_matrix.transpose(boundaries[self.order_id[x]]) * boundaries[self.order_id[x]]
+                if x < len(X)-1:
+                    lap += boundaries[self.order_id[x+1]] * csr_matrix.transpose(boundaries[self.order_id[x+1]])
+            else:
+                lap = boundaries[self.order_id[x+1]] * csr_matrix.transpose(boundaries[self.order_id[x+1]])
+
+            laplacians.append(lap)
+
+        return laplacians
+
+
+
+
+

--- a/giotto/graphs/create_clique_complex.py
+++ b/giotto/graphs/create_clique_complex.py
@@ -7,7 +7,8 @@ import networkx as nx
 from scipy.spatial import distance_matrix
 from scipy.sparse import csr_matrix, lil_matrix
 from itertools import combinations
-from sklearn.utils.validation import check_symmetric, check_is_fitted, check_array
+from sklearn.utils.validation import check_symmetric, \
+    check_is_fitted, check_array
 from sklearn.base import BaseEstimator, TransformerMixin
 
 
@@ -40,8 +41,8 @@ class CreateCliqueComplex:
     data_type : string, optional, default: ``'graph'``
         Type of raw data to be preprocessed. If set to 'graph'
         the Input 'graph' has to be a netowrkx graph object.
-        If set to 'cloud' the data is to be interpreted as a collection
-        of points where row index represents sample ID and columns the features.
+        If set to 'cloud' the data is to be interpreted as a collection of
+        points where row index represents sample ID and columns the features.
         If set to 'matrix' the data is to be interpreted as a
         distance matrix (symmetric) collecting element-wise distances
         between the elements.
@@ -101,19 +102,22 @@ class CreateCliqueComplex:
     def _find_lists(self):
 
         """
-        Collect all cliques of a graph and create dictionary with all simplices.
+        Collect all cliques of a graph and create dictionary with simplices.
         """
 
         # Index for edges and nodes, arbitrary id to edges
         sim_complex = dict()
 
-        sim_complex[1] = dict(zip(np.arange(nx.number_of_edges(self.graph)), self.graph.edges))
+        sim_complex[1] = dict(zip(np.arange(
+            nx.number_of_edges(self.graph)), self.graph.edges))
         sim_complex[0] = dict(zip(self.graph.nodes, self.graph.nodes))
 
-        # Dictionary containing simplexes orders as indexes, list of tuplas with node id forming the simplexes
+        # Dictionary containing simplexes orders as indexes,
+        # list of tuplas with node id forming the simplexes
         cliques = list(nx.enumerate_all_cliques(self.graph))
 
-        for x in range(nx.number_of_nodes(self.graph) + nx.number_of_edges(self.graph), len(cliques)):
+        for x in range(nx.number_of_nodes(self.graph) + nx.number_of_edges(
+                self.graph), len(cliques)):
             if sim_complex.get(len(cliques[x]) - 1) is None:
                 i = 0
                 sim_complex[(len(cliques[x]) - 1)] = dict()
@@ -126,15 +130,18 @@ class CreateCliqueComplex:
         self.complex_dict = sim_complex
 
     def _create_graph(self):
-        distance_to_adjacent = np.vectorize(lambda x: 1 if x < self.alpha else 0)
+        distance_to_adjacent = np.vectorize(
+            lambda x: 1 if x < self.alpha else 0)
 
         if self.data_type == 'cloud':
-            self.adjacent_matrix = distance_to_adjacent(distance_matrix(self.data, self.data, p=2))
+            self.adjacent_matrix = distance_to_adjacent(
+                distance_matrix(self.data, self.data, p=2))
         else:
             check_symmetric(self.data)
             self.adjacent_matrix = distance_to_adjacent(self.data)
 
-        self.adjacent_matrix = self.adjacent_matrix - np.identity(self.data.shape[0])
+        self.adjacent_matrix = self.adjacent_matrix - np.identity(
+            self.data.shape[0])
         return nx.from_numpy_matrix(self.adjacent_matrix)
 
     def get_adjacent_matrix(self):
@@ -219,9 +226,11 @@ class CreateBoundaryMatrices(BaseEstimator, TransformerMixin):
             if isinstance(self.orders, int):
                 orders = [self.orders]
             if order in self.orders:
-                # Temporary sparse matrix, useful for dynamic creation of sparse matrices
+                # Temporary sparse matrix, useful for dynamic creation
+                # of sparse matrices
                 # This is the boundary matrix from order to order-1 simplexes
-                temp_mat = lil_matrix((self.sizes[order - 1], self.sizes[order]))
+                temp_mat = lil_matrix(
+                    (self.sizes[order - 1], self.sizes[order]))
                 for k, v in order_inc.items():
                     for x in v:
                         temp_mat[k, x[0]] = np.sign(x[1])
@@ -254,15 +263,16 @@ class CreateBoundaryMatrices(BaseEstimator, TransformerMixin):
         for order, order_list in complex_dict.items():
             if order > 1:
 
-                # To check if this simplex has been already put into the dictionary
-                compare = dict((tuple(np.sort(y)), x) for x, y in complex_dict[order - 1].items())
+                # To check if this simplex is in the dictionary
+                compare = dict((tuple(np.sort(y)), x) for
+                               x, y in complex_dict[order - 1].items())
                 # Create new dict for incidence from order-1 to order simplexes
                 incidence[order] = dict()
                 # Start from zero to label simplexes
                 idx = 0
 
                 for y, c in order_list.items():
-                    # Order the set of vertices to impose the right orientations
+                    # Order the set of vertices to impose the orientations
                     c = np.sort(c)
                     complex_dict[order][idx] = tuple(c)
                     # Keep track of the (-1) exponent
@@ -270,7 +280,8 @@ class CreateBoundaryMatrices(BaseEstimator, TransformerMixin):
                     # Find all faces of c (c contains order+1 vertices)
                     for x in combinations(c, order):
                         if incidence[order].get(compare[x]) is not None:
-                            incidence[order][compare[x]].append((idx, (-1) ** i))
+                            incidence[order][compare[x]].append((
+                                idx, (-1) ** i))
                         else:
                             incidence[order][compare[x]] = [(idx, (-1) ** i)]
                         i += 1
@@ -320,7 +331,8 @@ class CreateLaplacianMatrices(BaseEstimator, TransformerMixin):
         else:
             self.orders = sorted(orders)
 
-        self.bound_orders = tuple(sorted((set(self.orders) - {0}).union(set([x + 1 for x in self.orders]))))
+        self.bound_orders = tuple(sorted(
+            (set(self.orders) - {0}).union(set([x + 1 for x in self.orders]))))
         self.order_id = dict()
         for x, y in enumerate(self.bound_orders):
             self.order_id[y] = x
@@ -330,8 +342,8 @@ class CreateLaplacianMatrices(BaseEstimator, TransformerMixin):
     def transform(self, X, y=None):
         """Compute laplacians of complex.
 
-        Compute laplacians starting from a Graph Object up to certain order applying the formula
-        from the boundary matrices
+        Compute laplacians starting from a Graph Object up to certain order
+        applying the formula from the boundary matrices
 
         Parameters
         ----------
@@ -357,13 +369,17 @@ class CreateLaplacianMatrices(BaseEstimator, TransformerMixin):
         boundaries = cb.transform(X)
 
         for x in self.orders:
-            # if maximal order, don't use the x+1 boundary, if minimal don't use 0 boundaries
+            # if maximal order, don't use the x+1 boundary,
+            # if minimal don't use 0 boundaries
             if x > 0:
-                lap = csr_matrix.transpose(boundaries[self.order_id[x]]) * boundaries[self.order_id[x]]
+                lap = csr_matrix.transpose(boundaries[self.order_id[x]]) * \
+                      boundaries[self.order_id[x]]
                 if x < len(X)-1:
-                    lap += boundaries[self.order_id[x+1]] * csr_matrix.transpose(boundaries[self.order_id[x+1]])
+                    lap += boundaries[self.order_id[x+1]] * \
+                           csr_matrix.transpose(boundaries[self.order_id[x+1]])
             else:
-                lap = boundaries[self.order_id[x+1]] * csr_matrix.transpose(boundaries[self.order_id[x+1]])
+                lap = boundaries[self.order_id[x+1]] * \
+                      csr_matrix.transpose(boundaries[self.order_id[x+1]])
 
             laplacians.append(lap)
 

--- a/giotto/graphs/create_clique_complex.py
+++ b/giotto/graphs/create_clique_complex.py
@@ -296,7 +296,6 @@ class CreateLaplacianMatrices(BaseEstimator, TransformerMixin):
     This step computes the Laplacian matrices that can be used both to
     analyse the complex and compute the heat diffusion.
 
-
     """
     def __init__(self):
         return

--- a/giotto/graphs/create_clique_complex.py
+++ b/giotto/graphs/create_clique_complex.py
@@ -226,8 +226,6 @@ class CreateBoundaryMatrices(BaseEstimator, TransformerMixin):
             if isinstance(self.orders_, int):
                 orders = [self.orders_]
             if order in self.orders_:
-                # Temporary sparse matrix, useful for dynamic
-                # creation of sparse matrices
                 # This is the boundary matrix from order to order-1 simplexes
                 temp_mat = lil_matrix(
                     (self.sizes_[order - 1], self.sizes_[order]))
@@ -332,9 +330,11 @@ class CreateLaplacianMatrices(BaseEstimator, TransformerMixin):
         else:
             self.orders_ = sorted(orders)
 
-        self.bound_orders_ = tuple(sorted((set(self.orders_) - {0}).union(
-            set([x + 1 for x in self.orders_]))))
+        self.bound_orders_ = set(self.orders_).union(
+            set([x + 1 for x in self.orders_]))
+        self.bound_orders_ = tuple(sorted(self.bound_orders_ - {0}))
         self.order_id_ = dict()
+
         for x, y in enumerate(self.bound_orders_):
             self.order_id_[y] = x
 
@@ -375,7 +375,7 @@ class CreateLaplacianMatrices(BaseEstimator, TransformerMixin):
             if x > 0:
                 lap = csr_matrix.transpose(boundaries[self.order_id_[x]]) *\
                       boundaries[self.order_id_[x]]
-                if x < len(X)-1:
+                if x < len(X):
                     lap += boundaries[self.order_id_[x+1]] *\
                         csr_matrix.transpose(boundaries[self.order_id_[x+1]])
             else:

--- a/giotto/graphs/graph_entropy.py
+++ b/giotto/graphs/graph_entropy.py
@@ -43,7 +43,7 @@ class GraphEntropy(BaseEstimator, TransformerMixin):
         self : object
 
         """
-        check_array(X)
+        check_array(X, allow_nd=True)
         self.is_fitted_ = True
 
         return self

--- a/giotto/graphs/graph_entropy.py
+++ b/giotto/graphs/graph_entropy.py
@@ -53,8 +53,9 @@ class GraphEntropy(BaseEstimator, TransformerMixin):
         Parameters
         ----------
         X : ndarray
-            Input containing the diffusion vectors for n_simplices with different
-            initial condition and times, shape (n_simplices, n_initial_conditions, n_times).
+            Input containing the diffusion vectors for n_simplices with
+            different initial condition and times, shape
+            (n_simplices, n_initial_conditions, n_times).
 
         y : None
             There is no need for a target in a transformer, yet the pipeline

--- a/giotto/graphs/graph_entropy.py
+++ b/giotto/graphs/graph_entropy.py
@@ -68,6 +68,7 @@ class GraphEntropy(BaseEstimator, TransformerMixin):
             Entropies of diffusion vectors, shape (n_simplices, n_times).
         """
         check_is_fitted(self, ['is_fitted_'])
+        check_array(X, allow_nd=True)
         entropies = entropy(np.abs(X), base=2)
 
         return np.nan_to_num(entropies, 0)

--- a/giotto/graphs/graph_entropy.py
+++ b/giotto/graphs/graph_entropy.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import numpy as np
+
+from scipy.stats import entropy
+from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.utils.validation import check_array, check_is_fitted
+
+
+class GraphEntropy(BaseEstimator, TransformerMixin):
+    """Compute diffusion entropy.
+
+    Once the diffusion has been computed, the related entropy at
+    each point in time is calculated. The entropy values will be
+    used as features to perform the embedding. In order to compute
+    the entropy the absolute values of the diffusion vectors are taken.
+    In order to preserve the invarince of the entropy calcuation with
+    respect to the orientation of the simplices in the complex the
+    initial condition has to be a delta (all energy placed in one simplex).
+
+    """
+
+    def fit(self, X, y=None):
+        """Do nothing and return the estimator unchanged.
+
+        This method is here to implement the usual scikit-learn API and hence
+        work in pipelines.
+
+        Parameters
+        ----------
+        X : ndarray
+            Input containing the diffusion vectors for n_simplices with different
+            initial condition and times, shape (n_simplices, n_initial_conditions, n_times).
+
+        y : None
+            There is no need for a target in this fit, yet the pipeline
+            API requires this parameter.
+
+        Returns
+        -------
+        self : object
+
+        """
+        check_array(X)
+        self.is_fitted = True
+
+        return self
+
+    def transform(self, X, y=None):
+        """Compute Entropy for diffusion vectors.
+
+        Parameters
+        ----------
+        X : ndarray
+            Input containing the diffusion vectors for n_simplices with different
+            initial condition and times, shape (n_simplices, n_initial_conditions, n_times).
+
+        y : None
+            There is no need for a target in a transformer, yet the pipeline
+            API requires this parameter.
+
+        Returns
+        -------
+        entropies : ndarray
+            Entropies of diffusion vectors, shape (n_simplices, n_times).
+        """
+        check_is_fitted(self, ['is_fitted'])
+        entropies = entropy(np.abs(X), base=2)
+
+        return np.nan_to_num(entropies, 0)
+

--- a/giotto/graphs/graph_entropy.py
+++ b/giotto/graphs/graph_entropy.py
@@ -44,7 +44,7 @@ class GraphEntropy(BaseEstimator, TransformerMixin):
 
         """
         check_array(X)
-        self.is_fitted = True
+        self.is_fitted_ = True
 
         return self
 
@@ -67,7 +67,7 @@ class GraphEntropy(BaseEstimator, TransformerMixin):
         entropies : ndarray
             Entropies of diffusion vectors, shape (n_simplices, n_times).
         """
-        check_is_fitted(self, ['is_fitted'])
+        check_is_fitted(self, ['is_fitted_'])
         entropies = entropy(np.abs(X), base=2)
 
         return np.nan_to_num(entropies, 0)

--- a/giotto/graphs/graph_entropy.py
+++ b/giotto/graphs/graph_entropy.py
@@ -30,8 +30,9 @@ class GraphEntropy(BaseEstimator, TransformerMixin):
         Parameters
         ----------
         X : ndarray
-            Input containing the diffusion vectors for n_simplices with different
-            initial condition and times, shape (n_simplices, n_initial_conditions, n_times).
+            Input containing the diffusion vectors for n_simplices with
+            different initial condition and times, shape
+            (n_simplices, n_initial_conditions, n_times).
 
         y : None
             There is no need for a target in this fit, yet the pipeline
@@ -53,8 +54,9 @@ class GraphEntropy(BaseEstimator, TransformerMixin):
         Parameters
         ----------
         X : ndarray
-            Input containing the diffusion vectors for n_simplices with different
-            initial condition and times, shape (n_simplices, n_initial_conditions, n_times).
+            Input containing the diffusion vectors for n_simplices with
+            different initial condition and times, shape
+            (n_simplices, n_initial_conditions, n_times).
 
         y : None
             There is no need for a target in a transformer, yet the pipeline

--- a/giotto/graphs/heat_diffusion.py
+++ b/giotto/graphs/heat_diffusion.py
@@ -108,7 +108,7 @@ class HeatDiffusion(BaseEstimator, TransformerMixin):
         eps = 1e-9
         n_simplices = csr_matrix.get_shape(lap)[0]
 
-        norm = np.vectorize(lambda x: 0 if float(x) < eps else x)
+        norm = np.vectorize(lambda x: 0 if np.abs(x) < eps else x)
         n_filters = len(self.taus_)
 
         if self.proc_ == 'exact':
@@ -116,9 +116,10 @@ class HeatDiffusion(BaseEstimator, TransformerMixin):
 
             heat = list()
             for i in range(n_filters):
-                heat.append(norm(U.dot(np.diagflat(
-                    np.exp(- self.taus_[i] * eigenvals).flatten())).dot
-                                 (U.T).dot(self.initial_condition)))
+                temp = U.dot(np.diagflat(
+                    np.exp(- self.taus_[i] * eigenvals).flatten())).dot(U.T).\
+                    dot(self.initial_condition)
+                heat.append((norm(temp)))
         else:
             heat = [sp.sparse.csc_matrix((n_simplices, n_simplices)) for i in
                     range(n_filters)]

--- a/giotto/graphs/heat_diffusion.py
+++ b/giotto/graphs/heat_diffusion.py
@@ -38,10 +38,10 @@ class HeatDiffusion(BaseEstimator, TransformerMixin):
         initial_condition : ndarray, optional, default "None"
             Initial condition for the diffusion process. If "None",
             the diffusion will be computed by using the identity matrix with
-            shape (n_simplices, n_simplices). If the initial condiditions are not
-            deltas placed on one simplex, the absolute values of diffusion vectors
-            depend on the orientation given to the simplices (in K-order
-            diffusion with K>0 ).
+            shape (n_simplices, n_simplices). If the initial condiditions are
+            not deltas placed on one simplex, the absolute values of diffusion
+            vectors depend on the orientation given to the simplices
+            (in K-order diffusion with K>0 ).
 
         order : int, optional, default "30"
             Order of the polynomial approximation.
@@ -116,16 +116,22 @@ class HeatDiffusion(BaseEstimator, TransformerMixin):
 
             heat = list()
             for i in range(n_filters):
-                heat.append(norm(U.dot(np.diagflat(np.exp(- self.taus[i] * eigenvals).flatten())).dot
+                heat.append(norm(U.dot(np.diagflat(
+                    np.exp(- self.taus[i] * eigenvals).flatten())).dot
                                  (U.T).dot(self.initial_condition)))
         else:
-            heat = [sp.sparse.csc_matrix((n_simplices, n_simplices)) for i in range(n_filters)]
-            monome = {0: sp.sparse.eye(n_simplices), 1: lap - sp.sparse.eye(n_simplices)}
+            heat = [sp.sparse.csc_matrix((n_simplices, n_simplices)) for i in
+                    range(n_filters)]
+            monome = {0: sp.sparse.eye(n_simplices),
+                      1: lap - sp.sparse.eye(n_simplices)}
             for k in range(2, self.order + 1):
-                monome[k] = 2 * (lap - sp.sparse.eye(n_simplices)).dot(monome[k - 1]) - monome[k - 2]
+                monome[k] = 2 * (lap - sp.sparse.eye(n_simplices)).dot(
+                    monome[k - 1]) - monome[k - 2]
             for i in range(n_filters):
-                coeffs = self._compute_cheb_coeff_basis(self.taus[i], self.order)
-                temp = sp.sum([coeffs[k] * monome[k] for k in range(0, self.order + 1)])
+                coeffs = self._compute_cheb_coeff_basis(
+                    self.taus[i], self.order)
+                temp = sp.sum([coeffs[k] * monome[k] for k in
+                               range(0, self.order + 1)])
                 heat[i] = norm(temp.A)  # cleans up the small coefficients
         return heat
 

--- a/giotto/graphs/heat_diffusion.py
+++ b/giotto/graphs/heat_diffusion.py
@@ -38,9 +38,9 @@ class HeatDiffusion(BaseEstimator, TransformerMixin):
         initial_condition : ndarray, optional, default "None"
             Initial condition for the diffusion process. If "None",
             the diffusion will be computed by using the identity matrix with
-            shape (n_simplices, n_simplices). If the initial condiditions are not
-            deltas placed on one simplex, the absolute values of diffusion vectors
-            depend on the orientation given to the simplices (in K-order
+            shape (n_simplices, n_simplices). If the initial condiditions are
+            not deltas placed on one simplex, the absolute values of diffusion
+            vectors depend on the orientation given to the simplices (K-order
             diffusion with K>0 ).
 
         order : int, optional, default "30"
@@ -116,16 +116,22 @@ class HeatDiffusion(BaseEstimator, TransformerMixin):
 
             heat = list()
             for i in range(n_filters):
-                heat.append(norm(U.dot(np.diagflat(np.exp(- self.taus[i] * eigenvals).flatten())).dot
+                heat.append(norm(U.dot(np.diagflat(
+                    np.exp(- self.taus[i] * eigenvals).flatten())).dot
                                  (U.T).dot(self.initial_condition)))
         else:
-            heat = [sp.sparse.csc_matrix((n_simplices, n_simplices)) for i in range(n_filters)]
-            monome = {0: sp.sparse.eye(n_simplices), 1: lap - sp.sparse.eye(n_simplices)}
+            heat = [sp.sparse.csc_matrix((n_simplices, n_simplices)) for i in
+                    range(n_filters)]
+            monome = {0: sp.sparse.eye(n_simplices),
+                      1: lap - sp.sparse.eye(n_simplices)}
             for k in range(2, self.order + 1):
-                monome[k] = 2 * (lap - sp.sparse.eye(n_simplices)).dot(monome[k - 1]) - monome[k - 2]
+                monome[k] = 2 * (lap - sp.sparse.eye(n_simplices)).dot(
+                    monome[k - 1]) - monome[k - 2]
             for i in range(n_filters):
-                coeffs = self._compute_cheb_coeff_basis(self.taus[i], self.order)
-                temp = sp.sum([coeffs[k] * monome[k] for k in range(0, self.order + 1)])
+                coeffs = self._compute_cheb_coeff_basis(
+                    self.taus[i], self.order)
+                temp = sp.sum([coeffs[k] * monome[k] for k in
+                               range(0, self.order + 1)])
                 heat[i] = norm(temp.A)  # cleans up the small coefficients
         return heat
 

--- a/giotto/graphs/heat_diffusion.py
+++ b/giotto/graphs/heat_diffusion.py
@@ -94,7 +94,7 @@ class HeatDiffusion(BaseEstimator, TransformerMixin):
         """
 
         check_is_fitted(self, ['taus_', 'proc_', 'order_'])
-
+        check_array(X, allow_nd=True, accept_sparse=True)
         heat = np.squeeze(np.asarray(self._compute_heat_diffusion(X)))
         heat = np.swapaxes(np.swapaxes(heat, 0, 2), 0, 1)
 

--- a/giotto/graphs/heat_diffusion.py
+++ b/giotto/graphs/heat_diffusion.py
@@ -94,7 +94,7 @@ class HeatDiffusion(BaseEstimator, TransformerMixin):
         """
 
         check_is_fitted(self, ['taus_', 'proc_', 'order_'])
-        check_array(X, allow_nd=True, accept_sparse=True)
+        check_array(X, accept_sparse=True)
         heat = np.squeeze(np.asarray(self._compute_heat_diffusion(X)))
         heat = np.swapaxes(np.swapaxes(heat, 0, 2), 0, 1)
 

--- a/giotto/graphs/heat_diffusion.py
+++ b/giotto/graphs/heat_diffusion.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+# License: Apache 2.0
+
+import numpy as np
+import scipy as sp
+from scipy.sparse import csr_matrix
+import math
+
+from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.utils.validation import check_is_fitted, check_array
+
+
+class HeatDiffusion(BaseEstimator, TransformerMixin):
+    """Compute heat diffusion.
+
+    Module that copmutes heat diffusion evolution at different
+    points in time. The initial condition and sampling times are
+    taken as input.
+
+    """
+
+    def __init__(self):
+        return
+
+    def fit(self, X, taus, initial_condition=None, order=50, proc="exact"):
+        """Compute heat diffusion throughout the complex.
+
+        Parameters
+        ----------
+        X : ndarray
+            Laplacian matrix to be used to compute the diffusion process,
+            shape (n_simplices, n_simpices).
+
+        taus : ndarray
+            Array contaning the points in time at which sampling
+            the heat diffusion process.
+
+        initial_condition : ndarray, optional, default "None"
+            Initial condition for the diffusion process. If "None",
+            the diffusion will be computed by using the identity matrix with
+            shape (n_simplices, n_simplices). If the initial condiditions are not
+            deltas placed on one simplex, the absolute values of diffusion vectors
+            depend on the orientation given to the simplices (in K-order
+            diffusion with K>0 ).
+
+        order : int, optional, default "30"
+            Order of the polynomial approximation.
+
+        proc : string, optional, default "exact"
+            Procedure to compute the signatures (approximate == by
+            using Chebychev approx -- or exact). At the moment,
+            The 'approximate' option holds only for 0-order diffusion.
+
+        Returns
+        -------
+        self : object
+
+        """
+
+        if initial_condition is not None:
+            check_array(initial_condition)
+            self.initial_condition = initial_condition
+        else:
+            self.initial_condition = np.identity(X.shape[0])
+
+        self.taus = taus
+        self.proc = proc
+        self.order = order
+
+        return self
+
+    def transform(self, X, y=None):
+        """Compute heat diffusion.
+
+        Compute heat diffusion processes both for a set of s-simplexes or for
+        all simplexes of order s.
+
+        Parameters
+        ----------
+        X : ndarray
+            Laplacian matrix to be used to compute the diffusion process,
+            shape (n_simplices, n_simpices).
+
+        y : None
+            There is no need for a target in a transformer, yet the pipeline
+            API requires this parameter.
+
+        Returns
+        -------
+
+        heat : ndarray
+            3D-array containing the diffusion vectors. The shape is
+            (n_simplices, n_initial_condition, n_times) where the initial
+            condition placed as input have been tranformed by solving the heat
+            equation in time.
+
+        """
+
+        check_is_fitted(self, ['taus', 'proc', 'order', 'initial_condition'])
+
+        heat = np.squeeze(np.asarray(self._compute_heat_diffusion(X)))
+        heat = np.swapaxes(np.swapaxes(heat, 0, 2), 0, 1)
+
+        return heat
+
+    def _compute_heat_diffusion(self, lap):
+
+        eps = 1e-9
+        n_simplices = csr_matrix.get_shape(lap)[0]
+
+        norm = np.vectorize(lambda x: 0 if float(x) < eps else x)
+        n_filters = len(self.taus)
+
+        if self.proc == 'exact':
+            eigenvals, U = self._get_eigens(lap)
+
+            heat = list()
+            for i in range(n_filters):
+                heat.append(norm(U.dot(np.diagflat(np.exp(- self.taus[i] * eigenvals).flatten())).dot
+                                 (U.T).dot(self.initial_condition)))
+        else:
+            heat = [sp.sparse.csc_matrix((n_simplices, n_simplices)) for i in range(n_filters)]
+            monome = {0: sp.sparse.eye(n_simplices), 1: lap - sp.sparse.eye(n_simplices)}
+            for k in range(2, self.order + 1):
+                monome[k] = 2 * (lap - sp.sparse.eye(n_simplices)).dot(monome[k - 1]) - monome[k - 2]
+            for i in range(n_filters):
+                coeffs = self._compute_cheb_coeff_basis(self.taus[i], self.order)
+                temp = sp.sum([coeffs[k] * monome[k] for k in range(0, self.order + 1)])
+                heat[i] = norm(temp.A)  # cleans up the small coefficients
+        return heat
+
+    def _compute_cheb_coeff_basis(self, scale, order):
+        xx = np.array([np.cos((2 * i - 1) * 1.0 / (2 * order) * math.pi)
+                       for i in range(1, order + 1)])
+        basis = [np.ones((1, order)), np.array(xx)]
+        for k in range(order + 1 - 2):
+            basis.append(2 * np.multiply(xx, basis[-1]) - basis[-2])
+        basis = np.vstack(basis)
+        f = np.exp(-scale * (xx + 1))
+        products = np.einsum("j,ij->ij", f, basis)
+        coeffs = 2.0 / order * products.sum(1)
+        coeffs[0] = coeffs[0] / 2
+        return list(coeffs)
+
+    def _get_eigens(self, lap):
+        vals, vecs = np.linalg.eigh(lap.todense())
+        return np.real(vals), vecs
+
+
+
+

--- a/giotto/graphs/heat_diffusion.py
+++ b/giotto/graphs/heat_diffusion.py
@@ -19,9 +19,6 @@ class HeatDiffusion(BaseEstimator, TransformerMixin):
 
     """
 
-    def __init__(self):
-        return
-
     def fit(self, X, taus, initial_condition=None, order=50, proc="exact"):
         """Compute heat diffusion throughout the complex.
 
@@ -77,7 +74,7 @@ class HeatDiffusion(BaseEstimator, TransformerMixin):
 
         Parameters
         ----------
-        X : ndarray
+        X : csr_matrix
             Laplacian matrix to be used to compute the diffusion process,
             shape (n_simplices, n_simpices).
 

--- a/giotto/graphs/tests/test_create_complex.py
+++ b/giotto/graphs/tests/test_create_complex.py
@@ -4,7 +4,8 @@ import networkx as nx
 
 
 from sklearn.exceptions import NotFittedError
-from giotto.graphs.create_clique_complex import CreateCliqueComplex, CreateLaplacianMatrices, CreateBoundaryMatrices
+from giotto.graphs.create_clique_complex import CreateCliqueComplex,\
+    CreateLaplacianMatrices, CreateBoundaryMatrices
 from numpy.testing import assert_almost_equal
 from scipy.spatial import distance_matrix
 
@@ -17,7 +18,8 @@ cd = cc.create_complex_from_graph()
 def test_graph_input_with_data_type():
 
     with pytest.raises(ValueError):
-        cc_ = CreateCliqueComplex(graph=nx.barbell_graph(10, 10), data_type='cloud')
+        cc_ = CreateCliqueComplex(
+            graph=nx.barbell_graph(10, 10), data_type='cloud')
 
 
 def test_data_input_with__graph_data_type():
@@ -33,7 +35,8 @@ def test_input_distance_matrix():
     cd_ = cc_.create_complex_from_graph()
 
     lap_cc = CreateLaplacianMatrices().fit(cd, (0)).transform(cd)[0].todense()
-    lap_cc_ = CreateLaplacianMatrices().fit(cd_, (0)).transform(cd_)[0].todense()
+    lap_cc_ = CreateLaplacianMatrices().fit(
+        cd_, (0)).transform(cd_)[0].todense()
 
     assert_almost_equal(lap_cc, lap_cc_)
 
@@ -43,7 +46,8 @@ def test_adjacency_matrix():
     cc_ = CreateCliqueComplex(g)
     adjacency = nx.adjacency_matrix(g)
 
-    assert_almost_equal(adjacency.todense(), cc_.get_adjacent_matrix().todense())
+    assert_almost_equal(adjacency.todense(),
+                        cc_.get_adjacent_matrix().todense())
 
 
 def test_create_boundary_matrices_not_fitted():

--- a/giotto/graphs/tests/test_create_complex.py
+++ b/giotto/graphs/tests/test_create_complex.py
@@ -1,0 +1,67 @@
+import numpy as np
+import pytest
+import networkx as nx
+
+
+from sklearn.exceptions import NotFittedError
+from create_clique_complex import CreateCliqueComplex, CreateBoundaryMatrices, CreateLaplacianMatrices
+from numpy.testing import assert_almost_equal
+from scipy.spatial import distance_matrix
+
+X = np.random.random((10, 2))
+alpha = 0.4
+cc = CreateCliqueComplex(data=X, alpha=alpha, data_type='cloud')
+cd = cc.create_complex_from_graph()
+heat_node = HeatDiffusion().fit(lap_node, taus).transform(lap_node)
+
+
+def test_graph_input_with_data_type():
+
+    with pytest.raises(ValueError):
+        cc_ = CreateCliqueComplex(graph=nx.barbell_graph(10, 10), data_type='cloud')
+
+
+def test_data_input_with__graph_data_type():
+
+    with pytest.raises(ValueError):
+        cc_ = CreateCliqueComplex(data=X, alpha=alpha)
+
+
+def test_input_distance_matrix():
+    dist = distance_matrix(X, X, p=2)
+
+    cc_ = CreateCliqueComplex(data=dist, alpha=alpha, data_type='matrix')
+    cd_ = cc_.create_complex_from_graph()
+
+    lap_cc = CreateLaplacianMatrices().fit(cd, (0)).transform(cd)[0].todense()
+    lap_cc_ = CreateLaplacianMatrices().fit(cd_, (0)).transform(cd_)[0].todense()
+
+    assert_almost_equal(lap_cc, lap_cc_)
+
+
+def test_adjacency_matrix():
+    g = nx.barbell_graph(8, 5)
+    cc_ = CreateCliqueComplex(g)
+    adjacency = nx.adjacency_matrix(g)
+
+    assert_almost_equal(adjacency.todense(), cc_.get_adjacent_matrix().todense())
+
+
+def test_create_boundary_matrices_not_fitted():
+    bound = CreateBoundaryMatrices()
+
+    with pytest.raises(NotFittedError):
+        bound.transform(cd)
+
+
+def test_create_laplacian_matrices_not_fitted():
+    lap = CreateLaplacianMatrices()
+
+    with pytest.raises(NotFittedError):
+        lap.transform(cd)
+
+
+def test_create_laplacian_matrices_symmetry():
+    lap = CreateLaplacianMatrices().fit(cd, (0)).transform(cd)
+
+    assert_almost_equal(lap[0].todense(), lap[0].todense().T)

--- a/giotto/graphs/tests/test_create_complex.py
+++ b/giotto/graphs/tests/test_create_complex.py
@@ -4,7 +4,7 @@ import networkx as nx
 
 
 from sklearn.exceptions import NotFittedError
-from create_clique_complex import CreateCliqueComplex, CreateBoundaryMatrices, CreateLaplacianMatrices
+from giotto.graphs.create_clique_complex import CreateCliqueComplex, CreateLaplacianMatrices, CreateBoundaryMatrices
 from numpy.testing import assert_almost_equal
 from scipy.spatial import distance_matrix
 
@@ -12,7 +12,6 @@ X = np.random.random((10, 2))
 alpha = 0.4
 cc = CreateCliqueComplex(data=X, alpha=alpha, data_type='cloud')
 cd = cc.create_complex_from_graph()
-heat_node = HeatDiffusion().fit(lap_node, taus).transform(lap_node)
 
 
 def test_graph_input_with_data_type():

--- a/giotto/graphs/tests/test_create_complex.py
+++ b/giotto/graphs/tests/test_create_complex.py
@@ -4,8 +4,9 @@ import networkx as nx
 
 
 from sklearn.exceptions import NotFittedError
-from giotto.graphs.create_clique_complex import CreateCliqueComplex,\
-    CreateLaplacianMatrices, CreateBoundaryMatrices
+from giotto.graphs.create_clique_complex import (CreateCliqueComplex,
+    CreateLaplacianMatrices, CreateBoundaryMatrices)
+
 from numpy.testing import assert_almost_equal
 from scipy.spatial import distance_matrix
 

--- a/giotto/graphs/tests/test_create_complex.py
+++ b/giotto/graphs/tests/test_create_complex.py
@@ -2,9 +2,9 @@ import numpy as np
 import pytest
 import networkx as nx
 
-
 from sklearn.exceptions import NotFittedError
-from giotto.graphs.create_clique_complex import CreateCliqueComplex, CreateLaplacianMatrices, CreateBoundaryMatrices
+from giotto.graphs.create_clique_complex import CreateCliqueComplex, \
+    CreateLaplacianMatrices, CreateBoundaryMatrices
 from numpy.testing import assert_almost_equal
 from scipy.spatial import distance_matrix
 
@@ -17,7 +17,8 @@ cd = cc.create_complex_from_graph()
 def test_graph_input_with_data_type():
 
     with pytest.raises(ValueError):
-        cc_ = CreateCliqueComplex(graph=nx.barbell_graph(10, 10), data_type='cloud')
+        cc_ = CreateCliqueComplex(
+            graph=nx.barbell_graph(10, 10), data_type='cloud')
 
 
 def test_data_input_with__graph_data_type():
@@ -32,8 +33,10 @@ def test_input_distance_matrix():
     cc_ = CreateCliqueComplex(data=dist, alpha=alpha, data_type='matrix')
     cd_ = cc_.create_complex_from_graph()
 
-    lap_cc = CreateLaplacianMatrices().fit(cd, (0)).transform(cd)[0].todense()
-    lap_cc_ = CreateLaplacianMatrices().fit(cd_, (0)).transform(cd_)[0].todense()
+    lap_cc = CreateLaplacianMatrices().fit(
+        cd, (0)).transform(cd)[0].todense()
+    lap_cc_ = CreateLaplacianMatrices().fit(
+        cd_, (0)).transform(cd_)[0].todense()
 
     assert_almost_equal(lap_cc, lap_cc_)
 
@@ -43,7 +46,8 @@ def test_adjacency_matrix():
     cc_ = CreateCliqueComplex(g)
     adjacency = nx.adjacency_matrix(g)
 
-    assert_almost_equal(adjacency.todense(), cc_.get_adjacent_matrix().todense())
+    assert_almost_equal(
+        adjacency.todense(), cc_.get_adjacent_matrix().todense())
 
 
 def test_create_boundary_matrices_not_fitted():

--- a/giotto/graphs/tests/test_create_complex.py
+++ b/giotto/graphs/tests/test_create_complex.py
@@ -4,8 +4,8 @@ import networkx as nx
 
 
 from sklearn.exceptions import NotFittedError
-from giotto.graphs.create_clique_complex import (CreateCliqueComplex,
-    CreateLaplacianMatrices, CreateBoundaryMatrices)
+from giotto.graphs.create_clique_complex import CreateCliqueComplex,\
+    CreateLaplacianMatrices, CreateBoundaryMatrices
 
 from numpy.testing import assert_almost_equal
 from scipy.spatial import distance_matrix

--- a/giotto/graphs/tests/test_graph_entropy.py
+++ b/giotto/graphs/tests/test_graph_entropy.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 
 from sklearn.exceptions import NotFittedError
-from giotto.graphs.create_clique_complex import CreateCliqueComplex, CreateLaplacianMatrices
+from giotto.graphs.create_clique_complex import CreateCliqueComplex,\
+    CreateLaplacianMatrices
 from giotto.graphs.graph_entropy import GraphEntropy
 from giotto.graphs.heat_diffusion import HeatDiffusion
 

--- a/giotto/graphs/tests/test_graph_entropy.py
+++ b/giotto/graphs/tests/test_graph_entropy.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pytest
+
+from sklearn.exceptions import NotFittedError
+from create_clique_complex import CreateCliqueComplex, CreateBoundaryMatrices, CreateLaplacianMatrices
+from graph_entropy import GraphEntropy
+from heat_diffusion import HeatDiffusion
+
+taus = np.linspace(0, 5, 20)
+
+X = np.random.random((10, 2))
+alpha = 0.4
+cc = CreateCliqueComplex(data=X, alpha=alpha, data_type='cloud')
+cd = cc.create_complex_from_graph()
+lap_node = CreateLaplacianMatrices().fit(cd, (0)).transform(cd)[0]
+heat_vectors = HeatDiffusion().fit(lap_node, taus=taus).transform(lap_node)
+
+
+def test_graph_entropy_fitted():
+    entropy = GraphEntropy()
+
+    with pytest.raises(NotFittedError):
+        embs = entropy.transform(heat_vectors)
+
+
+test_graph_entropy_fitted()
+

--- a/giotto/graphs/tests/test_graph_entropy.py
+++ b/giotto/graphs/tests/test_graph_entropy.py
@@ -2,8 +2,8 @@ import numpy as np
 import pytest
 
 from sklearn.exceptions import NotFittedError
-from giotto.graphs.create_clique_complex import CreateCliqueComplex,\
-    CreateLaplacianMatrices
+from giotto.graphs.create_clique_complex import (CreateCliqueComplex,
+    CreateLaplacianMatrices)
 from giotto.graphs.graph_entropy import GraphEntropy
 from giotto.graphs.heat_diffusion import HeatDiffusion
 

--- a/giotto/graphs/tests/test_graph_entropy.py
+++ b/giotto/graphs/tests/test_graph_entropy.py
@@ -2,8 +2,8 @@ import numpy as np
 import pytest
 
 from sklearn.exceptions import NotFittedError
-from giotto.graphs.create_clique_complex import CreateCliqueComplex, \
-    CreateLaplacianMatrices
+from giotto.graphs.create_clique_complex import CreateCliqueComplex
+from giotto.graphs.create_clique_complex import CreateLaplacianMatrices
 from giotto.graphs.graph_entropy import GraphEntropy
 from giotto.graphs.heat_diffusion import HeatDiffusion
 
@@ -22,7 +22,3 @@ def test_graph_entropy_fitted():
 
     with pytest.raises(NotFittedError):
         embs = entropy.transform(heat_vectors)
-
-
-test_graph_entropy_fitted()
-

--- a/giotto/graphs/tests/test_graph_entropy.py
+++ b/giotto/graphs/tests/test_graph_entropy.py
@@ -2,9 +2,9 @@ import numpy as np
 import pytest
 
 from sklearn.exceptions import NotFittedError
-from create_clique_complex import CreateCliqueComplex, CreateBoundaryMatrices, CreateLaplacianMatrices
-from graph_entropy import GraphEntropy
-from heat_diffusion import HeatDiffusion
+from giotto.graphs.create_clique_complex import CreateCliqueComplex, CreateLaplacianMatrices
+from giotto.graphs.graph_entropy import GraphEntropy
+from giotto.graphs.heat_diffusion import HeatDiffusion
 
 taus = np.linspace(0, 5, 20)
 

--- a/giotto/graphs/tests/test_graph_entropy.py
+++ b/giotto/graphs/tests/test_graph_entropy.py
@@ -3,7 +3,7 @@ import pytest
 
 from sklearn.exceptions import NotFittedError
 from giotto.graphs.create_clique_complex import (CreateCliqueComplex,
-    CreateLaplacianMatrices)
+    CreateLaplacianMatrices, CreateBoundaryMatrices)
 from giotto.graphs.graph_entropy import GraphEntropy
 from giotto.graphs.heat_diffusion import HeatDiffusion
 

--- a/giotto/graphs/tests/test_graph_entropy.py
+++ b/giotto/graphs/tests/test_graph_entropy.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 
 from sklearn.exceptions import NotFittedError
-from giotto.graphs.create_clique_complex import CreateCliqueComplex, CreateLaplacianMatrices
+from giotto.graphs.create_clique_complex import CreateCliqueComplex, \
+    CreateLaplacianMatrices
 from giotto.graphs.graph_entropy import GraphEntropy
 from giotto.graphs.heat_diffusion import HeatDiffusion
 

--- a/giotto/graphs/tests/test_graph_entropy.py
+++ b/giotto/graphs/tests/test_graph_entropy.py
@@ -13,11 +13,12 @@ X = np.random.random((10, 2))
 alpha = 0.4
 cc = CreateCliqueComplex(data=X, alpha=alpha, data_type='cloud')
 cd = cc.create_complex_from_graph()
-lap_node = CreateLaplacianMatrices().fit(cd, (0)).transform(cd)[0]
-heat_vectors = HeatDiffusion().fit(lap_node, taus=taus).transform(lap_node)
 
 
 def test_graph_entropy_fitted():
+    lap_node = CreateLaplacianMatrices().fit(cd, (0)).transform(cd)[0]
+    heat_vectors = HeatDiffusion().fit(lap_node, taus=taus).transform(lap_node)
+
     entropy = GraphEntropy()
 
     with pytest.raises(NotFittedError):

--- a/giotto/graphs/tests/test_graph_entropy.py
+++ b/giotto/graphs/tests/test_graph_entropy.py
@@ -3,7 +3,7 @@ import pytest
 
 from sklearn.exceptions import NotFittedError
 from giotto.graphs.create_clique_complex import (CreateCliqueComplex,
-    CreateLaplacianMatrices, CreateBoundaryMatrices)
+    CreateLaplacianMatrices)
 from giotto.graphs.graph_entropy import GraphEntropy
 from giotto.graphs.heat_diffusion import HeatDiffusion
 
@@ -13,16 +13,14 @@ X = np.random.random((10, 2))
 alpha = 0.4
 cc = CreateCliqueComplex(data=X, alpha=alpha, data_type='cloud')
 cd = cc.create_complex_from_graph()
-lap_node = CreateLaplacianMatrices().fit(cd, (0)).transform(cd)[0]
-heat_vectors = HeatDiffusion().fit(lap_node, taus=taus).transform(lap_node)
 
 
 def test_graph_entropy_fitted():
+    l_n = CreateLaplacianMatrices().fit(cd, (0)).transform(cd)[0]
+    heat_vectors = HeatDiffusion().fit(l_n, taus=taus).transform(l_n)
     entropy = GraphEntropy()
 
     with pytest.raises(NotFittedError):
         embs = entropy.transform(heat_vectors)
 
-
-test_graph_entropy_fitted()
 

--- a/giotto/graphs/tests/test_heat_diffusion.py
+++ b/giotto/graphs/tests/test_heat_diffusion.py
@@ -2,8 +2,8 @@ import numpy as np
 import pytest
 
 from sklearn.exceptions import NotFittedError
-from giotto.graphs.create_clique_complex import CreateCliqueComplex,\
-    CreateLaplacianMatrices
+from giotto.graphs.create_clique_complex import CreateCliqueComplex
+from giotto.graphs.create_clique_complex import CreateLaplacianMatrices
 from giotto.graphs.heat_diffusion import HeatDiffusion
 
 taus = np.linspace(0, 5, 20)
@@ -36,4 +36,5 @@ def test_heat_diffusion_initial_condition_shape():
         lap_node, taus, initial_condition=ic).transform(lap_node)
 
     assert heat_node.shape == (lap_node.shape[0], ic.shape[1], len(taus))
+
 

--- a/giotto/graphs/tests/test_heat_diffusion.py
+++ b/giotto/graphs/tests/test_heat_diffusion.py
@@ -3,7 +3,7 @@ import pytest
 
 from sklearn.exceptions import NotFittedError
 from giotto.graphs.create_clique_complex import (CreateCliqueComplex,
-    CreateLaplacianMatrices)
+    CreateLaplacianMatrices, CreateBoundaryMatrices)
 from giotto.graphs.heat_diffusion import HeatDiffusion
 
 taus = np.linspace(0, 5, 20)

--- a/giotto/graphs/tests/test_heat_diffusion.py
+++ b/giotto/graphs/tests/test_heat_diffusion.py
@@ -2,8 +2,8 @@ import numpy as np
 import pytest
 
 from sklearn.exceptions import NotFittedError
-from giotto.graphs.create_clique_complex import CreateCliqueComplex,\
-    CreateLaplacianMatrices
+from giotto.graphs.create_clique_complex import (CreateCliqueComplex,
+    CreateLaplacianMatrices)
 from giotto.graphs.heat_diffusion import HeatDiffusion
 
 taus = np.linspace(0, 5, 20)

--- a/giotto/graphs/tests/test_heat_diffusion.py
+++ b/giotto/graphs/tests/test_heat_diffusion.py
@@ -3,7 +3,7 @@ import pytest
 
 from sklearn.exceptions import NotFittedError
 from giotto.graphs.create_clique_complex import (CreateCliqueComplex,
-    CreateLaplacianMatrices, CreateBoundaryMatrices)
+    CreateLaplacianMatrices)
 from giotto.graphs.heat_diffusion import HeatDiffusion
 
 taus = np.linspace(0, 5, 20)
@@ -32,6 +32,7 @@ def test_heat_vectors_shape():
 def test_heat_diffusion_initial_condition_shape():
     # Check with 5 random initial conditions
     ic = np.random.random((20, 5))
+
     heat_node = HeatDiffusion().fit(
         lap_node, taus, initial_condition=ic).transform(lap_node)
 

--- a/giotto/graphs/tests/test_heat_diffusion.py
+++ b/giotto/graphs/tests/test_heat_diffusion.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 
 from sklearn.exceptions import NotFittedError
-from giotto.graphs.create_clique_complex import CreateCliqueComplex, CreateLaplacianMatrices
+from giotto.graphs.create_clique_complex import CreateCliqueComplex,\
+    CreateLaplacianMatrices
 from giotto.graphs.heat_diffusion import HeatDiffusion
 
 taus = np.linspace(0, 5, 20)
@@ -31,7 +32,8 @@ def test_heat_vectors_shape():
 def test_heat_diffusion_initial_condition_shape():
     # Check with 5 random initial conditions
     ic = np.random.random((20, 5))
-    heat_node = HeatDiffusion().fit(lap_node, taus, initial_condition=ic).transform(lap_node)
+    heat_node = HeatDiffusion().fit(
+        lap_node, taus, initial_condition=ic).transform(lap_node)
 
     assert heat_node.shape == (lap_node.shape[0], ic.shape[1], len(taus))
 

--- a/giotto/graphs/tests/test_heat_diffusion.py
+++ b/giotto/graphs/tests/test_heat_diffusion.py
@@ -2,8 +2,8 @@ import numpy as np
 import pytest
 
 from sklearn.exceptions import NotFittedError
-from create_clique_complex import CreateCliqueComplex, CreateBoundaryMatrices, CreateLaplacianMatrices
-from heat_diffusion import HeatDiffusion
+from giotto.graphs.create_clique_complex import CreateCliqueComplex, CreateLaplacianMatrices
+from giotto.graphs.heat_diffusion import HeatDiffusion
 
 taus = np.linspace(0, 5, 20)
 

--- a/giotto/graphs/tests/test_heat_diffusion.py
+++ b/giotto/graphs/tests/test_heat_diffusion.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+
+from sklearn.exceptions import NotFittedError
+from create_clique_complex import CreateCliqueComplex, CreateBoundaryMatrices, CreateLaplacianMatrices
+from heat_diffusion import HeatDiffusion
+
+taus = np.linspace(0, 5, 20)
+
+X = np.random.random((20, 2))
+cc = CreateCliqueComplex(data=X, alpha=0.4, data_type='cloud')
+cd = cc.create_complex_from_graph()
+lap_node, lap_edge = CreateLaplacianMatrices().fit(cd, (0, 1)).transform(cd)
+
+
+def test_heat_diffusion_not_fitted():
+    diffusor = HeatDiffusion()
+
+    with pytest.raises(NotFittedError):
+        heat = diffusor.transform(lap_node)
+
+
+def test_heat_vectors_shape():
+    heat_node = HeatDiffusion().fit(lap_node, taus).transform(lap_node)
+    heat_edge = HeatDiffusion().fit(lap_edge, taus).transform(lap_edge)
+
+    assert heat_node.shape == (lap_node.shape[0], lap_node.shape[0], len(taus))
+    assert heat_edge.shape == (lap_edge.shape[0], lap_edge.shape[0], len(taus))
+
+
+def test_heat_diffusion_initial_condition_shape():
+    # Check with 5 random initial conditions
+    ic = np.random.random((20, 5))
+    heat_node = HeatDiffusion().fit(lap_node, taus, initial_condition=ic).transform(lap_node)
+
+    assert heat_node.shape == (lap_node.shape[0], ic.shape[1], len(taus))
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy >= 1.17.0
 scipy >= 0.17.0
 scikit-learn >= 0.21.3
 joblib >= 0.11
+networkx >= 2.4


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/giotto-learn/giotto-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Issue #100 


#### What does this implement/fix? Explain your changes.
The new modules implement the heat diffusion process. Once the graph and clique complex are constructed by using the module CreateCliqueComplex, starting by either an exisiting graph,a point cloud or a distance matrix, the boundary and laplacian matrices of the complex are computed for any orders (upon user request). Once the laplacians are computed, it is possible to analyse the heat diffusion process defined over nodes, edges, triangles and in general over any k-simplices. At the end the module GraphEntropy is used to compare different diffusion processes and can be used to define simplex embeddings. 

#### Any other comments?
The pipeline can be used to perform graph analysis (e.g. molecules)

