### PR TITLE
Minor mapper enhancements

### DIFF
--- a/examples/mapper_quickstart.ipynb
+++ b/examples/mapper_quickstart.ipynb
@@ -120,7 +120,7 @@
     "\n",
     "4. Construct the topological graph whose vertices are the cluster sets $(C_{i,j})_{i\\in I, j \\in \\{1,\\ldots,k_i\\}}$ and an edge exists between two nodes if they share points in common: $C_{i,j} \\cap C_{k,l} \\neq \\emptyset$. This step is handled automatically by giotto-tda.\n",
     "\n",
-    "These four steps are implemented in the `MapperPipeline()`  object that mimics the `Pipeline()` class from scikit-learn. We provide a convenience function `make_mapper_pipeline()` that allows you to pass the choice of filter function, cover, and clustering algorithm as arguments. For example, to project our data onto the $x$- and $y$-axes, we could setup the pipeline as follows:"
+    "These four steps are implemented in the `MapperPipeline`  object that mimics the `Pipeline` class from scikit-learn. We provide a convenience function `make_mapper_pipeline()` that allows you to pass the choice of filter function, cover, and clustering algorithm as arguments. For example, to project our data onto the $x$- and $y$-axes, we could setup the pipeline as follows:"
    ]
   },
   {
@@ -129,7 +129,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# define filter function - can be any scikit-learn Transformer\n",
+    "# define filter function - can be any scikit-learn transformer\n",
     "filter_func = Projection(columns=[0, 1])\n",
     "# define cover\n",
     "cover = CubicalCover(n_intervals=10, overlap_frac=0.3)\n",
@@ -327,7 +327,7 @@
    "metadata": {},
    "source": [
     "## Run the Mapper pipeline\n",
-    "Behind the scenes of `plot_static_mapper_graph()` is a `MapperPipeline()` object `pipe` that can be used like a typical scikit-learn estimator. For example, to extract the underlying graph data structure we can do the following:"
+    "Behind the scenes of `plot_static_mapper_graph()` is a `MapperPipeline` object `pipe` that can be used like a typical scikit-learn estimator. For example, to extract the underlying graph data structure we can do the following:"
    ]
   },
   {

--- a/gtda/mapper/cluster.py
+++ b/gtda/mapper/cluster.py
@@ -325,7 +325,7 @@ class FirstSimpleGap(ClusterMixin, BaseEstimator, Agglomerative):
     value in the full dendrogram. If possible, the dendrogram is cut at the
     first occurrence of a gap, between the linkage values of successive merges,
     which exceeds this threshold. Otherwise, a single cluster is returned. The
-    algorithm can partially overridden to ensure that the final number of
+    algorithm can be partially overridden to ensure that the final number of
     clusters does not exceed a certain threshold, by passing a parameter
     `max_fraction`.
 
@@ -335,7 +335,7 @@ class FirstSimpleGap(ClusterMixin, BaseEstimator, Agglomerative):
         The fraction of the largest linkage in the dendrogram to be used as
         a threshold for determining a large enough gap.
 
-    max_fraction : int or None, optional, default: ``None``
+    max_fraction : float or None, optional, default: ``None``
         When not ``None``, the algorithm is constrained to produce no more
         than ``max_fraction * (n_samples - 1)`` clusters, even if a
         candidate gap is observed in the iterative process which would produce
@@ -462,8 +462,8 @@ class FirstHistogramGap(ClusterMixin, BaseEstimator, Agglomerative):
     linkage at which the tree is to be cut is the first one after which a
     bin of height no greater than f (i.e. a "gap") is observed; 3) if no gap is
     observed, increase k and repeat 1) and 2) until termination. The algorithm
-    can partially overridden to ensure that the final number of clusters does
-    not exceed a certain threshold, by passing a parameter `max_fraction`.
+    can be partially overridden to ensure that the final number of clusters
+    does not exceed a certain threshold, by passing a parameter `max_fraction`.
 
     Parameters
     ----------
