### PR TITLE
Abandon direct reference specifications approach to installing the python-igraph dependency on Windows

### DIFF
--- a/.azure-ci/python-igraph_dependencies_win.py
+++ b/.azure-ci/python-igraph_dependencies_win.py
@@ -16,9 +16,9 @@ def whl_urls(python_ver, pkg):
         '0.7.1.post6-cp{}-cp{}-win_amd64.whl'.\
         format(python_ver, python_ver_1)
     if pkg == 'pycairo':
-        return pycairo_whl_url
+        print(pycairo_whl_url)
     elif pkg == 'python-igraph':
-        return igraph_whl_url
+        print(igraph_whl_url)
     else:
         raise ValueError("Second argument must be either 'pycairo' or "
                          "python-igraph")

--- a/.azure-ci/python-igraph_dependencies_win.py
+++ b/.azure-ci/python-igraph_dependencies_win.py
@@ -1,7 +1,7 @@
 import sys
 
 
-def pycairo_igraph_whl_urls(python_ver):
+def whl_urls(python_ver, pkg):
     if python_ver == '38':
         python_ver_1 = python_ver
     else:
@@ -15,8 +15,14 @@ def pycairo_igraph_whl_urls(python_ver):
         '-learn/windows-binaries/python-igraph/python_igraph-' \
         '0.7.1.post6-cp{}-cp{}-win_amd64.whl'.\
         format(python_ver, python_ver_1)
-    return pycairo_whl_url + ' ' + igraph_whl_url
+    if pkg == 'pycairo':
+        return pycairo_whl_url
+    elif pkg == 'python-igraph':
+        return igraph_whl_url
+    else:
+        raise ValueError("Second argument must be either 'pycairo' or "
+                         "python-igraph")
 
 
 if __name__ == '__main__':
-    pycairo_igraph_whl_urls(sys.argv[1])
+    whl_urls(sys.argv[1], sys.argv[2])

--- a/.azure-ci/python-igraph_dependencies_win.py
+++ b/.azure-ci/python-igraph_dependencies_win.py
@@ -1,0 +1,22 @@
+import sys
+
+
+def pycairo_igraph_whl_urls(python_ver):
+    if python_ver == '38':
+        python_ver_1 = python_ver
+    else:
+        python_ver_1 = python_ver + 'm'
+    pycairo_whl_url = \
+        'https://storage.googleapis.com/l2f-open-models/giotto' \
+        '-learn/windows-binaries/pycairo/pycairo-1.18.2-cp{}' \
+        '-cp{}-win_amd64.whl'.format(python_ver, python_ver_1)
+    igraph_whl_url = \
+        'https://storage.googleapis.com/l2f-open-models/giotto' \
+        '-learn/windows-binaries/python-igraph/python_igraph-' \
+        '0.7.1.post6-cp{}-cp{}-win_amd64.whl'.\
+        format(python_ver, python_ver_1)
+    return pycairo_whl_url + ' ' + igraph_whl_url
+
+
+if __name__ == '__main__':
+    pycairo_igraph_whl_urls(sys.argv[1])

--- a/README.rst
+++ b/README.rst
@@ -74,21 +74,41 @@ To run the examples, jupyter is required.
 User installation
 ~~~~~~~~~~~~~~~~~
 
