### PR TITLE
Attempt to fix manylinux2010 builds for python 3.8

### DIFF
--- a/azure-ci/docker_scripts.sh
+++ b/azure-ci/docker_scripts.sh
@@ -5,14 +5,13 @@ set -x
 # upgrading pip and setuptools
 PYTHON_PATH=$(eval find "/opt/python/*${python_ver}*" -print)
 export PATH=${PYTHON_PATH}/bin:${PATH}
-pip install --upgrade pip setuptools
+pip install --upgrade pip==19.3.1 setuptools
 
 # installing cmake
 pip install cmake
 
 # install dependencies for python-igraph
 yum install -y libxml2 libxml2-devel zlib1g-devel bison flex
-pip install python-igraph
 
 # installing boost
 yum install -y wget tar


### PR DESCRIPTION
As of today, our manylinux2010 builds have started to fail on python 3.8. Coincidentally, `pip` was bumped to versions 20.0.0 and then 20.0.1 today. See (#208). This is an attempt to see whether this update was the source of the problem.