@@ -471,7 +471,7 @@ class FirstHistogramGap(ClusterMixin, BaseEstimator, Agglomerative):
         The frequency threshold for declaring that a gap in the histogram of
         merges is present.
 
-    max_fraction : int or None, optional, default: ``None``
+    max_fraction : float or None, optional, default: ``None``
         When not ``None``, the algorithm is constrained to produce no more
         than ``max_fraction * (n_samples - 1)`` clusters, even if a
         candidate gap is observed in the iterative process which would produce

--- a/gtda/mapper/cluster.py
+++ b/gtda/mapper/cluster.py
@@ -428,7 +428,7 @@ class FirstSimpleGap(ClusterMixin, BaseEstimator, Agglomerative):
         self
 
         """
-        _max_fraction = 1 if self.max_fraction is None else self.max_fraction
+        _max_fraction = 1. if self.max_fraction is None else self.max_fraction
         validate_params({'relative_gap_size': self.relative_gap_size,
                          'max_fraction': _max_fraction},
                         self._hyperparameters)
@@ -545,7 +545,7 @@ class FirstHistogramGap(ClusterMixin, BaseEstimator, Agglomerative):
 
     _hyperparameters = {'freq_threshold': [numbers.Number, (0, np.inf)],
                         'max_fraction': [float, (0, 1)],
-                        'n_bins_start': [int]}
+                        'n_bins_start': [int, (1, np.inf)]}
 
     def __init__(self, freq_threshold=0, max_fraction=None, n_bins_start=5,
                  affinity='euclidean', memory=None, linkage='single'):
@@ -576,7 +576,7 @@ class FirstHistogramGap(ClusterMixin, BaseEstimator, Agglomerative):
         self
 
         """
