### PR TITLE
Create and upload pytest coverage reports only in one build job

### DIFF
--- a/.azure-ci/docker_scripts.sh
+++ b/.azure-ci/docker_scripts.sh
@@ -29,7 +29,7 @@ cd /io
 pip install -e ".[tests, doc]"
 
 # Test dev install with pytest and flake8
-pytest --cov gtda --no-cov --no-coverage-upload
+pytest gtda --no-cov --no-coverage-upload
 flake8 --exit-zero /io/
 
 # Uninstall giotto-tda/giotto-tda-nightly dev

--- a/.azure-ci/docker_scripts.sh
+++ b/.azure-ci/docker_scripts.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-# Upgrading pip and setuptools, TODO: Monitor status of pip versions
+# Upgrade pip and setuptools. TODO: Monitor status of pip versions
 PYTHON_PATH=$(eval find "/opt/python/*${python_ver}*" -print)
 export PATH=${PYTHON_PATH}/bin:${PATH}
 pip install --upgrade pip==19.3.1 setuptools
@@ -29,13 +29,13 @@ cd /io
 pip install -e ".[tests, doc]"
 
 # Test dev install with pytest and flake8
-pytest --cov . --cov-report xml
+pytest --cov gtda --no-cov --no-coverage-upload
 flake8 --exit-zero /io/
 
 # Uninstall giotto-tda/giotto-tda-nightly dev
 pip uninstall -y giotto-tda
 pip uninstall -y giotto-tda-nightly
 
-# Building wheels
+# Build wheels
 pip install wheel
 python setup.py sdist bdist_wheel

--- a/.azure-ci/docker_scripts.sh
+++ b/.azure-ci/docker_scripts.sh
@@ -24,15 +24,17 @@ cd ..
 export BOOST_ROOT=/boost
 export Boost_INCLUDE_DIR=/boost/include
 
-# Install and uninstall giotto-tda dev
+# Install dev environment
 cd /io
 pip install -e ".[tests, doc]"
-pip uninstall -y giotto-tda
-pip uninstall -y giotto-tda-nightly
 
-# Testing, linting
+# Test dev install with pytest and flake8
 pytest --cov . --cov-report xml
 flake8 --exit-zero /io/
+
+# Uninstall giotto-tda/giotto-tda-nightly dev
+pip uninstall -y giotto-tda
+pip uninstall -y giotto-tda-nightly
 
 # Building wheels
 pip install wheel

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ jobs:
     displayName: 'Install dev environment'
 
   - script: |
-      pytest --cov gtda --cov-report xml
+      pytest --cov gtda --no-coverage-upload
       flake8
     failOnStderr: true
     displayName: 'Test with pytest and flake8'
@@ -129,7 +129,7 @@ jobs:
     displayName: 'Install dev environment'
 
   - script: |
-      pytest --cov gtda --cov-report xml
+      pytest --cov gtda --no-coverage-upload
       flake8
     failOnStderr: true
     displayName: 'Test with pytest and flake8'
@@ -393,7 +393,7 @@ jobs:
     displayName: 'Install dev environment'
 
   - script: |
-      pytest --cov gtda --cov-report xml
+      pytest --cov gtda --no-cov --no-coverage-upload
       flake8
     failOnStderr: true
     displayName: 'Test dev install with pytest and flake8'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ jobs:
     displayName: 'Install dev environment'
 
   - script: |
-      pytest --cov gtda --no-coverage-upload
+      pytest gtda --no-cov --no-coverage-upload
       flake8
     failOnStderr: true
     displayName: 'Test with pytest and flake8'
@@ -80,7 +80,7 @@ jobs:
     displayName: 'Install dev environment'
 
   - script: |
-      pytest --cov gtda --cov-report xml
+      pytest gtda --cov --cov-report xml
       flake8
     failOnStderr: true
     displayName: 'Test with pytest and flake8'
@@ -129,7 +129,7 @@ jobs:
     displayName: 'Install dev environment'
 
   - script: |
-      pytest --cov gtda --no-coverage-upload
+      pytest gtda --no-cov --no-coverage-upload
       flake8
     failOnStderr: true
     displayName: 'Test with pytest and flake8'
@@ -279,7 +279,7 @@ jobs:
     displayName: 'Install dev environment'
 
   - script: |
-      pytest --cov gtda --cov-report xml
+      pytest gtda --cov --cov-report xml
       flake8
     failOnStderr: true
     displayName: 'Test dev install with pytest and flake8'
@@ -393,7 +393,7 @@ jobs:
     displayName: 'Install dev environment'
 
   - script: |
-      pytest --cov gtda --no-cov --no-coverage-upload
+      pytest gtda --no-cov --no-coverage-upload
       flake8
     failOnStderr: true
     displayName: 'Test dev install with pytest and flake8'


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Currently, coverage reports are produced and uploaded by pytest in all build jobs in `azure-pipelines.yml`. But there seems to be no need for this and it should be enough to perform this step only in one job. Here, I chose the macOS build job for this purporse.