### PR TITLE
Remove `pip install python-igraph` from manylinux2010 script

### DIFF
--- a/azure-ci/docker_scripts.sh
+++ b/azure-ci/docker_scripts.sh
@@ -12,7 +12,6 @@ pip install cmake
 
 # install dependencies for python-igraph
 yum install -y libxml2 libxml2-devel zlib1g-devel bison flex
-pip install python-igraph
 
 # installing boost
 yum install -y wget tar


### PR DESCRIPTION
This is undesirable as it does not properly test our `requirements.txt` and our `setup.py`.