### PR TITLE
Fix Mapper svg URL ahead of migration to docs-tda.giotto.ai

### DIFF
--- a/gtda/mapper/pipeline.py
+++ b/gtda/mapper/pipeline.py
@@ -155,7 +155,7 @@ def make_mapper_pipeline(scaler=None,
     steps. [1]_
 
     The role of this function's key parameters is illustrated in `this diagram
-    <https://docs.giotto.ai/mapper_pipeline.svg>`_. All computational steps
+    <https://docs-tda.giotto.ai/mapper_pipeline.svg>`_. All computational steps
     may be arbitrary scikit-learn Pipeline objects. The scaling and cover
     steps must be transformers implementing a ``fit_transform`` method. The
     filter function step may be a transformer implementing a ``fit_transform``,


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Ensures links to docs.giotto.ai no longer exist as we are migrating to docs-tda.giotto.ai