-        _max_fraction = 1 if self.max_fraction is None else self.max_fraction
+        _max_fraction = 1. if self.max_fraction is None else self.max_fraction
         validate_params({'freq_threshold': self.freq_threshold,
                          'max_fraction': _max_fraction,
                          'n_bins_start': self.n_bins_start},

--- a/gtda/mapper/cluster.py
+++ b/gtda/mapper/cluster.py
@@ -1,6 +1,7 @@
-"""Clustering methods."""
+"""Clustering methods and classes for parallelised clustering."""
 # License: GNU AGPLv3
 
+import numbers
 from inspect import signature
 
 import numpy as np
@@ -15,6 +16,7 @@ except ImportError:
 from sklearn.utils import check_array
 from sklearn.utils.validation import check_memory
 
+from ..utils.validation import validate_params
 from .utils._cluster import _num_clusters_histogram, _num_clusters_simple
 
 
@@ -322,13 +324,22 @@ class FirstSimpleGap(ClusterMixin, BaseEstimator, Agglomerative):
     A simple threshold is determined as a fraction of the largest linkage
     value in the full dendrogram. If possible, the dendrogram is cut at the
     first occurrence of a gap, between the linkage values of successive merges,
-    which exceeds this threshold. Otherwise, a single cluster is returned.
+    which exceeds this threshold. Otherwise, a single cluster is returned. The
+    algorithm can partially overridden to ensure that the final number of
+    clusters does not exceed a certain threshold, by passing a parameter
+    `max_fraction`.
 
     Parameters
     ----------
     relative_gap_size : float, optional, default: ``0.3``
         The fraction of the largest linkage in the dendrogram to be used as
         a threshold for determining a large enough gap.
+
+    max_fraction : int or None, optional, default: ``None``
+        When not ``None``, the algorithm is constrained to produce no more
+        than ``max_fraction * (n_samples - 1)`` clusters, even if a
+        candidate gap is observed in the iterative process which would produce
+        a greater number of clusters.
 
     affinity : str, optional, default: ``'euclidean'``
         Metric used to compute the linkage. Can be ``'euclidean'``, ``'l1'``,
@@ -386,9 +397,13 @@ class FirstSimpleGap(ClusterMixin, BaseEstimator, Agglomerative):
 
     """
 
-    def __init__(self, relative_gap_size=0.3, affinity='euclidean',
-                 memory=None, linkage='single'):
+    _hyperparameters = {'relative_gap_size': [float, (0, 1)],
+                        'max_fraction': [float, (0, 1)]}
+
+    def __init__(self, relative_gap_size=0.3, max_fraction=None,
+                 affinity='euclidean', memory=None, linkage='single'):
         self.relative_gap_size = relative_gap_size
+        self.max_fraction = max_fraction
         self.affinity = affinity
         self.memory = memory
         self.linkage = linkage
@@ -413,7 +428,12 @@ class FirstSimpleGap(ClusterMixin, BaseEstimator, Agglomerative):
         self
 
         """
+        _max_fraction = 1 if self.max_fraction is None else self.max_fraction
+        validate_params({'relative_gap_size': self.relative_gap_size,
+                         'max_fraction': _max_fraction},
+                        self._hyperparameters)
         X = check_array(X)
+
         if X.shape[0] == 1:
             self.labels_ = np.array([0])
             return self
@@ -421,7 +441,8 @@ class FirstSimpleGap(ClusterMixin, BaseEstimator, Agglomerative):
         self._build_tree(X)
 
         min_gap_size = self.relative_gap_size * self.distances_[-1]
-        self.n_clusters_ = _num_clusters_simple(self.distances_, min_gap_size)
+        self.n_clusters_ = _num_clusters_simple(
+            self.distances_, min_gap_size, self.max_fraction)
 
         # Cut the tree to find labels
         # TODO: Verify whether Daniel Mullner's implementation of this step
@@ -440,13 +461,21 @@ class FirstHistogramGap(ClusterMixin, BaseEstimator, Agglomerative):
     dendrogram, as a function of the linkage parameter; 2) the value of
     linkage at which the tree is to be cut is the first one after which a
     bin of height no greater than f (i.e. a "gap") is observed; 3) if no gap is
-    observed, increase k and repeat 1) and 2) until termination.
+    observed, increase k and repeat 1) and 2) until termination. The algorithm
+    can partially overridden to ensure that the final number of clusters does
+    not exceed a certain threshold, by passing a parameter `max_fraction`.
 
     Parameters
     ----------
     freq_threshold : int, optional, default: ``0``
         The frequency threshold for declaring that a gap in the histogram of
         merges is present.
+
+    max_fraction : int or None, optional, default: ``None``
+        When not ``None``, the algorithm is constrained to produce no more
+        than ``max_fraction * (n_samples - 1)`` clusters, even if a
+        candidate gap is observed in the iterative process which would produce
+        a greater number of clusters.
 
     n_bins_start : int, optional, default: ``5``
         The initial number of bins in the iterative process for finding a
@@ -514,9 +543,14 @@ class FirstHistogramGap(ClusterMixin, BaseEstimator, Agglomerative):
 
     """
 
-    def __init__(self, freq_threshold=0, n_bins_start=5, affinity='euclidean',
-                 memory=None, linkage='single'):
+    _hyperparameters = {'freq_threshold': [numbers.Number, (0, np.inf)],
+                        'max_fraction': [float, (0, 1)],
+                        'n_bins_start': [int]}
+
+    def __init__(self, freq_threshold=0, max_fraction=None, n_bins_start=5,
+                 affinity='euclidean', memory=None, linkage='single'):
         self.freq_threshold = freq_threshold
+        self.max_fraction = max_fraction
         self.n_bins_start = n_bins_start
         self.affinity = affinity
         self.memory = memory
@@ -542,6 +576,11 @@ class FirstHistogramGap(ClusterMixin, BaseEstimator, Agglomerative):
         self
 
         """
