### PR TITLE
Tests for the time_series module

### DIFF
--- a/gtda/time_series/tests/test_embedding.py
+++ b/gtda/time_series/tests/test_embedding.py
@@ -76,7 +76,6 @@ def test_embedder_transform(parameters_type, expected):
 
 def test_embedder_resample():
     embedder = TakensEmbedding(time_delay=4, dimension=5, stride=3)
-    embedder = embedder.fit(signal)
     y_resampled = embedder.resample(y)
     assert_almost_equal(y_resampled, y[np.arange(4, 20, 3)])
 
@@ -95,6 +94,5 @@ def test_window_transform():
 
 def test_window_resample():
     windows = SlidingWindow(width=3, stride=2)
-    windows = windows.fit(signal_embedded_search)
     y_resampled = windows.resample(y)
     assert_almost_equal(y_resampled, y[np.arange(3, 20, 2)])

--- a/gtda/time_series/tests/test_embedding.py
+++ b/gtda/time_series/tests/test_embedding.py
@@ -78,7 +78,7 @@ def test_embedder_resample():
     embedder = TakensEmbedding(time_delay=4, dimension=5, stride=3)
     embedder = embedder.fit(signal)
     y_resampled = embedder.resample(y)
-    assert_almost_equal(y_resampled, y[np.arange(4,20,3)])
+    assert_almost_equal(y_resampled, y[np.arange(4, 20, 3)])
 
 
 def test_window_params():
@@ -90,11 +90,11 @@ def test_window_params():
 def test_window_transform():
     embedder = SlidingWindow(width=3, stride=2)
     x_windows = embedder.fit_transform(signal_embedded_search)
-    assert (x_windows.shape == (8,4,2))
+    assert (x_windows.shape == (8, 4, 2))
 
 
 def test_window_resample():
     embedder = SlidingWindow(width=3, stride=2)
     embedder = embedder.fit(signal_embedded_search)
     y_resampled = embedder.resample(y)
-    assert_almost_equal(y_resampled, y[np.arange(3,20,2)])
+    assert_almost_equal(y_resampled, y[np.arange(3, 20, 2)])

--- a/gtda/time_series/tests/test_embedding.py
+++ b/gtda/time_series/tests/test_embedding.py
@@ -76,12 +76,14 @@ def test_embedder_transform(parameters_type, expected):
 
 def test_embedder_resample():
     embedder = TakensEmbedding(time_delay=4, dimension=5, stride=3)
+    embedder.fit(signal)
     y_resampled = embedder.resample(y)
     assert_almost_equal(y_resampled, y[np.arange(4, 20, 3)])
 
 
 def test_window_params():
     windows = SlidingWindow(width=0)
+    windows.fit(signal)
     with pytest.raises(ValueError):
         windows.fit(signal)
 

--- a/gtda/time_series/tests/test_embedding.py
+++ b/gtda/time_series/tests/test_embedding.py
@@ -31,6 +31,8 @@ signal_embedded_search = np.array([[2., 2.47942554],
                                    [2.79848711, 2.41211849],
                                    [2.41211849, 1.92484888]])
 
