### PR TITLE
Freeze sklearn version to 0.22.0 (#119)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy >= 1.17.0
 scipy >= 0.17.0
-scikit-learn >= 0.22
+scikit-learn == 0.22.0
 joblib >= 0.11
 networkx >= 2.4
 plotly >= 4.3.0


### PR DESCRIPTION
Temporary solution in preparation for a better fix for v0.1.4.

#### Reference Issues/PRs
(#119)

#### What does this implement/fix? Explain your changes.
Sklearn version frozen to v0.22.0 to avoid errors thrown by `check_is_fitted` in v0.22.1 if no attributes are passed.

#### Any other comments?
Tested on a fresh environment.