+        _max_fraction = 1 if self.max_fraction is None else self.max_fraction
+        validate_params({'freq_threshold': self.freq_threshold,
+                         'max_fraction': _max_fraction,
+                         'n_bins_start': self.n_bins_start},
+                        self._hyperparameters)
         X = check_array(X)
         if X.shape[0] == 1:
             self.labels_ = np.array([0])
@@ -550,7 +589,8 @@ class FirstHistogramGap(ClusterMixin, BaseEstimator, Agglomerative):
         self._build_tree(X)
 
         self.n_clusters_ = _num_clusters_histogram(
-            self.distances_, self.freq_threshold, self.n_bins_start)
+            self.distances_, self.freq_threshold, self.n_bins_start,
+            self.max_fraction)
 
         # Cut the tree to find labels
         # TODO: Verify whether Daniel Mullner's implementation of this step

--- a/gtda/mapper/cluster.py
+++ b/gtda/mapper/cluster.py
@@ -433,7 +433,7 @@ class FirstSimpleGap(ClusterMixin, BaseEstimator, Agglomerative):
 
 class FirstHistogramGap(ClusterMixin, BaseEstimator, Agglomerative):
     """Agglomerative clustering with stopping rule given by a histogram-based
-    version of the first gap method.
+    version of the first gap method, introduced in [1]_.
 
     Given a frequency threshold f and an initial integer k: 1) create a
     histogram of k equally spaced bins of the number of merges in the
@@ -505,6 +505,12 @@ class FirstHistogramGap(ClusterMixin, BaseEstimator, Agglomerative):
     See also
     --------
     FirstSimpleGap
+
+    References
+    ----------
+    .. [1] G. Singh, F. Mémoli, and G. Carlsson, "Topological methods for the
+           analysis of high dimensional data sets and 3D object recognition";
+           in *SPBG*, pp. 91--100, 2007.
 
     """
 

--- a/gtda/mapper/cluster.py
+++ b/gtda/mapper/cluster.py
@@ -1,7 +1,6 @@
 """Clustering methods and classes for parallelised clustering."""
 # License: GNU AGPLv3
 
-import numbers
 from inspect import signature
 
 import numpy as np
@@ -543,7 +542,7 @@ class FirstHistogramGap(ClusterMixin, BaseEstimator, Agglomerative):
 
     """
 
-    _hyperparameters = {'freq_threshold': [numbers.Number, (0, np.inf)],
+    _hyperparameters = {'freq_threshold': [int, (0, np.inf)],
                         'max_fraction': [float, (0, 1)],
                         'n_bins_start': [int, (1, np.inf)]}
 

--- a/gtda/mapper/cover.py
+++ b/gtda/mapper/cover.py
@@ -12,9 +12,9 @@ from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted
 
 from .utils._cover import (_check_has_one_column,
-                           _remove_empty_and_duplicate_intervals,
-                           _validate_kind)
+                           _remove_empty_and_duplicate_intervals)
 from ..utils._docs import adapt_fit_transform_docs
+from ..utils.validation import validate_params
 
 
 @adapt_fit_transform_docs
@@ -82,6 +82,10 @@ class OneDimensionalCover(BaseEstimator, TransformerMixin):
 
     """
 
+    _hyperparameters = {'kind': ['uniform', 'balanced'],
+                        'n_intervals': [int],
+                        'overlap_frac': [float, (0, 1)]}
+
     def __init__(self, kind='uniform', n_intervals=10, overlap_frac=0.1):
         self.kind = kind
         self.n_intervals = n_intervals
@@ -125,9 +129,7 @@ class OneDimensionalCover(BaseEstimator, TransformerMixin):
         self : object
 
         """
-        # TODO: Extend validation to n_intervals and overlap_frac,
-        #  using validate_params
-        _validate_kind(self.kind)
+        validate_params(self.get_params(), self._hyperparameters)
         X = check_array(X, ensure_2d=False)
         if X.ndim == 2:
             _check_has_one_column(X)
@@ -224,7 +226,7 @@ class OneDimensionalCover(BaseEstimator, TransformerMixin):
             or duplicated cover sets are removed.
 
         """
