### PR TITLE
Add global node ID to Mapper tooltip and remove pullback cover set label

### DIFF
--- a/examples/mapper_quickstart.ipynb
+++ b/examples/mapper_quickstart.ipynb
@@ -42,11 +42,9 @@
     "    make_mapper_pipeline,\n",
     "    Projection,\n",
     "    plot_static_mapper_graph,\n",
-    "    plot_interactive_mapper_graph\n",
+    "    plot_interactive_mapper_graph,\n",
     ")\n",
     "from gtda.mapper.utils.visualization import set_node_sizeref\n",
-    "\n",
-    "# from gtda.mapper.utils.visualization import set_node_sizeref\n",
     "\n",
     "# ML tools\n",
     "from sklearn import datasets\n",
@@ -54,6 +52,7 @@
     "from sklearn.decomposition import PCA\n",
     "\n",
     "import warnings\n",
+    "\n",
     "warnings.simplefilter(action=\"ignore\", category=FutureWarning)"
    ]
   },
@@ -185,10 +184,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plotly_kwargs = {\n",
-    "    'node_trace_marker_colorscale':'Blues'\n",
-    "}\n",
-    "fig = plot_static_mapper_graph(pipe, data, color_by_columns_dropdown=True, plotly_kwargs=plotly_kwargs)\n",
+    "plotly_kwargs = {\"node_trace_marker_colorscale\": \"Blues\"}\n",
+    "fig = plot_static_mapper_graph(\n",
+    "    pipe, data, color_by_columns_dropdown=True, plotly_kwargs=plotly_kwargs\n",
+    ")\n",
     "# Display figure\n",
     "fig.show(config={\"scrollZoom\": True})"
    ]
@@ -209,7 +208,9 @@
     "# Initialise estimator to color graph by\n",
     "pca = PCA(n_components=1).fit(data)\n",
     "\n",
-    "fig = plot_static_mapper_graph(pipe, data, color_by_columns_dropdown=True, color_variable=pca)\n",
+    "fig = plot_static_mapper_graph(\n",
+    "    pipe, data, color_by_columns_dropdown=True, color_variable=pca\n",
+    ")\n",
     "# Display figure\n",
     "fig.show(config={\"scrollZoom\": True})"
    ]
@@ -234,7 +235,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_df = pd.DataFrame(data, columns=['x', 'y']); data_df.head()"
+    "data_df = pd.DataFrame(data, columns=[\"x\", \"y\"])\n",
+    "data_df.head()"
    ]
   },
   {
@@ -250,7 +252,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pipe.set_params(filter_func=Projection(columns=['x', 'y']));"
+    "pipe.set_params(filter_func=Projection(columns=[\"x\", \"y\"]))"
    ]
   },
   {
@@ -278,8 +280,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Rest back to numpy projection\n",
-    "pipe.set_params(filter_func=Projection(columns=[0,1]));"
+    "# Reset back to numpy projection\n",
+    "pipe.set_params(filter_func=Projection(columns=[0, 1]))"
    ]
   },
   {
@@ -288,7 +290,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = plot_static_mapper_graph(pipe, data, layout='fruchterman_reingold', color_by_columns_dropdown=True)\n",
+    "fig = plot_static_mapper_graph(\n",
+    "    pipe, data, layout=\"fruchterman_reingold\", color_by_columns_dropdown=True\n",
+    ")\n",
     "# Display figure\n",
     "fig.show(config={\"scrollZoom\": True})"
    ]
