### PR TITLE
Increasing coverage for diagrams.features.HeatKernel.

### DIFF
--- a/giotto/diagrams/_utils.py
+++ b/giotto/diagrams/_utils.py
@@ -67,16 +67,20 @@ def _discretize(X, n_values=100, **kw_args):
     max_vals = {dim: np.max(_subdiagrams(X, [dim], remove_dim=True)[:, :, 1])
                 for dim in homology_dimensions}
     global_max_val = max(list(max_vals.values()))
-    max_vals = {
+    global_min_val = min(list(min_vals.values()))
+    max_vals_2 = {
         dim: max_vals[dim] if
         (max_vals[dim] != min_vals[dim]) else
         global_max_val for dim in homology_dimensions}
+    min_vals_2 = {dim: min_vals[dim] if
+        (max_vals_2[dim] != min_vals[dim]) else
+        global_min_val for dim in homology_dimensions}
 
     samplings = {}
     step_sizes = {}
     for dim in homology_dimensions:
-        samplings[dim], step_sizes[dim] = np.linspace(min_vals[dim],
-                                                      max_vals[dim],
+        samplings[dim], step_sizes[dim] = np.linspace(min_vals_2[dim],
+                                                      max_vals_2[dim],
                                                       retstep=True,
                                                       num=n_values)
         samplings[dim] = samplings[dim][:, None, None]

--- a/giotto/diagrams/_utils.py
+++ b/giotto/diagrams/_utils.py
@@ -72,9 +72,10 @@ def _discretize(X, n_values=100, **kw_args):
         dim: max_vals[dim] if
         (max_vals[dim] != min_vals[dim]) else
         global_max_val for dim in homology_dimensions}
-    min_vals_2 = {dim: min_vals[dim] if
-        (max_vals_2[dim] != min_vals[dim]) else
-        global_min_val for dim in homology_dimensions}
+    min_vals_2 = {dim: min_vals[dim]
+                  if (max_vals_2[dim] != min_vals[dim])
+                  else global_min_val
+                  for dim in homology_dimensions}
 
     samplings = {}
     step_sizes = {}

--- a/giotto/diagrams/features.py
+++ b/giotto/diagrams/features.py
@@ -476,7 +476,7 @@ class HeatKernel(BaseEstimator, TransformerMixin):
         self : object
 
         """
-        X = check_diagram(X)
+        X = check_diagram(X, at_least_two_values=True)
         validate_params(self.get_params(), self._hyperparameters)
 
         self.homology_dimensions_ = sorted(list(set(X[0, :, 2])))
@@ -513,7 +513,7 @@ class HeatKernel(BaseEstimator, TransformerMixin):
 
         """
         check_is_fitted(self)
-        X = check_diagram(X)
+        X = check_diagram(X, at_least_two_values=True)
 
         Xt = Parallel(n_jobs=self.n_jobs)(delayed(
             heats)(_subdiagrams(X, [dim], remove_dim=True)[s],

--- a/giotto/diagrams/tests/test_features.py
+++ b/giotto/diagrams/tests/test_features.py
@@ -1,11 +1,16 @@
 """Testing for PersistenceEntropy"""
 
 import numpy as np
+
 import pytest
+from hypothesis import given
+from hypothesis.extra.numpy import array_shapes, arrays
+from hypothesis.strategies import integers, floats, composite
+
 from numpy.testing import assert_almost_equal
 from sklearn.exceptions import NotFittedError
 
-from giotto.diagrams import PersistenceEntropy
+from giotto.diagrams import PersistenceEntropy, HeatKernel
 
 X_pe = np.array([[[0, 1, 0], [2, 3, 0], [4, 6, 1], [2, 6, 1]]])
 
@@ -22,3 +27,58 @@ def test_pe_transform():
     X_pe_res = np.array([[0.69314718, 0.63651417]])
 
     assert_almost_equal(pe.fit_transform(X_pe), X_pe_res)
+
+
+pts_gen = arrays(
+    dtype=np.float,
+    elements=floats(allow_nan=False,
+                    allow_infinity=False,
+                    min_value=0.,
+                    max_value=10),
+    shape=(1, 20, 2)
+)
+dims_gen = arrays(
+    dtype=np.int,
+    elements=integers(min_value=0.,
+                      max_value=3),
+    shape=(1, 20, 1)
+)
+
+
+@given(pts_gen, dims_gen)
+def test_hk_shape(pts, dims):
+    n_values = 10
+    hk = HeatKernel(sigma=1, n_values=n_values)
+
+    X = np.concatenate([pts, dims], axis=2)
+    num_dimensions = np.unique(dims)
+    X_T = hk.fit(X).transform(X)
+
+    assert X_T.shape == (X.shape[0], num_dimensions, n_values, n_values)
+
+
+@given(pts_gen, dims_gen)
+def test_hk_positive(pts, dims):
+    n_values = 10
+    hk = HeatKernel(sigma=1, n_values=n_values)
+
+    X = np.concatenate([pts, dims], axis=2)
+    num_dimensions = np.unique(dims)
+    X_T = hk.fit(X).transform(X)
+
+    assert np.all(X_T >= 0)
+
+
+@given(pts_gen, dims_gen)
+def test_hk_with_diag_points(pts, dims):
+    n_values = 10
+    hk = HeatKernel(sigma=1, n_values=n_values)
+
+    X = np.concatenate([pts, np.zeros((pts.shape[0], pts.shape[1], 1))], axis=2)
+    num_dimensions = np.unique(dims)
+    diag_points = np.array([[[2, 2, 0], [3, 3, 0], [7, 7, 0]]])
+    X_with_diag_points = np.concatenate([X, diag_points], axis=1)
+
+    X_T, X_with_diag_points_T = [hk.fit(x).transform(x) for x in [X, X_with_diag_points]]
+
+    assert_almost_equal(X_with_diag_points_T, X_T)

--- a/giotto/diagrams/tests/test_features.py
+++ b/giotto/diagrams/tests/test_features.py
@@ -11,6 +11,7 @@ from numpy.testing import assert_almost_equal
 from sklearn.exceptions import NotFittedError
 
 from giotto.diagrams import PersistenceEntropy, HeatKernel
+from giotto.utils.validation import _validate_distinct
 
 X_pe = np.array([[[0, 1, 0], [2, 3, 0], [4, 6, 1], [2, 6, 1]]])
 
@@ -33,52 +34,72 @@ pts_gen = arrays(
     dtype=np.float,
     elements=floats(allow_nan=False,
                     allow_infinity=False,
-                    min_value=0.,
+                    min_value=1.,
                     max_value=10),
     shape=(1, 20, 2)
 )
 dims_gen = arrays(
     dtype=np.int,
-    elements=integers(min_value=0.,
+    elements=integers(min_value=0,
                       max_value=3),
     shape=(1, 20, 1)
 )
 
 
+def get_input(pts, dims):
+    for p in pts:
+        try:
+            _validate_distinct([pts])
+        except ValueError:
+            p[0, 0:2] += 0.3 # add a distinct value
+    X = np.concatenate([np.sort(pts, axis=2), dims], axis=2)
+    return X
+
+
+def test_all_pts_the_same():
+    X = np.zeros((1, 4, 3))
+    hk = HeatKernel(sigma=1)
+    with pytest.raises(ValueError):
+        X_ = hk.fit(X).transform(X)
+
+
 @given(pts_gen, dims_gen)
 def test_hk_shape(pts, dims):
     n_values = 10
+    x = get_input(pts, dims)
+
     hk = HeatKernel(sigma=1, n_values=n_values)
+    num_dimensions = len(np.unique(dims))
+    x_t = hk.fit(x).transform(x)
 
-    X = np.concatenate([pts, dims], axis=2)
-    num_dimensions = np.unique(dims)
-    X_T = hk.fit(X).transform(X)
-
-    assert X_T.shape == (X.shape[0], num_dimensions, n_values, n_values)
+    assert x_t.shape == (x.shape[0], num_dimensions, n_values, n_values)
 
 
 @given(pts_gen, dims_gen)
 def test_hk_positive(pts, dims):
+    """ We expect the points above the PD-diagonal to be non-negative. (up to a numerical error)"""
     n_values = 10
     hk = HeatKernel(sigma=1, n_values=n_values)
 
-    X = np.concatenate([pts, dims], axis=2)
-    num_dimensions = np.unique(dims)
-    X_T = hk.fit(X).transform(X)
+    x = get_input(pts, dims)
+    x_t = hk.fit(x).transform(x)
 
-    assert np.all(X_T >= 0)
+    assert np.all((np.tril(x_t[:, :, ::-1, :]) + 1e-13) >= 0.)
 
 
-@given(pts_gen, dims_gen)
-def test_hk_with_diag_points(pts, dims):
+@given(pts_gen)
+def test_hk_with_diag_points(pts):
+    """Add points on the diagonal, and verify that we have the same results (on the same fitted values)."""
     n_values = 10
     hk = HeatKernel(sigma=1, n_values=n_values)
 
-    X = np.concatenate([pts, np.zeros((pts.shape[0], pts.shape[1], 1))], axis=2)
-    num_dimensions = np.unique(dims)
+    x = get_input(pts, np.zeros((pts.shape[0], pts.shape[1], 1)))
     diag_points = np.array([[[2, 2, 0], [3, 3, 0], [7, 7, 0]]])
-    X_with_diag_points = np.concatenate([X, diag_points], axis=1)
+    x_with_diag_points = np.concatenate([x, diag_points], axis=1)
 
-    X_T, X_with_diag_points_T = [hk.fit(x).transform(x) for x in [X, X_with_diag_points]]
+    # X_total = np.concatenate([X,X_with_diag_points], axis =0)
+    hk = hk.fit(x_with_diag_points)
 
-    assert_almost_equal(X_with_diag_points_T, X_T)
+    x_t, x_with_diag_points_t = [hk.transform(x_) for x_ in [x, x_with_diag_points]]
+
+    assert_almost_equal(x_with_diag_points_t, x_t, decimal=13)

--- a/giotto/diagrams/tests/test_features.py
+++ b/giotto/diagrams/tests/test_features.py
@@ -4,8 +4,8 @@ import numpy as np
 
 import pytest
 from hypothesis import given
-from hypothesis.extra.numpy import array_shapes, arrays
-from hypothesis.strategies import integers, floats, composite
+from hypothesis.extra.numpy import arrays
+from hypothesis.strategies import integers, floats
 
 from numpy.testing import assert_almost_equal
 from sklearn.exceptions import NotFittedError
@@ -51,7 +51,8 @@ def get_input(pts, dims):
         try:
             _validate_distinct([pts])
         except ValueError:
-            p[0, 0:2] += 0.3 # add a distinct value
+            p[0, 0:2] += 0.3
+            # add a distinct value, if not provided by hypothesis
     X = np.concatenate([np.sort(pts, axis=2), dims], axis=2)
     return X
 
@@ -60,7 +61,7 @@ def test_all_pts_the_same():
     X = np.zeros((1, 4, 3))
     hk = HeatKernel(sigma=1)
     with pytest.raises(ValueError):
-        X_ = hk.fit(X).transform(X)
+        _ = hk.fit(X).transform(X)
 
 
 @given(pts_gen, dims_gen)
@@ -77,7 +78,8 @@ def test_hk_shape(pts, dims):
 
 @given(pts_gen, dims_gen)
 def test_hk_positive(pts, dims):
-    """ We expect the points above the PD-diagonal to be non-negative. (up to a numerical error)"""
+    """ We expect the points above the PD-diagonal to be non-negative,
+    (up to a numerical error)"""
     n_values = 10
     hk = HeatKernel(sigma=1, n_values=n_values)
 
@@ -89,7 +91,8 @@ def test_hk_positive(pts, dims):
 
 @given(pts_gen)
 def test_hk_with_diag_points(pts):
-    """Add points on the diagonal, and verify that we have the same results (on the same fitted values)."""
+    """Add points on the diagonal, and verify that we have the same results
+    (on the same fitted values)."""
     n_values = 10
     hk = HeatKernel(sigma=1, n_values=n_values)
 
@@ -100,6 +103,7 @@ def test_hk_with_diag_points(pts):
     # X_total = np.concatenate([X,X_with_diag_points], axis =0)
     hk = hk.fit(x_with_diag_points)
 
-    x_t, x_with_diag_points_t = [hk.transform(x_) for x_ in [x, x_with_diag_points]]
+    x_t, x_with_diag_points_t = [hk.transform(x_)
+                                 for x_ in [x, x_with_diag_points]]
 
     assert_almost_equal(x_with_diag_points_t, x_t, decimal=13)

--- a/giotto/utils/validation.py
+++ b/giotto/utils/validation.py
@@ -64,12 +64,12 @@ def check_diagram(X, at_least_two_values=False):
 
 
 def _validate_distinct(X):
-    unique_values = [np.unique(x[0:2,:]) for x in X]
+    unique_values = [np.unique(x[0:2, :]) for x in X]
     if np.any([len(u) < 2 for u in unique_values]):
         raise ValueError("There should be at least two distinct points"
-                         "in the persistent diagrams: now, only {} is present".format(*unique_values))
+                         "in the persistent diagrams:" +
+                         "now, only {} is present".format(*unique_values))
     return 0
-
 
 
 def check_graph(X):

--- a/giotto/utils/validation.py
+++ b/giotto/utils/validation.py
@@ -22,7 +22,7 @@ available_metric_params = list(set(
      for (param, param_type, param_range) in param_list]))
 
 
-def check_diagram(X):
+def check_diagram(X, at_least_two_values=False):
     """Input validation on a diagram
     """
     if len(X.shape) != 3:
@@ -58,7 +58,18 @@ def check_diagram(X):
                          " {} points in "
                          "all n_samples diagrams are under the diagonal."
                          "".format(n_points_global - n_points_above_diag))
+    if at_least_two_values:
+        _validate_distinct(X)
     return X
+
+
+def _validate_distinct(X):
+    unique_values = [np.unique(x[0:2,:]) for x in X]
+    if np.any([len(u) < 2 for u in unique_values]):
+        raise ValueError("There should be at least two distinct points"
+                         "in the persistent diagrams: now, only {} is present".format(*unique_values))
+    return 0
+
 
 
 def check_graph(X):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/giotto-learn/giotto-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #176. See also #193

#### What does this implement/fix? Explain your changes.
Testing:
- output shape,
- whether the kernel is positive on the area 'above' the diagonal,
- whether the transform is invariant to 

Now, with `pytest --cov-report term-missing --cov=giotto-learn/giotto/diagrams/ giotto-learn/giotto/diagrams/tests/test_features.py giotto-learn/giotto/meta_transformers/tests/test_features.py`,
giotto-learn/giotto/diagrams/features.py                      92      0   100%

#### Any other comments?
1. Modified `giotto.utils.validation.check_diagram` to throw a meaningful error if the coordinates in a PD are all the same,
2. Much of the code in `giotto.diagrams._metrics`is not covered.
3. **Most of the coverage comes from  `giotto-learn/giotto/meta_transformers/tests/test_features.py`.**

<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
