### PR TITLE
Place pytest and flake8 tests on dev install before dev uninstall

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -279,22 +279,16 @@ jobs:
     displayName: 'Install dev environment'
 
   - script: |
-      pip uninstall -y giotto-tda
-    condition: eq(variables['nightly_check'], 'false')
-    failOnStderr: true
-    displayName: 'Uninstall giotto-tda dev'
-
-  - script: |
-      pip uninstall -y giotto-tda-nightly
-    condition: eq(variables['nightly_check'], 'true')
-    failOnStderr: true
-    displayName: 'Uninstall giotto-tda-nightly dev'
-
-  - script: |
       pytest --cov gtda --cov-report xml
       flake8
     failOnStderr: true
-    displayName: 'Test with pytest and flake8'
+    displayName: 'Test dev install with pytest and flake8'
+
+  - script: |
+      pip uninstall -y giotto-tda
+      pip uninstall -y giotto-tda-nightly
+    failOnStderr: true
+    displayName: 'Uninstall giotto-tda/giotto-tda-nightly'
 
   - script: |
       pip install wheel
@@ -399,22 +393,16 @@ jobs:
     displayName: 'Install dev environment'
 
   - script: |
-      pip uninstall -y giotto-tda
-    condition: eq(variables['nightly_check'], 'false')
-    failOnStderr: true
-    displayName: 'Uninstall giotto-tda dev'
-
-  - script: |
-      pip uninstall -y giotto-tda-nightly
-    condition: eq(variables['nightly_check'], 'true')
-    failOnStderr: true
-    displayName: 'Uninstall giotto-tda-nightly dev'
-
-  - script: |
       pytest --cov gtda --cov-report xml
       flake8
     failOnStderr: true
-    displayName: 'Test with pytest and flake8'
+    displayName: 'Test dev install with pytest and flake8'
+
+  - script: |
+      pip uninstall -y giotto-tda
+      pip uninstall -y giotto-tda-nightly
+    failOnStderr: true
+    displayName: 'Uninstall giotto-tda/giotto-tda-nightly dev'
 
   - bash: |
       sed -i $'s/\r$//' README.rst

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -285,9 +285,9 @@ jobs:
     displayName: 'Test dev install with pytest and flake8'
 
   - script: |
+      set -e
       pip uninstall -y giotto-tda
       pip uninstall -y giotto-tda-nightly
-    failOnStderr: true
     displayName: 'Uninstall giotto-tda/giotto-tda-nightly'
 
   - script: |
@@ -399,9 +399,8 @@ jobs:
     displayName: 'Test dev install with pytest and flake8'
 
   - script: |
-      pip uninstall -y giotto-tda
-      pip uninstall -y giotto-tda-nightly
-    failOnStderr: true
+      pip uninstall -y giotto-tda || exit /b
+      pip uninstall -y giotto-tda-nightly || exit /b
     displayName: 'Uninstall giotto-tda/giotto-tda-nightly dev'
 
   - bash: |


### PR DESCRIPTION
#### Reference Issues/PRs
Follows [discussion](https://github.com/giotto-ai/giotto-tda/pull/273#issuecomment-584569423) in #273.


#### What does this implement/fix? Explain your changes.
- Places the step running `pytest` and `flake8` on the dev installation *before* any steps uninstalling giotto-tda or giotto-tda-nightly.
- The opportunity was taken to make code leaner by merging the uninstall steps for regular and nightly versions into one, since a missing package when running `pip uninstall -y` will produce a warning but not an error (commit message has a mistake here).