### PR TITLE
Extend subsection approach from Mapper to other modules

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -112,6 +112,8 @@ Utilities
    :no-members:
    :no-inherited-members:
 
+Preprocessing
+-------------
 .. currentmodule:: giotto
 
 .. autosummary::
@@ -122,9 +124,25 @@ Utilities
    diagrams.Scaler
    diagrams.Filtering
 
-   diagrams.PairwiseDistance
-   diagrams.Amplitude
+Distances
+---------
+.. currentmodule:: giotto
 
+.. autosummary::
+   :toctree: generated/
+   :template: class.rst
+
+   diagrams.PairwiseDistance
+
+Diagram features
+----------------
+.. currentmodule:: giotto
+
+.. autosummary::
+   :toctree: generated/
+   :template: class.rst
+
+   diagrams.Amplitude
    diagrams.PersistenceEntropy
    diagrams.PersistenceLandscape
    diagrams.BettiCurve
@@ -138,19 +156,57 @@ Utilities
    :no-members:
    :no-inherited-members:
 
+Preprocessing
+-------------
 .. currentmodule:: giotto
 
 .. autosummary::
    :toctree: generated/
    :template: class.rst
 
+   time_series.SlidingWindow
    time_series.Resampler
    time_series.Stationarizer
+
+Time-delay embedding
+--------------------
+.. currentmodule:: giotto
+
+.. autosummary::
+   :toctree: generated/
+   :template: class.rst
+
    time_series.TakensEmbedding
-   time_series.SlidingWindow
-   time_series.PermutationEntropy
-   time_series.PearsonDissimilarity
+
+Target preparation
+------------------
+.. currentmodule:: giotto
+
+.. autosummary::
+   :toctree: generated/
+   :template: class.rst
+
    time_series.Labeller
+
+Dynamical systems
+-----------------
+.. currentmodule:: giotto
+
+.. autosummary::
+   :toctree: generated/
+   :template: class.rst
+
+   time_series.PermutationEntropy
+
+Multivariate
+------------
+.. currentmodule:: giotto
+
+.. autosummary::
+   :toctree: generated/
+   :template: class.rst
+
+   time_series.PearsonDissimilarity
 
 
 :mod:`giotto.graphs`: Graphs
@@ -160,6 +216,8 @@ Utilities
    :no-members:
    :no-inherited-members:
 
+Graph creation
+--------------
 .. currentmodule:: giotto
 
 .. autosummary::
@@ -168,6 +226,15 @@ Utilities
 
    graphs.TransitionGraph
    graphs.KNeighborsGraph
+
+Graph processing
+----------------
+.. currentmodule:: giotto
+
+.. autosummary::
+   :toctree: generated/
+   :template: class.rst
+
    graphs.GraphGeodesicDistance
    
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
To help better convey the structure of the library and the purpose and interdependence of our classes, I've extended the approach taken in the Mapper module whereby subsections are now created under each module in the docs page.

An issue we had is that large modules such as`diagrams` and `time_series` contained classes designed for use in very different contexts (an example: `PearsonCorrelation` and `Labeller`, both in `time_series`). This change tries to guide the user thematically and to better display the library's capabilities and scope.

Arguably, this should just be temporary fix and we might want to returned to a more "encyclopedic" approach presentation (i.e. as a pure API reference) once our docs pages are overhauled and better integrated with tutorials and user guides.

Zip of built pages attached.

[html.zip](https://github.com/giotto-ai/giotto-learn/files/4078325/html.zip)

