### PR TITLE
Patch for pybind11 inclusion during dev installation (#168)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.9)
 project(giotto_bindings LANGUAGES CXX)
 
-find_package(pybind11 REQUIRED)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/giotto/externals/pybind11)
 set(BINDINGS_DIR "giotto/externals/bindings")
 
 find_package(Boost 1.56 REQUIRED)


### PR DESCRIPTION
Change find_package(pybind11 REQUIRED) with add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/giotto/externals/pybind11) in CMakeLists

#### Reference Issues/PRs
(#168)
