### PR TITLE
Improve READMEs with new URLs, mapper_quickstart, tutorials and theory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,9 +25,6 @@ giotto-tda
 giotto-tda is a high performance topological machine learning toolbox in Python built on top of
 scikit-learn and is distributed under the GNU AGPLv3 license. It is part of the `Giotto <https://github.com/giotto-ai>`_ family of open-source projects.
 
-Website: https://giotto.ai
-
-
 Project genesis
 ---------------
 
@@ -35,6 +32,22 @@ giotto-tda is the result of a collaborative effort between `L2F SA
 <https://www.l2f.ch/>`_, the `Laboratory for Topology and Neuroscience
 <https://www.epfl.ch/labs/hessbellwald-lab/>`_ at EPFL, and the `Institute of Reconfigurable & Embedded Digital Systems (REDS)
 <https://heig-vd.ch/en/research/reds>`_ of HEIG-VD.
+
+Documentation
+-------------
+
+- API reference (stable release): https://docs-tda.giotto.ai
+- Theory glossary: https://giotto.ai/theory
+
+Getting started
+---------------
+
+To get started with giotto-tda, first follow the installations steps below. `This blog post <https://towardsdatascience.com/getting-started-with-giotto-learn-a-python-library-for-topological-machine-learning-451d88d2c4bc>`_, and references therein, offer a friendly introduction to the topic of topological machine learning and to the philosophy behind giotto-tda.
+
+Tutorials and use cases
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Simple tutorials can be found in the `examples <https://github.com/giotto-ai/giotto-tda/tree/master/examples>`_ folder. For a wide selection of use cases and application domains, you can visit `this page <https://giotto.ai/learn/course-content>`_.
 
 Installation
 ------------
@@ -74,11 +87,6 @@ bug fixes can be installed by running   ::
 The main difference between ``giotto-tda-nightly`` and the developer
 installation (see below) is that the former is shipped with pre-compiled wheels
 (similarly to the stable release) and hence does not require any C++ dependencies.
-
-Documentation
--------------
-
-- HTML documentation (stable release): https://docs.giotto.ai
 
 Contributing
 ------------

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 
 |Version|_ |Azure-build|_ |Azure-cov|_ |Azure-test|_ |Twitter-follow|_ |Slack-join|_
 
-.. |Version| .. image:: https://img.shields.io/pypi/v/giotto-tda
+.. |Version| image:: https://img.shields.io/pypi/v/giotto-tda
 .. _Version:
 
 .. |Azure-build| image:: https://dev.azure.com/maintainers/Giotto/_apis/build/status/giotto-ai.giotto-tda?branchName=master

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,10 @@
 .. image:: https://www.giotto.ai/static/vector/logo.svg
    :width: 850
 
-|Azure-build|_ |Azure-cov|_ |Azure-test|_ |Twitter-follow|_ |Slack-join|_
+|Version|_ |Azure-build|_ |Azure-cov|_ |Azure-test|_ |Twitter-follow|_ |Slack-join|_
+
+.. |Version| .. image:: https://img.shields.io/pypi/v/giotto-tda
+.. _Version:
 
 .. |Azure-build| image:: https://dev.azure.com/maintainers/Giotto/_apis/build/status/giotto-ai.giotto-tda?branchName=master
 .. _Azure-build: https://dev.azure.com/maintainers/Giotto/_build?definitionId=6&_a=summary&repositoryFilter=6&branchFilter=141&requestedForFilter=ae4334d8-48e3-4663-af95-cb6c654474ea

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -1,10 +1,10 @@
 .. image:: https://www.giotto.ai/static/vector/logo.svg
    :width: 850
 
-Examples and Tutorials
-======================
+Examples, tutorials and plotting utilities
+==========================================
 
-In this folder you can find basic tutorials and examples: you can read through them to understand how giotto-tda works.
+In this folder you can find basic tutorials and examples to get started quickly with giotto-tda. Additionally, ``plotting.py`` contains utilities for plotting the outputs of several computations you can perform with giotto-tda.
 
 Classifying Shapes
 ------------------
@@ -16,15 +16,16 @@ vertices forms the input of the Vietoris-Rips algorithm.
 Lorenz attractor
 ----------------
 
-This tutorial is about detecting chaotic regimes in a simulation of the `Lorenz attractor. <https://en.wikipedia.org/wiki/Lorenz_system>`_
-The main tools of giotto-tda useful for time-series analysis (such as the *Takens Embedding*) are used and explained in the tutorial.
-Other feature creation methods, such as the *persistence Landscape* or the *persistence Entropy* are described in the final part of the
+This tutorial is about detecting chaotic regimes in a simulation of the `Lorenz attractor. <https://en.wikipedia.org/wiki/Lorenz_system>`_. The main tools of giotto-tda useful for time-series analysis (such as the *Takens embedding*) are used and explained in the tutorial. Other feature creation methods, such as the *persistence landscape* or the *persistence entropy*, are described in the final part of the
 tutorial.
 
-Can there be non trivial H_2 in 2-dimensions?
---------------------------------------------
+Mapper quickstart
+-----------------
+
+The Mapper algorithm was introduced in v0.1.5, and allows you to visualize complex, high-dimensional data in a simple way as a graph to reveal structural insights. This tutorial covers some of the main functionalities of the ``gtda.mapper`` module.
+
+Can there be non trivial H\ :sub:`2` in 2 dimensions?
+-----------------------------------------------------
 
 This is a simple riddle that shows how the Vietoris-Rips algorithm may find counterintuitive patters in point-clouds.
-The second homology group, H_2, describes and counts voids: for example, the 2-sphere has a non-trivial H_2. Therefore,
-we would not expect to find voids in 2-dimensional flat space! On the other hand, it is enough to carefully position 6 points
-on the plane to get a nontrivial H_2: check the example out for an empirical proof!
+The second homology group, H\ :sub:`2`, describes and counts voids: for example, the 2-sphere has a non-trivial H\ :sub:`2`. Therefore, we would not expect to find voids in 2-dimensional flat space! On the other hand, it is enough to carefully position 6 points on the plane to get a nontrivial H\ :sub:`2`: check the example out for an empirical proof!


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
As per title. As the API reference page will be hosted on docs-tda.giotto.ai started today, links have been updated to be future-proof. A separate PR will deal with updating these links in code.