### PR TITLE
Add tests for heat_kernel

### DIFF
--- a/gtda/diagrams/tests/test_features.py
+++ b/gtda/diagrams/tests/test_features.py
@@ -3,9 +3,12 @@
 import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal
+from hypothesis import given
+from hypothesis.extra.numpy import arrays
+from hypothesis.strategies import integers, floats
 from sklearn.exceptions import NotFittedError
 
-from gtda.diagrams import PersistenceEntropy
+from gtda.diagrams import PersistenceEntropy, HeatKernel
 
 X_pe = np.array([[[0, 1, 0], [2, 3, 0], [4, 6, 1], [2, 6, 1]]])
 
@@ -22,3 +25,91 @@ def test_pe_transform():
     X_pe_res = np.array([[0.69314718, 0.63651417]])
 
     assert_almost_equal(pe.fit_transform(X_pe), X_pe_res)
+
+
+pts_gen = arrays(
+    dtype=np.float,
+    elements=floats(allow_nan=False,
+                    allow_infinity=False,
+                    min_value=1.,
+                    max_value=10),
+    shape=(1, 20, 2), unique=True
+)
+dims_gen = arrays(
+    dtype=np.int,
+    elements=integers(min_value=0,
+                      max_value=3),
+    shape=(1, 20, 1)
+)
+
+
+def _validate_distinct(X):
+    unique_values = [np.unique(x[0:2, :]) for x in X]
+    if np.any([len(u) < 2 for u in unique_values]):
+        raise ValueError("There should be at least two distinct points"
+                         "in the persistent diagrams:" +
+                         "now, only {} is present".format(*unique_values))
+    return 0
+
+
+def get_input(pts, dims):
+    for p in pts:
+        try:
+            _validate_distinct([pts])
+        except ValueError:
+            p[0, 0:2] += 0.3
+            # add a distinct value, if not provided by hypothesis
+    X = np.concatenate([np.sort(pts, axis=2), dims], axis=2)
+    return X
+
+
+def test_all_pts_the_same():
+    X = np.zeros((1, 4, 3))
+    hk = HeatKernel(sigma=1)
+    with pytest.raises(IndexError):
+        _ = hk.fit(X).transform(X)
+
+
+@given(pts_gen, dims_gen)
+def test_hk_shape(pts, dims):
+    n_values = 10
+    x = get_input(pts, dims)
+
+    hk = HeatKernel(sigma=1, n_values=n_values)
+    num_dimensions = len(np.unique(dims))
+    x_t = hk.fit(x).transform(x)
+
+    assert x_t.shape == (x.shape[0], num_dimensions, n_values, n_values)
+
+
+@given(pts_gen, dims_gen)
+def test_hk_positive(pts, dims):
+    """ We expect the points above the PD-diagonal to be non-negative,
+    (up to a numerical error)"""
+    n_values = 10
+    hk = HeatKernel(sigma=1, n_values=n_values)
+
+    x = get_input(pts, dims)
+    x_t = hk.fit(x).transform(x)
+
+    assert np.all((np.tril(x_t[:, :, ::-1, :]) + 1e-13) >= 0.)
+
+
+@given(pts_gen)
+def test_hk_with_diag_points(pts):
+    """Add points on the diagonal, and verify that we have the same results
+    (on the same fitted values)."""
+    n_values = 10
+    hk = HeatKernel(sigma=1, n_values=n_values)
+
+    x = get_input(pts, np.zeros((pts.shape[0], pts.shape[1], 1)))
+    diag_points = np.array([[[2, 2, 0], [3, 3, 0], [7, 7, 0]]])
+    x_with_diag_points = np.concatenate([x, diag_points], axis=1)
+
+    # X_total = np.concatenate([X,X_with_diag_points], axis =0)
+    hk = hk.fit(x_with_diag_points)
+
+    x_t, x_with_diag_points_t = [hk.transform(x_)
+                                 for x_ in [x, x_with_diag_points]]
+
+    assert_almost_equal(x_with_diag_points_t, x_t, decimal=13)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/giotto-learn/giotto-learn/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Fixes #176. PReviously, some changes from this PR were in #196, but there was an authorship problem with my dual identity.

#### What does this implement/fix? Explain your changes.
Testing:
- output shape,
- whether the kernel is positive on the area 'above' the diagonal,
- whether the transform is invariant to adding points on the diagonal.

#### Any other comments?
1. Much of the code in `giotto.diagrams._metrics`is not covered.
2. **Most of the coverage comes from  `giotto-learn/giotto/meta_transformers/tests/test_features.py`.**

<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