@@ -342,7 +346,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "graph['node_metadata'].keys()"
+    "graph[\"node_metadata\"].keys()"
    ]
   },
   {
@@ -358,7 +362,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "node_id, node_elements = graph['node_metadata']['node_id'], graph['node_metadata']['node_elements']"
+    "node_id, node_elements = (\n",
+    "    graph[\"node_metadata\"][\"node_id\"],\n",
+    "    graph[\"node_metadata\"][\"node_elements\"],\n",
+    ")"
    ]
   },
   {
@@ -367,7 +374,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print('Node Id: {}, \\nNode elements: {}, \\nData points: {}'.format(node_id[0], node_elements[0], data[node_elements[0]]))"
+    "print(\n",
+    "    \"Node Id: {}, \\nNode elements: {}, \\nData points: {}\".format(\n",
+    "        node_id[0], node_elements[0], data[node_elements[0]]\n",
+    "    )\n",
+    ")"
    ]
   },
   {
@@ -387,7 +398,13 @@
     "plotly_kwargs = {\n",
     "    \"node_trace_marker_sizeref\": set_node_sizeref(node_elements, node_scale=30)\n",
     "}\n",
-    "fig = plot_static_mapper_graph(pipe, data, layout_dim=3, color_by_columns_dropdown=True, plotly_kwargs=plotly_kwargs)\n",
+    "fig = plot_static_mapper_graph(\n",
+    "    pipe,\n",
+    "    data,\n",
+    "    layout_dim=3,\n",
+    "    color_by_columns_dropdown=True,\n",
+    "    plotly_kwargs=plotly_kwargs,\n",
+    ")\n",
     "# Display figure\n",
     "fig.show(config={\"scrollZoom\": True})"
    ]
