### PR TITLE
Replace there with here in docstring for consistency

### DIFF
--- a/giotto/homology/grids.py
+++ b/giotto/homology/grids.py
@@ -96,7 +96,7 @@ class CubicalPersistence(BaseEstimator, TransformerMixin):
     def fit(self, X, y=None):
         """Do nothing and return the estimator unchanged.
 
-        This method is there to implement the usual scikit-learn API and hence
+        This method is here to implement the usual scikit-learn API and hence
         work in pipelines.
 
         Parameters


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Resolves the "replace there with here" issue