-        _validate_kind(self.kind)
+        validate_params(self.get_params(), self._hyperparameters)
         X = check_array(X, ensure_2d=False)
         if X.ndim == 2:
             _check_has_one_column(X)
@@ -360,6 +362,10 @@ class CubicalCover(BaseEstimator, TransformerMixin):
 
     """
 
+    _hyperparameters = {'kind': ['uniform', 'balanced'],
+                        'n_intervals': [int],
+                        'overlap_frac': [float, (0, 1)]}
+
     def __init__(self, kind='uniform', n_intervals=10, overlap_frac=0.1):
         self.kind = kind
         self.n_intervals = n_intervals
@@ -415,7 +421,7 @@ class CubicalCover(BaseEstimator, TransformerMixin):
         self : object
 
         """
-        _validate_kind(self.kind)
+        validate_params(self.get_params(), self._hyperparameters)
         # reshape filter function values derived from FunctionTransformer
         if X.ndim == 1:
             X = X[:, None]
@@ -496,8 +502,7 @@ class CubicalCover(BaseEstimator, TransformerMixin):
             n_features` as empty or duplicated cover sets are removed.
 
         """
-        _validate_kind(self.kind)
-
+        validate_params(self.get_params(), self._hyperparameters)
         # reshape filter function values derived from FunctionTransformer
         if X.ndim == 1:
             X = X[:, None]

--- a/gtda/mapper/cover.py
+++ b/gtda/mapper/cover.py
@@ -82,8 +82,8 @@ class OneDimensionalCover(BaseEstimator, TransformerMixin):
 
     """
 
-    _hyperparameters = {'kind': ['uniform', 'balanced'],
-                        'n_intervals': [int],
+    _hyperparameters = {'kind': [str, ['uniform', 'balanced']],
+                        'n_intervals': [int, (1, np.inf)],
                         'overlap_frac': [float, (0, 1)]}
 
     def __init__(self, kind='uniform', n_intervals=10, overlap_frac=0.1):
@@ -362,8 +362,8 @@ class CubicalCover(BaseEstimator, TransformerMixin):
 
     """
 
-    _hyperparameters = {'kind': ['uniform', 'balanced'],
-                        'n_intervals': [int],
+    _hyperparameters = {'kind': [str, ['uniform', 'balanced']],
+                        'n_intervals': [int, (1, np.inf)],
                         'overlap_frac': [float, (0, 1)]}
 
     def __init__(self, kind='uniform', n_intervals=10, overlap_frac=0.1):

--- a/gtda/mapper/pipeline.py
+++ b/gtda/mapper/pipeline.py
@@ -154,14 +154,15 @@ def make_mapper_pipeline(scaler=None,
     """Construct a MapperPipeline object according to the specified Mapper
     steps. [1]_
 
-    All steps may be arbitrary scikit-learn Pipeline objects. The scaling
-    and cover steps must be transformers implementing a ``fit_transform``
-    method. The filter function step may be a transformer implementing a
-    ``fit_transform``, or a callable acting on one-dimensional arrays -- in
-    the latter case, a transformer is internally created whose
-    ``fit_transform`` applies this callable independently on each row of the
-    data. The clustering step need only implement a ``fit`` method storing
-    clustering labels.
+    The role of this function's key parameters is illustrated in `this diagram
+    <https://docs.giotto.ai/mapper_pipeline.svg>`_. All computational steps
+    may be arbitrary scikit-learn Pipeline objects. The scaling and cover
+    steps must be transformers implementing a ``fit_transform`` method. The
+    filter function step may be a transformer implementing a ``fit_transform``,
+    or a callable acting on one-dimensional arrays -- in the latter case,
+    a transformer is internally created whose ``fit_transform`` applies this
+    callable independently on each row of the data. The clustering step need
+    only implement a ``fit`` method storing clustering labels.
 
     Parameters
     ----------

