### PR TITLE
Use a version of papermill that does not produce a warning

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -309,7 +309,7 @@ jobs:
 
   - script: |
       pip install openml pandas
-      pip install papermill
+      pip install 'papermill<=1.2.1'
       cd examples
       for n in *.ipynb
       do

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ jobs:
 
   - script: |
       pip install openml pandas
-      pip install papermill==1.2.1
+      pip install "papermill==1.2.1"
       cd examples
       for n in *.ipynb
       do
@@ -87,7 +87,7 @@ jobs:
 
   - script: |
       pip install openml pandas
-      pip install papermill==1.2.1
+      pip install "papermill==1.2.1"
       cd examples
       for n in *.ipynb
       do
@@ -136,7 +136,7 @@ jobs:
 
   - script: |
       pip install openml pandas
-      pip install papermill==1.2.1
+      pip install "papermill==1.2.1"
       cd examples
       FOR %%n in (*.ipynb) DO (papermill --start_timeout 2000 %%n -)
     failOnStderr: true
@@ -206,7 +206,7 @@ jobs:
 
   - script: |
       pip install openml pandas
-      pip install papermill==1.2.1
+      pip install "papermill==1.2.1"
       cd examples
       for n in *.ipynb
       do
@@ -309,7 +309,7 @@ jobs:
 
   - script: |
       pip install openml pandas
-      pip install papermill==1.2.1
+      pip install "papermill==1.2.1"
       cd examples
       for n in *.ipynb
       do
@@ -424,7 +424,7 @@ jobs:
   - script: |
       cd examples
       pip install openml pandas
-      pip install papermill==1.2.1
+      pip install "papermill==1.2.1"
       FOR %%n in (*.ipynb) DO (papermill --start_timeout 2000 %%n -)
     failOnStderr: true
     displayName: 'Test jupyter notebooks with papermill'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ jobs:
 
   - script: |
       pip install openml pandas
-      pip install 'papermill<=1.2.1'
+      pip install papermill==1.2.1
       cd examples
       for n in *.ipynb
       do
@@ -87,7 +87,7 @@ jobs:
 
   - script: |
       pip install openml pandas
-      pip install 'papermill<=1.2.1'
+      pip install papermill==1.2.1
       cd examples
       for n in *.ipynb
       do
@@ -136,7 +136,7 @@ jobs:
 
   - script: |
       pip install openml pandas
-      pip install 'papermill<=1.2.1'
+      pip install papermill==1.2.1
       cd examples
       FOR %%n in (*.ipynb) DO (papermill --start_timeout 2000 %%n -)
     failOnStderr: true
@@ -206,7 +206,7 @@ jobs:
 
   - script: |
       pip install openml pandas
-      pip install 'papermill<=1.2.1'
+      pip install papermill==1.2.1
       cd examples
       for n in *.ipynb
       do
@@ -309,7 +309,7 @@ jobs:
 
   - script: |
       pip install openml pandas
-      pip install 'papermill<=1.2.1'
+      pip install papermill==1.2.1
       cd examples
       for n in *.ipynb
       do
@@ -424,7 +424,7 @@ jobs:
   - script: |
       cd examples
       pip install openml pandas
-      pip install 'papermill<=1.2.1'
+      pip install papermill==1.2.1
       FOR %%n in (*.ipynb) DO (papermill --start_timeout 2000 %%n -)
     failOnStderr: true
     displayName: 'Test jupyter notebooks with papermill'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ jobs:
 
   - script: |
       pip install openml pandas
-      pip install papermill
+      pip install 'papermill<=1.2.1'
       cd examples
       for n in *.ipynb
       do
@@ -87,7 +87,7 @@ jobs:
 
   - script: |
       pip install openml pandas
-      pip install papermill
+      pip install 'papermill<=1.2.1'
       cd examples
       for n in *.ipynb
       do
@@ -136,7 +136,7 @@ jobs:
 
   - script: |
       pip install openml pandas
-      pip install papermill
+      pip install 'papermill<=1.2.1'
       cd examples
       FOR %%n in (*.ipynb) DO (papermill --start_timeout 2000 %%n -)
     failOnStderr: true
@@ -206,7 +206,7 @@ jobs:
 
   - script: |
       pip install openml pandas
-      pip install papermill
+      pip install 'papermill<=1.2.1'
       cd examples
       for n in *.ipynb
       do
@@ -424,7 +424,7 @@ jobs:
   - script: |
       cd examples
       pip install openml pandas
-      pip install papermill
+      pip install 'papermill<=1.2.1'
       FOR %%n in (*.ipynb) DO (papermill --start_timeout 2000 %%n -)
     failOnStderr: true
     displayName: 'Test jupyter notebooks with papermill'


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #279 .

#### What does this implement/fix? Explain your changes.
Force the version of papermill installed in the pipelines.

#### Any other comments?
In the future, we might want to investigate what really happens/ open an issue on papermill's repo.
