### PR TITLE
Replace `pytest giotto` with `pytest gtda` in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -156,7 +156,7 @@ Testing
 After installation, you can launch the test suite from outside the
 source directory::
 
-    pytest giotto
+    pytest gtda
 
 
 Changelog


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Removes legacy `giotto` from README.rst.