--- a/gtda/mapper/utils/_cluster.py
+++ b/gtda/mapper/utils/_cluster.py
@@ -3,7 +3,7 @@ from functools import partial
 import numpy as np
 
 
-def _num_clusters_histogram(distances, freq_threshold, n_bins_start):
+def _num_clusters_histogram(distances, freq_threshold, n_bins_start, max_frac):
     if distances.size == 1:
         return 1
 
@@ -11,17 +11,37 @@ def _num_clusters_histogram(distances, freq_threshold, n_bins_start):
         threshold_func = _zero_bins
     else:
         threshold_func = partial(_bins_below_threshold, freq_threshold)
+
     zero_bins = False
     i = 0
-    while not zero_bins:
-        hist, edges = np.histogram(distances, bins=n_bins_start + i)
-        zero_bins_indices = threshold_func(hist)
-        zero_bins = zero_bins_indices.size
-        i += 1
-    first_gap = zero_bins_indices[0]
-    left_bin_edge_first_gap = edges[first_gap]
-    gap_idx = (distances <= left_bin_edge_first_gap).sum()
-    num_clust = distances.size + 1 - gap_idx
+    if max_frac is None:
+        while not zero_bins:
+            hist, edges = np.histogram(distances, bins=n_bins_start + i)
+            zero_bins_indices = threshold_func(hist)
+            zero_bins = zero_bins_indices.size
+            i += 1
+        first_gap = zero_bins_indices[0]
+        left_bin_edge_first_gap = edges[first_gap]
+        gap_idx = (distances <= left_bin_edge_first_gap).sum()
+        num_clust = distances.size + 1 - gap_idx
+    else:
+        max_num_clust = np.ceil(max_frac * distances.size)
+        over_max_num = True
+        while over_max_num:
+            while (not zero_bins) and (not under_max_num):
+                hist, edges = np.histogram(distances, bins=n_bins_start + i)
+                zero_bins_indices = threshold_func(hist)
+                zero_bins = zero_bins_indices.size
+                i += 1
+            first_gap = zero_bins_indices[0]
+            left_bin_edge_first_gap = edges[first_gap]
+            gap_idx = (distances <= left_bin_edge_first_gap).sum()
+            num_clust = distances.size + 1 - gap_idx
+            if num_clust > max_num_clust:
+                num_clust = max_num_clust
+                break
+            else:
+                over_max_num = False
     return num_clust
 
 
@@ -33,13 +53,17 @@ def _bins_below_threshold(freq_threshold, hist):
     return np.flatnonzero(hist < freq_threshold)
 
 
-def _num_clusters_simple(distances, min_gap_size):
+def _num_clusters_simple(distances, min_gap_size, max_frac):
     # Differences between subsequent elements (padding by the first
     # distance)
     diff = np.ediff1d(distances, to_begin=distances[0])
     gap_indices = np.flatnonzero(diff >= min_gap_size)
     if gap_indices.size:
         num_clust = distances.size + 1 - gap_indices[0]
+        if max_frac is None:
+            return num_clust
+        max_num_clust = np.ceil(max_frac * distances.size)
+        num_clust = num_clust if num_clust <= max_num_clust else max_num_clust
         return num_clust
     # No big enough gaps -> one cluster
     return 1

--- a/gtda/mapper/utils/_cluster.py
+++ b/gtda/mapper/utils/_cluster.py
@@ -28,7 +28,7 @@ def _num_clusters_histogram(distances, freq_threshold, n_bins_start, max_frac):
         max_num_clust = np.ceil(max_frac * distances.size)
         over_max_num = True
         while over_max_num:
