### PR TITLE
Update pybind11 to pull from master

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,6 @@ class CMakeBuild(build_ext):
             return 0
         os.mkdir(dir_pybind11)
         subprocess.check_call(['git', 'clone',
-                               '--single-branch', '--branch', 'v2.4',
                                'https://github.com/pybind/pybind11.git',
                                dir_pybind11])
         os.chdir(dir_pybind11)


### PR DESCRIPTION
After fix https://github.com/pybind/pybind11/pull/2087, windows wheel should be able to compile again

Signed-off-by: julian <julian.burellaperez@heig-vd.ch>

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/giotto-ai/giotto-tda/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#170

#### What does this implement/fix? Explain your changes.

After discussion with `pybind11` a fix was found to our current problem on building Windows Wheel.
See https://github.com/pybind/pybind11/pull/2087


#### Any other comments?


<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