+y = np.arange(signal.shape[0])
+
 signal_embedded_fixed = \
     np.array([[2., 2.47942554, 2.84147098, 2.99749499, 2.90929743],
               [2.47942554, 2.84147098, 2.99749499, 2.90929743, 2.59847214],
@@ -72,7 +74,27 @@ def test_embedder_transform(parameters_type, expected):
     assert_almost_equal(embedder.fit_transform(signal), expected)
 
 
+def test_embedder_resample():
+    embedder = TakensEmbedding(time_delay=4, dimension=5, stride=3)
+    embedder = embedder.fit(signal)
+    y_resampled = embedder.resample(y)
+    assert_almost_equal(y_resampled, y[np.arange(4,20,3)])
+
+
 def test_window_params():
-    window = SlidingWindow(width=0)
+    embedder = SlidingWindow(width=0)
     with pytest.raises(ValueError):
-        window.fit(signal)
+        embedder.fit(signal)
+
+
+def test_window_transform():
+    embedder = SlidingWindow(width=3, stride=2)
+    x_windows = embedder.fit_transform(signal_embedded_search)
+    assert (x_windows.shape == (8,4,2))
+
+
+def test_window_resample():
+    embedder = SlidingWindow(width=3, stride=2)
+    embedder = embedder.fit(signal_embedded_search)
+    y_resampled = embedder.resample(y)
+    assert_almost_equal(y_resampled, y[np.arange(3,20,2)])

--- a/gtda/time_series/tests/test_embedding.py
+++ b/gtda/time_series/tests/test_embedding.py
@@ -82,19 +82,19 @@ def test_embedder_resample():
 
 
 def test_window_params():
-    embedder = SlidingWindow(width=0)
+    windows = SlidingWindow(width=0)
     with pytest.raises(ValueError):
-        embedder.fit(signal)
+        windows.fit(signal)
 
 
 def test_window_transform():
-    embedder = SlidingWindow(width=3, stride=2)
-    x_windows = embedder.fit_transform(signal_embedded_search)
+    windows = SlidingWindow(width=3, stride=2)
+    x_windows = windows.fit_transform(signal_embedded_search)
     assert (x_windows.shape == (8, 4, 2))
 
 
 def test_window_resample():
-    embedder = SlidingWindow(width=3, stride=2)
-    embedder = embedder.fit(signal_embedded_search)
-    y_resampled = embedder.resample(y)
+    windows = SlidingWindow(width=3, stride=2)
+    windows = windows.fit(signal_embedded_search)
+    y_resampled = windows.resample(y)
     assert_almost_equal(y_resampled, y[np.arange(3, 20, 2)])

--- a/gtda/time_series/tests/test_embedding.py
+++ b/gtda/time_series/tests/test_embedding.py
@@ -83,7 +83,6 @@ def test_embedder_resample():
 
 def test_window_params():
     windows = SlidingWindow(width=0)
-    windows.fit(signal)
     with pytest.raises(ValueError):
         windows.fit(signal)
 
@@ -96,5 +95,6 @@ def test_window_transform():
 
 def test_window_resample():
     windows = SlidingWindow(width=3, stride=2)
+    windows.fit(y)
     y_resampled = windows.resample(y)
     assert_almost_equal(y_resampled, y[np.arange(3, 20, 2)])

--- a/gtda/time_series/tests/test_features.py
+++ b/gtda/time_series/tests/test_features.py
@@ -8,6 +8,10 @@ from itertools import product
 
 X = np.ones((10, 200, 3)) # 10 samples, of 200 points embedded in a 3d space
 X_unif = np.tile(np.random.randn(200,3), (10,1,1))
+X_3 = np.array([[[1, 2, 3],
+                 [1, 2, 3],
+                 [7, 6, 5]]])
+pe_3 = 0.91829583
 
 def test_entropy_shape():
     pe = PermutationEntropy()
@@ -16,13 +20,16 @@ def test_entropy_shape():
 
 
 def test_entropy_unif():
-    """Checkl that the process gives the same on the same samples"""
+    """Check that the process gives the same on the same samples"""
     pe = PermutationEntropy()
     x_transformed = pe.fit_transform(X_unif)
     are_equal = [a==b for a,b in product(x_transformed, x_transformed)]
     assert np.all(are_equal)
 
-def test_uniform():
+
+def test_entropy_calc():
     pe = PermutationEntropy()
-    x_transformed = pe.fit_transform(X)
-    assert False
+    x_transformed = pe.fit_transform(X_3)
+    assert_almost_equal(x_transformed[0], pe_3, decimal=6)
+
+

--- a/gtda/time_series/tests/test_features.py
+++ b/gtda/time_series/tests/test_features.py
@@ -1,0 +1,28 @@
+"""Testing for feature creation from time series."""
+# License: GNU AGPLv3
+
+import numpy as np
+from numpy.testing import assert_almost_equal
+from gtda.time_series.features import PermutationEntropy
+from itertools import product
+
+X = np.ones((10, 200, 3)) # 10 samples, of 200 points embedded in a 3d space
+X_unif = np.tile(np.random.randn(200,3), (10,1,1))
+
+def test_entropy_shape():
+    pe = PermutationEntropy()
+    x_transformed = pe.fit_transform(X)
+    assert x_transformed.shape == (X.shape[0], 1)
+
+
+def test_entropy_unif():
+    """Checkl that the process gives the same on the same samples"""
+    pe = PermutationEntropy()
+    x_transformed = pe.fit_transform(X_unif)
+    are_equal = [a==b for a,b in product(x_transformed, x_transformed)]
+    assert np.all(are_equal)
+
+def test_uniform():
+    pe = PermutationEntropy()
+    x_transformed = pe.fit_transform(X)
+    assert False

--- a/gtda/time_series/tests/test_features.py
+++ b/gtda/time_series/tests/test_features.py
@@ -7,7 +7,7 @@ from gtda.time_series.features import PermutationEntropy
 from itertools import product
 
 X = np.ones((10, 200, 3))  # 10 samples, of 200 points embedded in a 3d space
-X_unif = np.tile(np.random.randn(200,3), (10,1,1))
+X_unif = np.tile(np.random.randn(200, 3), (10, 1, 1))
 X_3 = np.array([[[1, 2, 3],
                  [1, 2, 3],
                  [7, 6, 5]]])
@@ -24,7 +24,7 @@ def test_entropy_unif():
     """Check that the process gives the same on the same samples"""
     pe = PermutationEntropy()
     x_transformed = pe.fit_transform(X_unif)
-    are_equal = [a==b for a,b in product(x_transformed, x_transformed)]
+    are_equal = [a == b for a, b in product(x_transformed, x_transformed)]
     assert np.all(are_equal)
 
 
@@ -32,5 +32,3 @@ def test_entropy_calc():
     pe = PermutationEntropy()
     x_transformed = pe.fit_transform(X_3)
     assert_almost_equal(x_transformed[0], pe_3, decimal=6)
-
-

--- a/gtda/time_series/tests/test_features.py
+++ b/gtda/time_series/tests/test_features.py
@@ -6,12 +6,13 @@ from numpy.testing import assert_almost_equal
 from gtda.time_series.features import PermutationEntropy
 from itertools import product
 
-X = np.ones((10, 200, 3)) # 10 samples, of 200 points embedded in a 3d space
+X = np.ones((10, 200, 3))  # 10 samples, of 200 points embedded in a 3d space
 X_unif = np.tile(np.random.randn(200,3), (10,1,1))
 X_3 = np.array([[[1, 2, 3],
                  [1, 2, 3],
                  [7, 6, 5]]])
 pe_3 = 0.91829583
+
 
 def test_entropy_shape():
     pe = PermutationEntropy()

--- a/gtda/time_series/tests/test_features.py
+++ b/gtda/time_series/tests/test_features.py
@@ -21,7 +21,7 @@ def test_entropy_shape():
 
 
 def test_entropy_unif():
-    """Check that the process gives the same on the same samples"""
+    """Check that the process gives the same results on the same samples"""
     pe = PermutationEntropy()
     x_transformed = pe.fit_transform(X_unif)
     are_equal = [a == b for a, b in product(x_transformed, x_transformed)]

--- a/gtda/time_series/tests/test_preprocessing.py
+++ b/gtda/time_series/tests/test_preprocessing.py
@@ -44,6 +44,15 @@ def test_resampler_transform(period, expected):
     assert_almost_equal(resampler.fit_transform(signal_array), expected)
 
 
+@pytest.mark.parametrize("period, expected",
+                         [(2, signal_resampled_2),
+                          (4, signal_resampled_4)])
+def test_resampler_resample(period, expected):
+    resampler = Resampler(period=period)
+    _ = resampler.fit_transform(signal_array)
+    assert_almost_equal(resampler.resample(signal_array), expected)
+
+
 signal = signal_array.reshape(-1, 1)
 
 signal_stationarized_return = np.array(
@@ -109,3 +118,12 @@ def test_stationarizer_transform(operation, expected):
     stationarizer = Stationarizer(operation=operation)
 
     assert_almost_equal(stationarizer.fit_transform(signal), expected)
+
+
+@pytest.mark.parametrize("operation, expected",
+                         [('return', signal_stationarized_return)])
+def test_stationarizer_resample(operation, expected):
+    stationarizer = Stationarizer(operation=operation)
+    signal_1d = signal.reshape(-1)
+    _ = stationarizer.fit_transform(signal_1d)
+    assert_almost_equal(stationarizer.resample(signal_1d), signal_1d[1:])

--- a/gtda/time_series/tests/test_preprocessing.py
+++ b/gtda/time_series/tests/test_preprocessing.py
@@ -49,7 +49,7 @@ def test_resampler_transform(period, expected):
                           (4, signal_resampled_4)])
 def test_resampler_resample(period, expected):
     resampler = Resampler(period=period)
-    _ = resampler.fit_transform(signal_array)
+    resampler.fit(signal_array)
     assert_almost_equal(resampler.resample(signal_array), expected)
 
 
@@ -125,5 +125,5 @@ def test_stationarizer_transform(operation, expected):
 def test_stationarizer_resample(operation, expected):
     stationarizer = Stationarizer(operation=operation)
     signal_1d = signal.reshape(-1)
-    _ = stationarizer.fit_transform(signal_1d)
+    stationarizer.fit(signal_1d)
     assert_almost_equal(stationarizer.resample(signal_1d), signal_1d[1:])

--- a/gtda/time_series/tests/test_target.py
+++ b/gtda/time_series/tests/test_target.py
@@ -8,39 +8,41 @@ import pytest
 from gtda.time_series.target import Labeller
 
 signal = np.asarray([np.sin(x / 2) + 2 for x in range(0, 20)])
-X = np.tile(np.arange(10), reps=(2)).reshape(-1,1)
+X = np.tile(np.arange(10), reps=2).reshape(-1, 1)
 
 
 def test_labeller_shape():
     width = 3
-    l = Labeller(width=width, func=np.std, func_params={}, percentiles=None, n_steps_future=1)
-    signal_transformed = l.fit_transform(signal)
+    labeller = Labeller(width=width, func=np.std, func_params={}, percentiles=None, n_steps_future=1)
+    signal_transformed = labeller.fit_transform(signal)
     assert signal_transformed.shape == (20-(width+1)+1, 1)
 
 
 def test_labeller_transformed():
     width = 5
     n_steps_future=1
-    l = Labeller(width=width, func=np.max, func_params={}, percentiles=None, n_steps_future=n_steps_future)
-    x,y = l.fit_transform_resample(X,X)
-    assert_almost_equal(x,  X[(width-1):-(n_steps_future)])
+    labeller = Labeller(width=width, func=np.max, func_params={}, percentiles=None, n_steps_future=n_steps_future)
+    x, y = labeller.fit_transform_resample(X,X)
+    assert_almost_equal(x,  X[(width-1):-n_steps_future])
 
 
 def test_labeller_resampled():
     width = 5
     n_steps_future=1
-    l = Labeller(width=width, func=np.max, func_params={}, percentiles=None, n_steps_future=n_steps_future)
-    x,y = l.fit_transform_resample(X,X)
+    labeller = Labeller(width=width, func=np.max, func_params={}, percentiles=None, n_steps_future=n_steps_future)
+    x,y = labeller.fit_transform_resample(X,X)
     assert_almost_equal(y,  np.array([5, 6, 7, 8, 9, 9, 9, 9, 9, 9, 5, 6, 7, 8, 9]))
+
 
 def test_labeller_with_percentage():
     width = 5
     n_steps_future=1
-    l = Labeller(width=width, func=np.max, func_params={}, percentiles=[100], n_steps_future=n_steps_future)
-    _ = l.fit_transform_resample(X,X)
-    assert np.max(X) == l.thresholds_[0]
+    labeller = Labeller(width=width, func=np.max, func_params={}, percentiles=[100], n_steps_future=n_steps_future)
+    _ = labeller.fit_transform_resample(X,X)
+    assert np.max(X) == labeller.thresholds_[0]
+
 
 def test_labeller_invalid_percentage():
-    l = Labeller(width=5, func=np.max, func_params={}, percentiles=[101], n_steps_future=2)
+    labeller = Labeller(width=5, func=np.max, func_params={}, percentiles=[101], n_steps_future=2)
     with pytest.raises(ValueError):
-        l.fit_transform_resample([],[])
+        labeller.fit_transform_resample([], [])

--- a/gtda/time_series/tests/test_target.py
+++ b/gtda/time_series/tests/test_target.py
@@ -13,36 +13,42 @@ X = np.tile(np.arange(10), reps=2).reshape(-1, 1)
 
 def test_labeller_shape():
     width = 3
-    labeller = Labeller(width=width, func=np.std, func_params={}, percentiles=None, n_steps_future=1)
+    labeller = Labeller(width=width, func=np.std, func_params={},
+                        percentiles=None, n_steps_future=1)
     signal_transformed = labeller.fit_transform(signal)
     assert signal_transformed.shape == (20-(width+1)+1, 1)
 
 
 def test_labeller_transformed():
     width = 5
-    n_steps_future=1
-    labeller = Labeller(width=width, func=np.max, func_params={}, percentiles=None, n_steps_future=n_steps_future)
-    x, y = labeller.fit_transform_resample(X,X)
+    n_steps_future = 1
+    labeller = Labeller(width=width, func=np.max, func_params={},
+                        percentiles=None, n_steps_future=n_steps_future)
+    x, y = labeller.fit_transform_resample(X, X)
     assert_almost_equal(x,  X[(width-1):-n_steps_future])
 
 
 def test_labeller_resampled():
     width = 5
-    n_steps_future=1
-    labeller = Labeller(width=width, func=np.max, func_params={}, percentiles=None, n_steps_future=n_steps_future)
-    x,y = labeller.fit_transform_resample(X,X)
-    assert_almost_equal(y,  np.array([5, 6, 7, 8, 9, 9, 9, 9, 9, 9, 5, 6, 7, 8, 9]))
+    n_steps_future = 1
+    labeller = Labeller(width=width, func=np.max, func_params={},
+                        percentiles=None, n_steps_future=n_steps_future)
+    x, y = labeller.fit_transform_resample(X, X)
+    assert_almost_equal(y,  np.array([5, 6, 7, 8, 9, 9, 9,
+                                      9, 9, 9, 5, 6, 7, 8, 9]))
 
 
 def test_labeller_with_percentage():
     width = 5
-    n_steps_future=1
-    labeller = Labeller(width=width, func=np.max, func_params={}, percentiles=[100], n_steps_future=n_steps_future)
-    _ = labeller.fit_transform_resample(X,X)
+    n_steps_future = 1
+    labeller = Labeller(width=width, func=np.max, func_params={},
+                        percentiles=[100], n_steps_future=n_steps_future)
+    _ = labeller.fit_transform_resample(X, X)
     assert np.max(X) == labeller.thresholds_[0]
 
 
 def test_labeller_invalid_percentage():
-    labeller = Labeller(width=5, func=np.max, func_params={}, percentiles=[101], n_steps_future=2)
+    labeller = Labeller(width=5, func=np.max, func_params={},
+                        percentiles=[101], n_steps_future=2)
     with pytest.raises(ValueError):
         labeller.fit_transform_resample([], [])

--- a/gtda/time_series/tests/test_target.py
+++ b/gtda/time_series/tests/test_target.py
@@ -1,0 +1,46 @@
+"""Testing for time series labelling."""
+# License: GNU AGPLv3
+
+import numpy as np
+from numpy.testing import assert_almost_equal
+import pytest
+
+from gtda.time_series.target import Labeller
+
+signal = np.asarray([np.sin(x / 2) + 2 for x in range(0, 20)])
+X = np.tile(np.arange(10), reps=(2)).reshape(-1,1)
+
+
+def test_labeller_shape():
+    width = 3
+    l = Labeller(width=width, func=np.std, func_params={}, percentiles=None, n_steps_future=1)
+    signal_transformed = l.fit_transform(signal)
+    assert signal_transformed.shape == (20-(width+1)+1, 1)
+
+
+def test_labeller_transformed():
+    width = 5
+    n_steps_future=1
+    l = Labeller(width=width, func=np.max, func_params={}, percentiles=None, n_steps_future=n_steps_future)
+    x,y = l.fit_transform_resample(X,X)
+    assert_almost_equal(x,  X[(width-1):-(n_steps_future)])
+
+
+def test_labeller_resampled():
+    width = 5
+    n_steps_future=1
+    l = Labeller(width=width, func=np.max, func_params={}, percentiles=None, n_steps_future=n_steps_future)
+    x,y = l.fit_transform_resample(X,X)
+    assert_almost_equal(y,  np.array([5, 6, 7, 8, 9, 9, 9, 9, 9, 9, 5, 6, 7, 8, 9]))
+
+def test_labeller_with_percentage():
+    width = 5
+    n_steps_future=1
+    l = Labeller(width=width, func=np.max, func_params={}, percentiles=[100], n_steps_future=n_steps_future)
+    _ = l.fit_transform_resample(X,X)
+    assert np.max(X) == l.thresholds_[0]
+
+def test_labeller_invalid_percentage():
+    l = Labeller(width=5, func=np.max, func_params={}, percentiles=[101], n_steps_future=2)
+    with pytest.raises(ValueError):
+        l.fit_transform_resample([],[])

--- a/gtda/time_series/tests/test_target.py
+++ b/gtda/time_series/tests/test_target.py
@@ -43,7 +43,7 @@ def test_labeller_with_percentage():
     n_steps_future = 1
     labeller = Labeller(width=width, func=np.max, func_params={},
                         percentiles=[100], n_steps_future=n_steps_future)
-    _ = labeller.fit_transform_resample(X, X)
+    labeller.fit(X)
     assert np.max(X) == labeller.thresholds_[0]
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/giotto-ai/giotto-tda/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #184, #183., #221.
Contains changes from #222.

#### What does this implement/fix? Explain your changes.
Increases overall coverage for `gtda.time_series`, by testing `preprocessing`, `features`, `target`, `embedding`.
Correct the parameters for percentile in hyperparameters of Labeller.

#### Other comments
The tests are manual/example-based, since I was unable to find nice invariants for `hypothesis`, without replicating the logic of these transformers.
A step forward towards #221, but it does not fix the `validate_params`issue.