-            while (not zero_bins) and (not under_max_num):
+            while (not zero_bins) and over_max_num:
                 hist, edges = np.histogram(distances, bins=n_bins_start + i)
                 zero_bins_indices = threshold_func(hist)
                 zero_bins = zero_bins_indices.size

--- a/gtda/mapper/utils/_cluster.py
+++ b/gtda/mapper/utils/_cluster.py
@@ -1,4 +1,5 @@
 from functools import partial
+from math import ceil
 
 import numpy as np
 
@@ -25,7 +26,7 @@ def _num_clusters_histogram(distances, freq_threshold, n_bins_start, max_frac):
         gap_idx = (distances <= left_bin_edge_first_gap).sum()
         num_clust = distances.size + 1 - gap_idx
     else:
-        max_num_clust = np.ceil(max_frac * distances.size)
+        max_num_clust = ceil(max_frac * distances.size)
         over_max_num = True
         while over_max_num:
             while (not zero_bins) and over_max_num:
@@ -62,7 +63,7 @@ def _num_clusters_simple(distances, min_gap_size, max_frac):
         num_clust = distances.size + 1 - gap_indices[0]
         if max_frac is None:
             return num_clust
-        max_num_clust = np.ceil(max_frac * distances.size)
+        max_num_clust = ceil(max_frac * distances.size)
         num_clust = num_clust if num_clust <= max_num_clust else max_num_clust
         return num_clust
     # No big enough gaps -> one cluster

--- a/gtda/mapper/utils/_cover.py
+++ b/gtda/mapper/utils/_cover.py
@@ -1,11 +1,6 @@
 import numpy as np
 
 
-def _validate_kind(kind):
-    if kind not in ['uniform', 'balanced']:
-        raise ValueError("'kind' must be one of 'uniform' or 'balanced'")
-
-
 def _check_has_one_column(X):
     if X.shape[1] > 1:
         raise ValueError("X cannot have more than one column.")

--- a/gtda/mapper/visualization.py
+++ b/gtda/mapper/visualization.py
@@ -95,7 +95,7 @@ def plot_static_mapper_graph(
     else:
         pipe = pipeline
 
-    if node_color_statistic is None:
+    if node_color_statistic is not None:
         _node_color_statistic = node_color_statistic
     else:
         _node_color_statistic = np.mean

--- a/gtda/utils/validation.py
+++ b/gtda/utils/validation.py
@@ -86,7 +86,7 @@ def validate_params(parameters, references):
                     if (parameter < references[key][1][1][0] or
                             parameter > references[key][1][1][1]):
                         raise ValueError("Parameter {} is a list containing {}"
-                                         "which should be in the range ({},{})"
+                                         "which should be in the range [{},{}]"
                                          "".format(key, parameter,
                                                    references[key][1][1][0],
                                                    references[key][1][1][1]))
@@ -95,7 +95,7 @@ def validate_params(parameters, references):
             if (parameters[key] < references[key][1][0] or
                     parameters[key] > references[key][1][1]):
                 raise ValueError("Parameter {} is {}, while it"
-                                 " should be in the range ({},{})"
+                                 " should be in the range [{}, {}]"
                                  "".format(key, parameters[key],
                                            references[key][1][0],
                                            references[key][1][1]))


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
- Changes the default parameter for `node_color_statistic` in `plot_static_mapper_graph` and `plot_interactive_mapper_graph` from `np.mean` to `None`. This is consistent with the treatment of defaults elsewhere in giotto-tda and makes for better-looking documentation, avoiding such horrors as `node_color_statistic=<function mean at 0x10d7d6ef0>`.
- Wording changes and docstring improvements
- Add new `max_fraction` parameter to agglomerative clusterers to address, addressing a variant of (#130)
- Add hyperparameter validation to cover classes and flat-cut clusterers
- Print closed instead of open intervals in `utils.validation.validate_params`