### PR TITLE
Reshape 1D estimators in decorator for compatibility with FeatureUnion

### DIFF
--- a/gtda/mapper/tests/test_filter.py
+++ b/gtda/mapper/tests/test_filter.py
@@ -93,6 +93,6 @@ def test_gaussian_density_values(X):
     kde_desired = KernelDensity(bandwidth=np.std(X))
     kde_actual = method_to_transform(
         KernelDensity, 'score_samples')(bandwidth=np.std(X))
-    Xt_desired = kde_desired.fit(X).score_samples(X)
+    Xt_desired = kde_desired.fit(X).score_samples(X).reshape(-1, 1)
     Xt_actual = kde_actual.fit_transform(X)
     assert_almost_equal(Xt_actual, Xt_desired)

--- a/gtda/mapper/utils/decorators.py
+++ b/gtda/mapper/utils/decorators.py
@@ -51,7 +51,11 @@ def method_to_transform(cls, method_name):
             def transform(self, X, y=None):
                 has_method = hasattr(self, method_name)
                 if has_method:
-                    return getattr(self, method_name)(X)
+                    Xt = getattr(self, method_name)(X)
+                    # reshape 1D estimators to have shape (n_samples, 1)
+                    if Xt.ndim == 1:
+                        Xt = Xt[:, None]
+                    return Xt
         ExtendedEstimator.__name__ = 'Extended' + wrapped.__name__
         return ExtendedEstimator
     wrapped_cls = wrapper(cls)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Reshapes 1D estimators in the `method_to_transform()` decorator for compatibility with scikit-learn's `FeatureUnion` which expects 1D arrays to have shape `(n_samples, 1)`.

#### Any other comments?
Useful when trying to concatenate several 1D filter functions in the Mapper pipeline, e.g.

```
from sklearn.ensemble import IsolationForest
from gtda.mapper import method_to_transform
from sklearn.pipeline import FeatureUnion
from sklearn.decomposition import PCA

pca = PCA(n_components=1)
isolation_forest = method_to_transform(IsolationForest, 'decision_function')

filter_funcs = FeatureUnion([('isolation', isolation_forest(random_state=1729)), ('pca', pca)])

filter_values = filter_funcs.fit_transform(X)
...
```