@@ -439,43 +456,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In general, any callable (i.e. function) that operates **_row-wise_** can be passed. For example we can filter by the ratio of $x$- and $y$-coordinates as follows:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def calculate_xy_ratio(row):\n",
-    "    return row[0] / row[1]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pipe = make_mapper_pipeline(\n",
-    "    filter_func=calculate_xy_ratio,\n",
-    "    cover=cover,\n",
-    "    clusterer=clusterer,\n",
-    "    verbose=True,\n",
-    "    n_jobs=n_jobs,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = plot_static_mapper_graph(pipe, data, plotly_kwargs=None)\n",
-    "# Display figure\n",
-    "fig.show(config={\"scrollZoom\": True})"
+    "In general, any callable (i.e. function) that operates **_row-wise_** can be passed."
    ]
   },
   {
@@ -522,7 +503,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.6"
   },
   "toc": {
    "base_numbering": 1,

--- a/gtda/mapper/nerve.py
+++ b/gtda/mapper/nerve.py
@@ -30,7 +30,7 @@ class Nerve(BaseEstimator, TransformerMixin):
     X_ : list of tuple
         Nodes of the Mapper graph obtained from the input data for
         :meth:`fit`. It is a flattened version of the input Mapper cover,
-        with the addition of a globally unique node Id as the first entry in
+        with the addition of a globally unique node ID as the first entry in
         each tuple. Created only when :meth:`fit` is called.
 
     edges_ : list of dict

--- a/gtda/mapper/pipeline.py
+++ b/gtda/mapper/pipeline.py
@@ -250,6 +250,18 @@ def make_mapper_pipeline(scaler=None,
     >>> mapper_graph = mapper.fit_transform(X)  # Create the mapper graph
     >>> print(type(mapper_graph))
     igraph.Graph
+    >>> # Node metadata stored as dict in graph object
+    >>> print(mapper_graph['node_metadata'].keys())
+    dict_keys(['node_id', 'pullback_set_label', 'partial_cluster_label',
+               'node_elements'])
+    >>> # Find which points belong to first node of graph
+    >>> node_id, node_elements = mapper_graph['node_metadata']['node_id'],
+    ... mapper_graph['node_metadata']['node_elements']
+    >>> print('Node Id: {}, Node elements: {}, Data points: {}'
+              .format(node_id[0], node_elements[0], X[node_elements[0]]))
+    Node Id: 0,
+    Node elements: [8768],
+    Data points: [[0.01838998 0.76928754 0.98199244 0.0074299 ]]
     >>> #######################################################################
     >>> # Example using a scaler from scikit-learn, a filter function from
     >>> # gtda.mapper.filter, and a clusterer from gtda.mapper.cluster

--- a/gtda/mapper/utils/visualization.py
+++ b/gtda/mapper/utils/visualization.py
@@ -17,15 +17,12 @@ def _get_node_size(node_elements):
 
 def _get_node_text(graph):
     return [
-        ('Node Id:{}<br>Node size:{}<br>Partial cluster '
-         'label:{}')
-        .format(
-            node_id, len(node_elements), partial_cluster_label,
+        ("Node ID:{}<br>Node size:{}").format(node_id, len(node_elements),)
+        for node_id, node_elements in zip(
+            graph["node_metadata"]["node_id"],
+            graph["node_metadata"]["node_elements"]
         )
-        for node_id, node_elements, partial_cluster_label in
-        zip(graph['node_metadata']['node_id'],
-            graph['node_metadata']['node_elements'],
-            graph['node_metadata']['partial_cluster_label'])]
+    ]
 
 
 def set_node_sizeref(node_elements, node_scale=12):

--- a/gtda/mapper/utils/visualization.py
+++ b/gtda/mapper/utils/visualization.py
@@ -17,14 +17,14 @@ def _get_node_size(node_elements):
 
 def _get_node_text(graph):
     return [
-        ('Node size:{}<br>Pullback cover set label:{}<br>Partial cluster '
+        ('Node Id:{}<br>Node size:{}<br>Partial cluster '
          'label:{}')
         .format(
-            len(node_elements), pullback_set_label, partial_cluster_label,
+            node_id, len(node_elements), partial_cluster_label,
         )
-        for node_elements, pullback_set_label, partial_cluster_label in
-        zip(graph['node_metadata']['node_elements'],
-            graph['node_metadata']['pullback_set_label'],
+        for node_id, node_elements, partial_cluster_label in
+        zip(graph['node_metadata']['node_id'],
+            graph['node_metadata']['node_elements'],
             graph['node_metadata']['partial_cluster_label'])]
 
 

--- a/gtda/mapper/visualization.py
+++ b/gtda/mapper/visualization.py
@@ -19,7 +19,9 @@ def plot_static_mapper_graph(
         color_variable=None, node_color_statistic=None,
         color_by_columns_dropdown=False, plotly_kwargs=None,
         clone_pipeline=True):
-    """Plotting function for static Mapper graphs.
+    """Plotting function for static Mapper graphs, with nodes colored according
+    to :attr:`color_variable`. By default, the hovertext displays a globally
+    unique ID and the number of elements associated with a given node.
 
     Parameters
     ----------

--- a/gtda/mapper/visualization.py
+++ b/gtda/mapper/visualization.py
@@ -19,9 +19,11 @@ def plot_static_mapper_graph(
         color_variable=None, node_color_statistic=None,
         color_by_columns_dropdown=False, plotly_kwargs=None,
         clone_pipeline=True):
-    """Plotting function for static Mapper graphs, with nodes colored according
-    to :attr:`color_variable`. By default, the hovertext displays a globally
-    unique ID and the number of elements associated with a given node.
+    """Plotting function for static Mapper graphs.
+
+    Nodes are colored according to :attr:`color_variable`. By default, the
+    hovertext displays a globally unique ID and the number of elements
+    associated with a given node.
 
     Parameters
     ----------
@@ -176,6 +178,10 @@ def plot_interactive_mapper_graph(pipeline, data, layout='kamada_kawai',
                                   color_by_columns_dropdown=False,
                                   plotly_kwargs=None):
     """Plotting function for interactive Mapper graphs.
+
+    Nodes are colored according to :attr:`color_variable`. By default, the
+    hovertext displays a globally unique ID and the number of elements
+    associated with a given node.
 
     Parameters
     ----------

--- a/gtda/mapper/visualization.py
+++ b/gtda/mapper/visualization.py
@@ -179,9 +179,10 @@ def plot_interactive_mapper_graph(pipeline, data, layout='kamada_kawai',
                                   plotly_kwargs=None):
     """Plotting function for interactive Mapper graphs.
 
-    Nodes are colored according to :attr:`color_variable`. By default, the
-    hovertext displays a globally unique ID and the number of elements
-    associated with a given node.
+    Provides functionality to interactively update parameters from the cover
+    and clustering steps defined in :attr:`pipeline`. Nodes are colored
+    according to :attr:`color_variable`. By default, the hovertext displays a
+    globally unique ID and the number of elements associated with a given node.
 
     Parameters
     ----------


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/giotto-ai/giotto-tda/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Resolves #237 

#### What does this implement/fix? Explain your changes.
* Introduces a global node ID that can be used to retrieve the node members in the original data array. 
* The _Pullback cover set label_ string has been removed as it is a somewhat advanced concept that the user can implement themselves by updating `node_trace_text` in `plotly_kwargs`. 
