### PR TITLE
Fix/mapper colors

### DIFF
--- a/examples/mapper_quickstart.ipynb
+++ b/examples/mapper_quickstart.ipynb
@@ -34,7 +34,7 @@
     "import pandas as pd  # Not a requirement of giotto-tda, but is compatible with the gtda.mapper module\n",
     "\n",
     "# Data viz\n",
-    "import plotly.graph_objects as go\n",
+    "from plotting import plot_point_cloud\n",
     "\n",
     "# TDA magic\n",
     "from gtda.mapper import (\n",
@@ -72,11 +72,7 @@
    "source": [
     "data, _ = datasets.make_circles(n_samples=5000, noise=0.05, factor=0.3, random_state=42)\n",
     "\n",
-    "fig = go.Figure(\n",
-    "    data=go.Scatter(x=data[:, 0], y=data[:, 1], mode=\"markers\"),\n",
-    "    layout={\"autosize\": False},\n",
-    ")\n",
-    "fig.show()"
+    "plot_point_cloud(data)"
    ]
   },
   {

--- a/gtda/mapper/utils/visualization.py
+++ b/gtda/mapper/utils/visualization.py
@@ -133,13 +133,13 @@ def _get_node_colors(data, is_data_dataframe, node_elements,
                 color_data = data[color_variable].to_numpy()
             else:
                 color_data = data[:, color_variable]
-        node_colors = get_node_summary(node_elements, color_data,
 
-                                       summary_stat=node_color_statistic)
+        node_colors = get_node_summary(
+            node_elements, color_data, summary_stat=node_color_statistic)
 
-        # normalise node colours in range [0,1] for colorscale
-        node_colors = (node_colors - np.min(node_colors)) / \
-            (np.max(node_colors) - np.min(node_colors))
+    # Normalise node colours in range [0,1] for colorscale mapping
+    node_colors = (node_colors - np.min(node_colors)) / \
+        (np.max(node_colors) - np.min(node_colors))
 
     return node_colors
 

--- a/gtda/mapper/utils/visualization.py
+++ b/gtda/mapper/utils/visualization.py
@@ -134,7 +134,12 @@ def _get_node_colors(data, is_data_dataframe, node_elements,
             else:
                 color_data = data[:, color_variable]
         node_colors = get_node_summary(node_elements, color_data,
+
                                        summary_stat=node_color_statistic)
+
+        # normalise node colours in range [0,1] for colorscale
+        node_colors = (node_colors - np.min(node_colors)) / \
+            (np.max(node_colors) - np.min(node_colors))
 
     return node_colors
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/giotto-ai/giotto-tda/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #266 

#### What does this implement/fix? Explain your changes.
* Normalises `node_colors` values to lie in range [0,1]
* Reuses `plot_point_cloud` function from `examples/` for Mapper quickstart notebook

#### Any other comments?


<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