+Linux and macOS
+'''''''''''''''
 The simplest way to install giotto-tda is using ``pip``   ::
 
     pip install -U giotto-tda
 
-Note: the above may fail on old versions of ``pip``. We recommend upgrading ``pip``
-to a recent version.
+If necessary, this will also automatically install all the above dependencies. Note: we recommend
+upgrading ``pip`` to a recent version as the above may fail on very old versions.
 
 Pre-release, experimental builds containing recently added features, and/or
 bug fixes can be installed by running   ::
 
     pip install -U giotto-tda-nightly
 
-The main difference between ``giotto-tda-nightly`` and the developer
-installation (see below) is that the former is shipped with pre-compiled wheels
-(similarly to the stable release) and hence does not require any C++ dependencies.
+The main difference between giotto-tda-nightly and the developer installation (see below)
+is that the former is shipped with pre-compiled wheels (similarly to the stable release)
+and hence does not require any C++ dependencies.
+
+Windows
+'''''''
+In this case, python-igraph and its dependency pycairo must be manually installed before
+proceeding as above. This is because the python-igraph project does not yet provide official
+installers for Windows via PyPI, so that ``pip install python-igraph`` would fail there.
+The preferred way to install python-igraph on Windows is to download and install the relevant
+wheels built by Christoph Gohlke for both `pycairo <https://www.lfd.uci.edu/~gohlke/pythonlibs/#pycairo>`_
+and `python-igraph <https://www.lfd.uci.edu/~gohlke/pythonlibs/#python-igraph>`_. We
+host these wheels so they can be fetched with convenient URLs. For Python 3.5 to 3.7, you may run   ::
+
+    pip install https://storage.googleapis.com/l2f-open-models/giotto-learn/windows-binaries/pycairo/pycairo-1.18.2-cp<PYTHON VERSION>-cp<PYTHON VERSION>m-win_amd64.whl
+    pip install https://storage.googleapis.com/l2f-open-models/giotto-learn/windows-binaries/python-igraph/python_igraph-0.7.1.post6-cp<PYTHON VERSION>-cp<PYTHON VERSION>m-win_amd64.whl
+
+where ``<PYTHON VERSION>`` is e.g. ``37`` for Python 3.7. For Python 3.8, you may run   ::
+
+    pip install https://storage.googleapis.com/l2f-open-models/giotto-learn/windows-binaries/pycairo/pycairo-1.18.2-cp<PYTHON VERSION>-cp<PYTHON VERSION>-win_amd64.whl
+    pip install https://storage.googleapis.com/l2f-open-models/giotto-learn/windows-binaries/python-igraph/python_igraph-0.7.1.post6-cp<PYTHON VERSION>-cp<PYTHON VERSION>-win_amd64.whl
 
 Contributing
 ------------

--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,8 @@ Developer installation
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Installing both the PyPI release and source of giotto-tda in the same environment is not recommended since it is
-known to cause conflicts with the C++ bindings.
+known to cause conflicts with the C++ bindings. On  Windows, the pycairo and python-igraph dependencies have to be
+installed manually just as in the case of a simple user installation.
 
 The developer installation requires three important C++ dependencies:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -343,7 +343,7 @@ jobs:
     displayName: 'Install tools'
 
   - bash: |
-      igraphDependencies=`python .azure-ci\python-igraph_dependencies_win.py python_ver`
+      igraphDependencies=`python .azure-ci/python-igraph_dependencies_win.py python_ver`
       pip install $igraphDepencencies
     displayName: 'Install pycairo and python-igraph'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,7 +108,13 @@ jobs:
       pip install wheel twine
     displayName: 'Install tools'
 
-  - script: pip install -e ".[tests, doc]"
+  - bash: |
+      igraphDependencies=`python .azure-ci\python-igraph_dependencies_win.py python_ver`
+      pip install $igraphDepencencies
+    displayName: 'Install pycairo and python-igraph'
+
+  - script: |
+      pip install -e ".[tests, doc]"
     displayName: 'Install dev environment'
 
   - script: |
@@ -118,7 +124,8 @@ jobs:
       flake8
     displayName: 'Test with pytest, nbconvert and flake8'
 
-# these jobs are triggered manually and they test the code and the examples and build the wheels and docs.
+
+# These jobs are triggered manually and they test the code and the examples and build the wheels and docs.
 
 - job: 'manylinux2010'
   condition: eq(variables['build_check'], 'true')
@@ -157,7 +164,7 @@ jobs:
       sed -i "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
       cat gtda/_version.py
     condition: eq(variables['nightly_check'], 'true')
-    displayName: 'change name to giotto-tda-nightly'
+    displayName: 'Change name to giotto-tda-nightly'
 
   - task: Bash@3
     inputs:
@@ -179,13 +186,13 @@ jobs:
     displayName: 'Install and test the wheels'
 
   - task: CopyFiles@2
-    displayName: 'copy files'
+    displayName: 'Copy files'
     inputs:
       contents: 'dist/*'
       targetFolder: '$(Build.ArtifactStagingDirectory)'
 
   - task: PublishBuildArtifacts@1
-    displayName: 'create download link'
+    displayName: 'Create download link'
     inputs:
       pathToPublish: '$(Build.ArtifactStagingDirectory)'
       artifactName: 'wheel_and_doc'
@@ -225,13 +232,13 @@ jobs:
       cat gtda/_version.py
       rm gtda/_version.py.bak
     condition: eq(variables['nightly_check'], 'true')
-    displayName: 'change name to giotto-tda-nightly'
+    displayName: 'Change name to giotto-tda-nightly'
 
   - script: |
       brew update
       brew install boost
       brew install gcc
-    displayName: 'install boost and gcc'
+    displayName: 'Install boost and gcc'
 
   - script: python -m pip install --upgrade pip setuptools
     displayName: 'Install tools'
@@ -260,13 +267,13 @@ jobs:
     displayName: 'Test with pytest, nbconvert and flake8'
 
   - script: python setup.py sdist bdist_wheel
-    displayName: 'build the wheels'
+    displayName: 'Build the wheels'
 
   - script: |
       pip install dist/*.whl
       cd /tmp/
       pytest --cov --pyargs gtda --cov-report xml --ignore-glob='*externals*'
-    displayName: 'install and test the wheels'
+    displayName: 'Install and test the wheels'
 
   - script: |
       cd doc/
@@ -282,16 +289,16 @@ jobs:
       tarCompression: 'gz'
       archiveFile: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
       replaceExistingArchive: true
-    displayName: 'archive doc'
+    displayName: 'Archive doc'
 
   - task: CopyFiles@2
-    displayName: 'copy files'
+    displayName: 'Copy files'
     inputs:
       contents: 'dist/*'
       targetFolder: '$(Build.ArtifactStagingDirectory)'
 
   - task: PublishBuildArtifacts@1
-    displayName: 'create download link'
+    displayName: 'Create download link'
     inputs:
       pathToPublish: '$(Build.ArtifactStagingDirectory)'
       artifactName: 'wheel_and_doc'
@@ -330,10 +337,15 @@ jobs:
       sed -i "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
       cat gtda/_version.py
     condition: eq(variables['nightly_check'], 'true')
-    displayName: 'change name to giotto-tda-nightly'
+    displayName: 'Change name to giotto-tda-nightly'
 
   - script: python -m pip install --upgrade pip setuptools
     displayName: 'Install tools'
+
+  - bash: |
+      igraphDependencies=`python .azure-ci\python-igraph_dependencies_win.py python_ver`
+      pip install $igraphDepencencies
+    displayName: 'Install pycairo and python-igraph'
 
   - script: |
       pip install -e ".[tests, doc]"
@@ -361,22 +373,22 @@ jobs:
   - bash: |
       sed -i $'s/\r$//' README.rst
       python setup.py sdist bdist_wheel
-    displayName: 'build the wheels'
+    displayName: 'Build the wheels'
 
   - bash: |
       pip install dist/*.whl
       cd /tmp/
       pytest --cov --pyargs gtda --cov-report xml --ignore-glob='*externals*'
-    displayName: 'install and test the wheels'
+    displayName: 'Install and test the wheels'
 
   - task: CopyFiles@2
-    displayName: 'copy files'
+    displayName: 'Copy files'
     inputs:
       contents: 'dist/*'
       targetFolder: '$(Build.ArtifactStagingDirectory)'
 
   - task: PublishBuildArtifacts@1
-    displayName: 'create download link'
+    displayName: 'Create download link'
     inputs:
       pathToPublish: '$(Build.ArtifactStagingDirectory)'
       artifactName: 'wheel_and_doc'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,7 +110,7 @@ jobs:
 
   - bash: |
       pycairo_url=`python .azure-ci/python-igraph_dependencies_win.py python_ver "pycairo"`
-      python-igraph_url=`python .azure-ci/python-igraph_dependencies_win.py python_ver "python-igraph"`
+      igraph_url=`python .azure-ci/python-igraph_dependencies_win.py python_ver "python-igraph"`
       pip install $pycairo_url $igraph_url
     displayName: 'Install pycairo and python-igraph'
 
@@ -345,7 +345,7 @@ jobs:
 
   - bash: |
       pycairo_url=`python .azure-ci/python-igraph_dependencies_win.py python_ver "pycairo"`
-      python-igraph_url=`python .azure-ci/python-igraph_dependencies_win.py python_ver "python-igraph"`
+      igraph_url=`python .azure-ci/python-igraph_dependencies_win.py python_ver "python-igraph"`
       pip install $pycairo_url $igraph_url
     displayName: 'Install pycairo and python-igraph'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -344,8 +344,8 @@ jobs:
     displayName: 'Install tools'
 
   - bash: |
-      pycairo_url=$(python .azure-ci/python-igraph_dependencies_win.py $python_ver 'pycairo')
-      igraph_url=$(python .azure-ci/python-igraph_dependencies_win.py $python_ver 'python-igraph')
+      pycairo_url=$(python .azure-ci/python-igraph_dependencies_win.py '$(python_ver)' 'pycairo')
+      igraph_url=$(python .azure-ci/python-igraph_dependencies_win.py '$(python_ver)' 'python-igraph')
       pip install "$pycairo_url" "$igraph_url"
     displayName: 'Install pycairo and python-igraph'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,8 +109,9 @@ jobs:
     displayName: 'Install tools'
 
   - bash: |
-      igraphDependencies=`python .azure-ci\python-igraph_dependencies_win.py python_ver`
-      pip install $igraphDepencencies
+      pycairo_url=`python .azure-ci/python-igraph_dependencies_win.py python_ver "pycairo"`
+      python-igraph_url=`python .azure-ci/python-igraph_dependencies_win.py python_ver "python-igraph"`
+      pip install $pycairo_url $igraph_url
     displayName: 'Install pycairo and python-igraph'
 
   - script: |
@@ -343,8 +344,9 @@ jobs:
     displayName: 'Install tools'
 
   - bash: |
-      igraphDependencies=`python .azure-ci/python-igraph_dependencies_win.py python_ver`
-      pip install $igraphDepencencies
+      pycairo_url=`python .azure-ci/python-igraph_dependencies_win.py python_ver "pycairo"`
+      python-igraph_url=`python .azure-ci/python-igraph_dependencies_win.py python_ver "python-igraph"`
+      pip install $pycairo_url $igraph_url
     displayName: 'Install pycairo and python-igraph'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -334,7 +334,7 @@ jobs:
       versionSpec: '$(python.version)'
 
   - bash: |
-      sed -i "s/'giotto-tda'/'giotto-tda'/1" setup.py
+      sed -i "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
       sed -i "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
       cat gtda/_version.py
     condition: eq(variables['nightly_check'], 'true')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,8 +109,8 @@ jobs:
     displayName: 'Install tools'
 
   - bash: |
-      pycairo_url=$(python .azure-ci/python-igraph_dependencies_win.py $python_ver 'pycairo')
-      igraph_url=$(python .azure-ci/python-igraph_dependencies_win.py $python_ver 'python-igraph')
+      pycairo_url=$(python .azure-ci/python-igraph_dependencies_win.py '$(python_ver)' 'pycairo')
+      igraph_url=$(python .azure-ci/python-igraph_dependencies_win.py '$(python_ver)' 'python-igraph')
       pip install "$pycairo_url" "$igraph_url"
     displayName: 'Install pycairo and python-igraph'
 
@@ -128,185 +128,185 @@ jobs:
 
 # These jobs are triggered manually and they test the code and the examples and build the wheels and docs.
 
-#- job: 'manylinux2010'
-#  condition: eq(variables['build_check'], 'true')
-#  pool:
-#    vmImage: 'ubuntu-16.04'
-#  strategy:
-#    matrix:
-#      Python35:
-#        arch: x86_64
-#        plat: manylinux2010_x86_64
-#        python_ver: '35'
-#        python.version: '3.5'
-#      Python36:
-#        arch: x86_64
-#        plat: manylinux2010_x86_64
-#        python_ver: '36'
-#        python.version: '3.6'
-#      Python37:
-#        arch: x86_64
-#        plat: manylinux2010_x86_64
-#        python_ver: '37'
-#        python.version: '3.7'
-#      Python38:
-#        arch: x86_64
-#        plat: manylinux2010_x86_64
-#        python_ver: '38'
-#        python.version: '3.8'
-#
-#  steps:
-#  - task: UsePythonVersion@0
-#    inputs:
-#      versionSpec: '$(python.version)'
-#
-#  - bash: |
-#      sed -i "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
-#      sed -i "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
-#      cat gtda/_version.py
-#    condition: eq(variables['nightly_check'], 'true')
-#    displayName: 'Change name to giotto-tda-nightly'
-#
-#  - task: Bash@3
-#    inputs:
-#      filePath: .azure-ci/build_manylinux2010.sh
-#      failOnStderr: false
-#    env:
-#      python_ver: $(python_ver)
-#    displayName: 'Run the docker and open bash'
-#
-#  - script: |
-#      python -m pip install --upgrade pip
-#      pip install pytest pytest-cov pytest-azurepipelines pytest-benchmark flake8 hypothesis
-#    displayName: 'Install pytest suite'
-#
-#  - script: |
-#      pip install dist/*.whl
-#      cd /tmp/
-#      pytest --cov --pyargs gtda --cov-report xml --ignore-glob='*externals*'
-#    displayName: 'Install and test the wheels'
-#
-#  - task: CopyFiles@2
-#    displayName: 'Copy files'
-#    inputs:
-#      contents: 'dist/*'
-#      targetFolder: '$(Build.ArtifactStagingDirectory)'
-#
-#  - task: PublishBuildArtifacts@1
-#    displayName: 'Create download link'
-#    inputs:
-#      pathToPublish: '$(Build.ArtifactStagingDirectory)'
-#      artifactName: 'wheel_and_doc'
-#
-#  - bash: |
-#      pip install twine
-#      for f in dist/*linux* ; do sudo mv "$f" "${f/linux/manylinux2010}"; done
-#      twine upload -u giotto-tda -p $(pypi_psw) --skip-existing dist/*
-#    condition: eq(variables['nightly_check'], 'true')
-#    displayName: 'Upload wheels to PyPI'
-#
-#
-#- job: 'macOS1014'
-#  condition: eq(variables['build_check'], 'true')
-#  pool:
-#    vmImage: 'macOS-10.14'
-#  strategy:
-#    matrix:
-#      Python35:
-#        python.version: '3.5'
-#      Python36:
-#        python.version: '3.6'
-#      Python37:
-#        python.version: '3.7'
-#      Python38:
-#        python.version: '3.8'
-#
-#  steps:
-#  - task: UsePythonVersion@0
-#    inputs:
-#      versionSpec: '$(python.version)'
-#
-#  - bash: |
-#      sed -i.bak "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
-#      rm setup.py.bak
-#      sed -i.bak "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
-#      cat gtda/_version.py
-#      rm gtda/_version.py.bak
-#    condition: eq(variables['nightly_check'], 'true')
-#    displayName: 'Change name to giotto-tda-nightly'
-#
-#  - script: |
-#      brew update
-#      brew install boost
-#      brew install gcc
-#    displayName: 'Install boost and gcc'
-#
-#  - script: python -m pip install --upgrade pip setuptools
-#    displayName: 'Install tools'
-#
-#  - script: |
-#      pip install -e ".[tests, doc]"
-#      pip install wheel twine
-#    displayName: 'Install dev environment'
-#
-#  - script: |
-#      pip install openml
-#      jupyter nbconvert --to notebook --execute examples/*.ipynb
-#      pip uninstall -y giotto-tda
-#      pytest --cov gtda --cov-report xml
-#      flake8
-#    condition: eq(variables['nightly_check'], 'false')
-#    displayName: 'Test with pytest, nbconvert and flake8'
-#
-#  - script: |
-#      pip install openml
-#      jupyter nbconvert --to notebook --execute examples/*.ipynb
-#      pip uninstall -y giotto-tda-nightly
-#      pytest --cov gtda --cov-report xml
-#      flake8
-#    condition: eq(variables['nightly_check'], 'true')
-#    displayName: 'Test with pytest, nbconvert and flake8'
-#
-#  - script: python setup.py sdist bdist_wheel
-#    displayName: 'Build the wheels'
-#
-#  - script: |
-#      pip install dist/*.whl
-#      cd /tmp/
-#      pytest --cov --pyargs gtda --cov-report xml --ignore-glob='*externals*'
-#    displayName: 'Install and test the wheels'
-#
-#  - script: |
-#      cd doc/
-#      make html
-#      cd ..
-#    displayName: 'Build sphinx doc'
-#
-#  - task: ArchiveFiles@2
-#    inputs:
-#      rootFolderOrFile: doc/build
-#      includeRootFolder: true
-#      archiveType: 'zip'
-#      tarCompression: 'gz'
-#      archiveFile: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
-#      replaceExistingArchive: true
-#    displayName: 'Archive doc'
-#
-#  - task: CopyFiles@2
-#    displayName: 'Copy files'
-#    inputs:
-#      contents: 'dist/*'
-#      targetFolder: '$(Build.ArtifactStagingDirectory)'
-#
-#  - task: PublishBuildArtifacts@1
-#    displayName: 'Create download link'
-#    inputs:
-#      pathToPublish: '$(Build.ArtifactStagingDirectory)'
-#      artifactName: 'wheel_and_doc'
-#
-#  - bash: twine upload -u giotto-tda -p $(pypi_psw) --skip-existing dist/*
-#    condition: eq(variables['nightly_check'], 'true')
-#    displayName: 'Upload wheels to PyPI'
+- job: 'manylinux2010'
+  condition: eq(variables['build_check'], 'true')
+  pool:
+    vmImage: 'ubuntu-16.04'
+  strategy:
+    matrix:
+      Python35:
+        arch: x86_64
+        plat: manylinux2010_x86_64
+        python_ver: '35'
+        python.version: '3.5'
+      Python36:
+        arch: x86_64
+        plat: manylinux2010_x86_64
+        python_ver: '36'
+        python.version: '3.6'
+      Python37:
+        arch: x86_64
+        plat: manylinux2010_x86_64
+        python_ver: '37'
+        python.version: '3.7'
+      Python38:
+        arch: x86_64
+        plat: manylinux2010_x86_64
+        python_ver: '38'
+        python.version: '3.8'
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+
+  - bash: |
+      sed -i "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
+      sed -i "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
+      cat gtda/_version.py
+    condition: eq(variables['nightly_check'], 'true')
+    displayName: 'Change name to giotto-tda-nightly'
+
+  - task: Bash@3
+    inputs:
+      filePath: .azure-ci/build_manylinux2010.sh
+      failOnStderr: false
+    env:
+      python_ver: $(python_ver)
+    displayName: 'Run the docker and open bash'
+
+  - script: |
+      python -m pip install --upgrade pip
+      pip install pytest pytest-cov pytest-azurepipelines pytest-benchmark flake8 hypothesis
+    displayName: 'Install pytest suite'
+
+  - script: |
+      pip install dist/*.whl
+      cd /tmp/
+      pytest --cov --pyargs gtda --cov-report xml --ignore-glob='*externals*'
+    displayName: 'Install and test the wheels'
+
+  - task: CopyFiles@2
+    displayName: 'Copy files'
+    inputs:
+      contents: 'dist/*'
+      targetFolder: '$(Build.ArtifactStagingDirectory)'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Create download link'
+    inputs:
+      pathToPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: 'wheel_and_doc'
+
+  - bash: |
+      pip install twine
+      for f in dist/*linux* ; do sudo mv "$f" "${f/linux/manylinux2010}"; done
+      twine upload -u giotto-tda -p $(pypi_psw) --skip-existing dist/*
+    condition: eq(variables['nightly_check'], 'true')
+    displayName: 'Upload wheels to PyPI'
+
+
+- job: 'macOS1014'
+  condition: eq(variables['build_check'], 'true')
+  pool:
+    vmImage: 'macOS-10.14'
+  strategy:
+    matrix:
+      Python35:
+        python.version: '3.5'
+      Python36:
+        python.version: '3.6'
+      Python37:
+        python.version: '3.7'
+      Python38:
+        python.version: '3.8'
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+
+  - bash: |
+      sed -i.bak "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
+      rm setup.py.bak
+      sed -i.bak "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
+      cat gtda/_version.py
+      rm gtda/_version.py.bak
+    condition: eq(variables['nightly_check'], 'true')
+    displayName: 'Change name to giotto-tda-nightly'
+
+  - script: |
+      brew update
+      brew install boost
+      brew install gcc
+    displayName: 'Install boost and gcc'
+
+  - script: python -m pip install --upgrade pip setuptools
+    displayName: 'Install tools'
+
+  - script: |
+      pip install -e ".[tests, doc]"
+      pip install wheel twine
+    displayName: 'Install dev environment'
+
+  - script: |
+      pip install openml
+      jupyter nbconvert --to notebook --execute examples/*.ipynb
+      pip uninstall -y giotto-tda
+      pytest --cov gtda --cov-report xml
+      flake8
+    condition: eq(variables['nightly_check'], 'false')
+    displayName: 'Test with pytest, nbconvert and flake8'
+
+  - script: |
+      pip install openml
+      jupyter nbconvert --to notebook --execute examples/*.ipynb
+      pip uninstall -y giotto-tda-nightly
+      pytest --cov gtda --cov-report xml
+      flake8
+    condition: eq(variables['nightly_check'], 'true')
+    displayName: 'Test with pytest, nbconvert and flake8'
+
+  - script: python setup.py sdist bdist_wheel
+    displayName: 'Build the wheels'
+
+  - script: |
+      pip install dist/*.whl
+      cd /tmp/
+      pytest --cov --pyargs gtda --cov-report xml --ignore-glob='*externals*'
+    displayName: 'Install and test the wheels'
+
+  - script: |
+      cd doc/
+      make html
+      cd ..
+    displayName: 'Build sphinx doc'
+
+  - task: ArchiveFiles@2
+    inputs:
+      rootFolderOrFile: doc/build
+      includeRootFolder: true
+      archiveType: 'zip'
+      tarCompression: 'gz'
+      archiveFile: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
+      replaceExistingArchive: true
+    displayName: 'Archive doc'
+
+  - task: CopyFiles@2
+    displayName: 'Copy files'
+    inputs:
+      contents: 'dist/*'
+      targetFolder: '$(Build.ArtifactStagingDirectory)'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Create download link'
+    inputs:
+      pathToPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: 'wheel_and_doc'
+
+  - bash: twine upload -u giotto-tda -p $(pypi_psw) --skip-existing dist/*
+    condition: eq(variables['nightly_check'], 'true')
+    displayName: 'Upload wheels to PyPI'
 
 
 - job: 'win2016'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,8 +109,8 @@ jobs:
     displayName: 'Install tools'
 
   - bash: |
-      pycairo_url=$(python .azure-ci/python-igraph_dependencies_win.py python_ver 'pycairo')
-      igraph_url=$(python .azure-ci/python-igraph_dependencies_win.py python_ver 'python-igraph')
+      pycairo_url=$(python .azure-ci/python-igraph_dependencies_win.py $python_ver 'pycairo')
+      igraph_url=$(python .azure-ci/python-igraph_dependencies_win.py $python_ver 'python-igraph')
       pip install "$pycairo_url" "$igraph_url"
     displayName: 'Install pycairo and python-igraph'
 
@@ -128,185 +128,185 @@ jobs:
 
 # These jobs are triggered manually and they test the code and the examples and build the wheels and docs.
 
-- job: 'manylinux2010'
-  condition: eq(variables['build_check'], 'true')
-  pool:
-    vmImage: 'ubuntu-16.04'
-  strategy:
-    matrix:
-      Python35:
-        arch: x86_64
-        plat: manylinux2010_x86_64
-        python_ver: '35'
-        python.version: '3.5'
-      Python36:
-        arch: x86_64
-        plat: manylinux2010_x86_64
-        python_ver: '36'
-        python.version: '3.6'
-      Python37:
-        arch: x86_64
-        plat: manylinux2010_x86_64
-        python_ver: '37'
-        python.version: '3.7'
-      Python38:
-        arch: x86_64
-        plat: manylinux2010_x86_64
-        python_ver: '38'
-        python.version: '3.8'
-
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '$(python.version)'
-
-  - bash: |
-      sed -i "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
-      sed -i "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
-      cat gtda/_version.py
-    condition: eq(variables['nightly_check'], 'true')
-    displayName: 'Change name to giotto-tda-nightly'
-
-  - task: Bash@3
-    inputs:
-      filePath: .azure-ci/build_manylinux2010.sh
-      failOnStderr: false
-    env:
-      python_ver: $(python_ver)
-    displayName: 'Run the docker and open bash'
-
-  - script: |
-      python -m pip install --upgrade pip
-      pip install pytest pytest-cov pytest-azurepipelines pytest-benchmark flake8 hypothesis
-    displayName: 'Install pytest suite'
-
-  - script: |
-      pip install dist/*.whl
-      cd /tmp/
-      pytest --cov --pyargs gtda --cov-report xml --ignore-glob='*externals*'
-    displayName: 'Install and test the wheels'
-
-  - task: CopyFiles@2
-    displayName: 'Copy files'
-    inputs:
-      contents: 'dist/*'
-      targetFolder: '$(Build.ArtifactStagingDirectory)'
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Create download link'
-    inputs:
-      pathToPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: 'wheel_and_doc'
-
-  - bash: |
-      pip install twine
-      for f in dist/*linux* ; do sudo mv "$f" "${f/linux/manylinux2010}"; done
-      twine upload -u giotto-tda -p $(pypi_psw) --skip-existing dist/*
-    condition: eq(variables['nightly_check'], 'true')
-    displayName: 'Upload wheels to PyPI'
-
-
-- job: 'macOS1014'
-  condition: eq(variables['build_check'], 'true')
-  pool:
-    vmImage: 'macOS-10.14'
-  strategy:
-    matrix:
-      Python35:
-        python.version: '3.5'
-      Python36:
-        python.version: '3.6'
-      Python37:
-        python.version: '3.7'
-      Python38:
-        python.version: '3.8'
-
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '$(python.version)'
-
-  - bash: |
-      sed -i.bak "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
-      rm setup.py.bak
-      sed -i.bak "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
-      cat gtda/_version.py
-      rm gtda/_version.py.bak
-    condition: eq(variables['nightly_check'], 'true')
-    displayName: 'Change name to giotto-tda-nightly'
-
-  - script: |
-      brew update
-      brew install boost
-      brew install gcc
-    displayName: 'Install boost and gcc'
-
-  - script: python -m pip install --upgrade pip setuptools
-    displayName: 'Install tools'
-
-  - script: |
-      pip install -e ".[tests, doc]"
-      pip install wheel twine
-    displayName: 'Install dev environment'
-
-  - script: |
-      pip install openml
-      jupyter nbconvert --to notebook --execute examples/*.ipynb
-      pip uninstall -y giotto-tda
-      pytest --cov gtda --cov-report xml
-      flake8
-    condition: eq(variables['nightly_check'], 'false')
-    displayName: 'Test with pytest, nbconvert and flake8'
-
-  - script: |
-      pip install openml
-      jupyter nbconvert --to notebook --execute examples/*.ipynb
-      pip uninstall -y giotto-tda-nightly
-      pytest --cov gtda --cov-report xml
-      flake8
-    condition: eq(variables['nightly_check'], 'true')
-    displayName: 'Test with pytest, nbconvert and flake8'
-
-  - script: python setup.py sdist bdist_wheel
-    displayName: 'Build the wheels'
-
-  - script: |
-      pip install dist/*.whl
-      cd /tmp/
-      pytest --cov --pyargs gtda --cov-report xml --ignore-glob='*externals*'
-    displayName: 'Install and test the wheels'
-
-  - script: |
-      cd doc/
-      make html
-      cd ..
-    displayName: 'Build sphinx doc'
-
-  - task: ArchiveFiles@2
-    inputs:
-      rootFolderOrFile: doc/build
-      includeRootFolder: true
-      archiveType: 'zip'
-      tarCompression: 'gz'
-      archiveFile: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
-      replaceExistingArchive: true
-    displayName: 'Archive doc'
-
-  - task: CopyFiles@2
-    displayName: 'Copy files'
-    inputs:
-      contents: 'dist/*'
-      targetFolder: '$(Build.ArtifactStagingDirectory)'
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Create download link'
-    inputs:
-      pathToPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: 'wheel_and_doc'
-
-  - bash: twine upload -u giotto-tda -p $(pypi_psw) --skip-existing dist/*
-    condition: eq(variables['nightly_check'], 'true')
-    displayName: 'Upload wheels to PyPI'
+#- job: 'manylinux2010'
+#  condition: eq(variables['build_check'], 'true')
+#  pool:
+#    vmImage: 'ubuntu-16.04'
+#  strategy:
+#    matrix:
+#      Python35:
+#        arch: x86_64
+#        plat: manylinux2010_x86_64
+#        python_ver: '35'
+#        python.version: '3.5'
+#      Python36:
+#        arch: x86_64
+#        plat: manylinux2010_x86_64
+#        python_ver: '36'
+#        python.version: '3.6'
+#      Python37:
+#        arch: x86_64
+#        plat: manylinux2010_x86_64
+#        python_ver: '37'
+#        python.version: '3.7'
+#      Python38:
+#        arch: x86_64
+#        plat: manylinux2010_x86_64
+#        python_ver: '38'
+#        python.version: '3.8'
+#
+#  steps:
+#  - task: UsePythonVersion@0
+#    inputs:
+#      versionSpec: '$(python.version)'
+#
+#  - bash: |
+#      sed -i "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
+#      sed -i "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
+#      cat gtda/_version.py
+#    condition: eq(variables['nightly_check'], 'true')
+#    displayName: 'Change name to giotto-tda-nightly'
+#
+#  - task: Bash@3
+#    inputs:
+#      filePath: .azure-ci/build_manylinux2010.sh
+#      failOnStderr: false
+#    env:
+#      python_ver: $(python_ver)
+#    displayName: 'Run the docker and open bash'
+#
+#  - script: |
+#      python -m pip install --upgrade pip
+#      pip install pytest pytest-cov pytest-azurepipelines pytest-benchmark flake8 hypothesis
+#    displayName: 'Install pytest suite'
+#
+#  - script: |
+#      pip install dist/*.whl
+#      cd /tmp/
+#      pytest --cov --pyargs gtda --cov-report xml --ignore-glob='*externals*'
+#    displayName: 'Install and test the wheels'
+#
+#  - task: CopyFiles@2
+#    displayName: 'Copy files'
+#    inputs:
+#      contents: 'dist/*'
+#      targetFolder: '$(Build.ArtifactStagingDirectory)'
+#
+#  - task: PublishBuildArtifacts@1
+#    displayName: 'Create download link'
+#    inputs:
+#      pathToPublish: '$(Build.ArtifactStagingDirectory)'
+#      artifactName: 'wheel_and_doc'
+#
+#  - bash: |
+#      pip install twine
+#      for f in dist/*linux* ; do sudo mv "$f" "${f/linux/manylinux2010}"; done
+#      twine upload -u giotto-tda -p $(pypi_psw) --skip-existing dist/*
+#    condition: eq(variables['nightly_check'], 'true')
+#    displayName: 'Upload wheels to PyPI'
+#
+#
+#- job: 'macOS1014'
+#  condition: eq(variables['build_check'], 'true')
+#  pool:
+#    vmImage: 'macOS-10.14'
+#  strategy:
+#    matrix:
+#      Python35:
+#        python.version: '3.5'
+#      Python36:
+#        python.version: '3.6'
+#      Python37:
+#        python.version: '3.7'
+#      Python38:
+#        python.version: '3.8'
+#
+#  steps:
+#  - task: UsePythonVersion@0
+#    inputs:
+#      versionSpec: '$(python.version)'
+#
+#  - bash: |
+#      sed -i.bak "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
+#      rm setup.py.bak
+#      sed -i.bak "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
+#      cat gtda/_version.py
+#      rm gtda/_version.py.bak
+#    condition: eq(variables['nightly_check'], 'true')
+#    displayName: 'Change name to giotto-tda-nightly'
+#
+#  - script: |
+#      brew update
+#      brew install boost
+#      brew install gcc
+#    displayName: 'Install boost and gcc'
+#
+#  - script: python -m pip install --upgrade pip setuptools
+#    displayName: 'Install tools'
+#
+#  - script: |
+#      pip install -e ".[tests, doc]"
+#      pip install wheel twine
+#    displayName: 'Install dev environment'
+#
+#  - script: |
+#      pip install openml
+#      jupyter nbconvert --to notebook --execute examples/*.ipynb
+#      pip uninstall -y giotto-tda
+#      pytest --cov gtda --cov-report xml
+#      flake8
+#    condition: eq(variables['nightly_check'], 'false')
+#    displayName: 'Test with pytest, nbconvert and flake8'
+#
+#  - script: |
+#      pip install openml
+#      jupyter nbconvert --to notebook --execute examples/*.ipynb
+#      pip uninstall -y giotto-tda-nightly
+#      pytest --cov gtda --cov-report xml
+#      flake8
+#    condition: eq(variables['nightly_check'], 'true')
+#    displayName: 'Test with pytest, nbconvert and flake8'
+#
+#  - script: python setup.py sdist bdist_wheel
+#    displayName: 'Build the wheels'
+#
+#  - script: |
+#      pip install dist/*.whl
+#      cd /tmp/
+#      pytest --cov --pyargs gtda --cov-report xml --ignore-glob='*externals*'
+#    displayName: 'Install and test the wheels'
+#
+#  - script: |
+#      cd doc/
+#      make html
+#      cd ..
+#    displayName: 'Build sphinx doc'
+#
+#  - task: ArchiveFiles@2
+#    inputs:
+#      rootFolderOrFile: doc/build
+#      includeRootFolder: true
+#      archiveType: 'zip'
+#      tarCompression: 'gz'
+#      archiveFile: '$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip'
+#      replaceExistingArchive: true
+#    displayName: 'Archive doc'
+#
+#  - task: CopyFiles@2
+#    displayName: 'Copy files'
+#    inputs:
+#      contents: 'dist/*'
+#      targetFolder: '$(Build.ArtifactStagingDirectory)'
+#
+#  - task: PublishBuildArtifacts@1
+#    displayName: 'Create download link'
+#    inputs:
+#      pathToPublish: '$(Build.ArtifactStagingDirectory)'
+#      artifactName: 'wheel_and_doc'
+#
+#  - bash: twine upload -u giotto-tda -p $(pypi_psw) --skip-existing dist/*
+#    condition: eq(variables['nightly_check'], 'true')
+#    displayName: 'Upload wheels to PyPI'
 
 
 - job: 'win2016'
@@ -344,8 +344,8 @@ jobs:
     displayName: 'Install tools'
 
   - bash: |
-      pycairo_url=$(python .azure-ci/python-igraph_dependencies_win.py python_ver 'pycairo')
-      igraph_url=$(python .azure-ci/python-igraph_dependencies_win.py python_ver 'python-igraph')
+      pycairo_url=$(python .azure-ci/python-igraph_dependencies_win.py $python_ver 'pycairo')
+      igraph_url=$(python .azure-ci/python-igraph_dependencies_win.py $python_ver 'python-igraph')
       pip install "$pycairo_url" "$igraph_url"
     displayName: 'Install pycairo and python-igraph'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -344,9 +344,9 @@ jobs:
     displayName: 'Install tools'
 
   - bash: |
-      pycairo_url=`python .azure-ci/python-igraph_dependencies_win.py python_ver "pycairo"`
-      igraph_url=`python .azure-ci/python-igraph_dependencies_win.py python_ver "python-igraph"`
-      pip install $pycairo_url $igraph_url
+      pycairo_url=$(python .azure-ci/python-igraph_dependencies_win.py python_ver 'pycairo')
+      igraph_url=$(python .azure-ci/python-igraph_dependencies_win.py python_ver 'python-igraph')
+      pip install "$pycairo_url" "$igraph_url"
     displayName: 'Install pycairo and python-igraph'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,9 +109,9 @@ jobs:
     displayName: 'Install tools'
 
   - bash: |
-      pycairo_url=`python .azure-ci/python-igraph_dependencies_win.py python_ver "pycairo"`
-      igraph_url=`python .azure-ci/python-igraph_dependencies_win.py python_ver "python-igraph"`
-      pip install $pycairo_url $igraph_url
+      pycairo_url=$(python .azure-ci/python-igraph_dependencies_win.py python_ver 'pycairo')
+      igraph_url=$(python .azure-ci/python-igraph_dependencies_win.py python_ver 'python-igraph')
+      pip install "$pycairo_url" "$igraph_url"
     displayName: 'Install pycairo and python-igraph'
 
   - script: |

--- a/gtda/mapper/pipeline.py
+++ b/gtda/mapper/pipeline.py
@@ -155,10 +155,10 @@ def make_mapper_pipeline(scaler=None,
     steps. [1]_
 
     The role of this function's key parameters is illustrated in `this diagram
-    <https://docs-tda.giotto.ai/mapper_pipeline.svg>`_. All computational steps
-    may be arbitrary scikit-learn Pipeline objects. The scaling and cover
-    steps must be transformers implementing a ``fit_transform`` method. The
-    filter function step may be a transformer implementing a ``fit_transform``,
+    </mapper_pipeline.svg>`_. All computational steps may be arbitrary
+    scikit-learn Pipeline objects. The scaling and cover steps must be
+    transformers implementing a ``fit_transform`` method. The filter
+    function step may be a transformer implementing a ``fit_transform``,
     or a callable acting on one-dimensional arrays -- in the latter case,
     a transformer is internally created whose ``fit_transform`` applies this
     callable independently on each row of the data. The clustering step need
@@ -179,9 +179,10 @@ def make_mapper_pipeline(scaler=None,
 
     clustering_preprocessing : object or None, optional, default: ``None``
         If not ``None``, it is a transformer which is applied to the
-        data independently to the `scaler` -> `filter_func` -> cover` pipeline.
-        Clustering is then performed on portions (determined by the `scaler`
-        -> `filter_func` -> cover` pipeline) of the transformed data.
+        data independently to the `scaler` -> `filter_func` -> `cover`
+        pipeline. Clustering is then performed on portions (determined by
+        the `scaler` -> `filter_func` -> `cover` pipeline) of the
+        transformed data.
 
     clusterer : object or None, optional, default: ``None``
         Clustering object. ``None`` means using DBSCAN

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ numpy >= 1.17.0
 scipy >= 0.17.0
 joblib >= 0.11
 scikit-learn >= 0.22.0
+python-igraph >= 0.7.1.post6
 matplotlib >= 3.0.3
 plotly >= 4.4.1
 ipywidgets >= 7.5.1

--- a/setup.py
+++ b/setup.py
@@ -49,27 +49,6 @@ CLASSIFIERS = ['Intended Audience :: Science/Research',
 KEYWORDS = 'machine learning, topological data analysis, persistent ' + \
     'homology, persistence diagrams, Mapper'
 INSTALL_REQUIRES = requirements
-is_system_win = platform.system() == 'Windows'
-if is_system_win:
-    python_ver = sys.version_info
-    python_ver_1 = str(python_ver.major) + str(python_ver.minor)
-    if python_ver_1 == '38':
-        python_ver_2 = python_ver_1
-    else:
-        python_ver_2 = python_ver_1 + 'm'
-    pycairo_whl_url = \
-        'https://storage.googleapis.com/l2f-open-models/giotto' \
-        '-learn/windows-binaries/pycairo/pycairo-1.18.2-cp{}' \
-        '-cp{}-win_amd64.whl'.format(python_ver_1, python_ver_2)
-    igraph_whl_url = \
-        'https://storage.googleapis.com/l2f-open-models/giotto' \
-        '-learn/windows-binaries/python-igraph/python_igraph-' \
-        '0.7.1.post6-cp{}-cp{}-win_amd64.whl'.\
-        format(python_ver_1, python_ver_2)
-    INSTALL_REQUIRES.append('pycairo @ {}'.format(pycairo_whl_url))
-    INSTALL_REQUIRES.append('python-igraph @ {}'.format(igraph_whl_url))
-else:
-    INSTALL_REQUIRES.append('python-igraph')
 EXTRAS_REQUIRE = {
     'tests': [
         'pytest',


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
In 5025215719639db85577034a6f3aba19fe973878, a solution was introduced for having `python-igraph` and its dependency `pycairo` installed automatically on Windows despite the lack of official wheels on PyPI. The idea was to use direct reference specifications to create entries such as `pycairo @ <URL>` and to include them among the `install_requires` parameter passed to `setup` if the platform is Windows. While this worked on all our CIs and on local tests on Windows machines, uploading on PyPI yields the following error:
```
400 Client Error: Invalid value for requires_dist. Error: Can’t have direct dependency: ‘pycairo @ https://storage.googleapis.com/l2f-open-models/giotto-learn/windows-binaries/pycairo/pycairo-1.18.2-cp35-cp35m-win_amd64.whl’ for url: https://upload.pypi.org/legacy/
```
This is an open issue with `pip` and is apparently done at the moment for security reasons. But it means we can no longer adopt this approach.

- This PR simply includes `python-igraph` as a required package (added to `requirements.txt`), and does not treat Windows preferentially in `setup.py`. Instead, the `README` tells the user to manually install `pycairo` and `python-igraph` ahead of attempting a simple `pip install` of the library.

- The azure pipelines have been updated to reintroduce such a manual installation step in the case of Windows.

- Additionally, an unrelated issue was fixed in `azure-pipelines.yml`: a seemingly missed replacement from `giotto-tda` to `giotto-tda-nightly` was performed in the build jobs for Windows.

- Finally, some small errors in the `make_mapper_pipeline` docstrings were fixed, taking advantage of the opportunity due to the delayed release.