### PR TITLE
Fix forgotten renamings of giotto into gtda

### DIFF
--- a/gtda/images/__init__.py
+++ b/gtda/images/__init__.py
@@ -1,4 +1,4 @@
-"""The module :mod:`giotto.images` implements techniques
+"""The module :mod:`gtda.images` implements techniques
     that can be used to apply Topological Data Analysis to images.
 """
 

--- a/gtda/images/preprocessing.py
+++ b/gtda/images/preprocessing.py
@@ -41,7 +41,7 @@ class Binarizer(BaseEstimator, TransformerMixin):
 
     See also
     --------
-    giotto.homology.CubicalPersistence
+    gtda.homology.CubicalPersistence
 
     """
     _hyperparameters = {'threshold': [numbers.Number, (1e-16, 1)],

--- a/gtda/images/tests/test_preprocessing.py
+++ b/gtda/images/tests/test_preprocessing.py
@@ -6,7 +6,7 @@ import pytest
 from numpy.testing import assert_almost_equal
 from sklearn.exceptions import NotFittedError
 
-from giotto.images import Binarizer
+from gtda.images import Binarizer
 
 images_2D = np.stack([np.ones((7, 8)),
                       np.concatenate([np.ones((7, 4)), np.zeros((7, 4))],

--- a/gtda/mapper/visualization.py
+++ b/gtda/mapper/visualization.py
@@ -24,7 +24,7 @@ def plot_static_mapper_graph(
 
     Parameters
     ----------
-    pipeline : :class:`~giotto.mapper.pipeline.MapperPipeline` object
+    pipeline : :class:`~gtda.mapper.pipeline.MapperPipeline` object
         Mapper pipeline to act on to data.
 
     data : array-like of shape (n_samples, n_features)
@@ -178,7 +178,7 @@ def plot_interactive_mapper_graph(pipeline, data, layout='kamada_kawai',
 
     Parameters
     ----------
-    pipeline : :class:`~giotto.mapper.pipeline.MapperPipeline` object
+    pipeline : :class:`~gtda.mapper.pipeline.MapperPipeline` object
         Mapper pipeline to act on to data.
 
     data : array-like of shape (n_samples, n_features)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
A couple of instances of `giotto` over `gtda` still remain on master. They went unnoticed in recent PRs also due to our ongoing difficulty to set up the azure pipelines to show test failures clearly as crosses. 