### PR TITLE
Fix mapper nan colors

### DIFF
--- a/gtda/mapper/utils/visualization.py
+++ b/gtda/mapper/utils/visualization.py
@@ -137,10 +137,13 @@ def _get_node_colors(data, is_data_dataframe, node_elements,
         node_colors = get_node_summary(
             node_elements, color_data, summary_stat=node_color_statistic)
 
-    # Normalise node colours in range [0,1] for colorscale mapping
+    # Check if node_colors contains NaNs
     if any(np.logical_not(np.isfinite(node_colors))):
         from warnings import warn
-        warn('The variable defining colors contains NaN values.', RuntimeWarning)
+        warn('NaN values detected in the array of Mapper node colors!'
+             'These values will be ignored in the color scale', RuntimeWarning)
+
+    # Normalise node colours in range [0,1] for colorscale mapping
     node_colors = (node_colors - np.nanmin(node_colors)) / \
         (np.nanmax(node_colors) - np.nanmin(node_colors))
 

--- a/gtda/mapper/utils/visualization.py
+++ b/gtda/mapper/utils/visualization.py
@@ -138,6 +138,9 @@ def _get_node_colors(data, is_data_dataframe, node_elements,
             node_elements, color_data, summary_stat=node_color_statistic)
 
     # Normalise node colours in range [0,1] for colorscale mapping
+    if any(np.logical_not(np.isfinite(node_colors))):
+        from warnings import warn
+        warn('The variable defining colors contains NaN values.', RuntimeWarning)
     node_colors = (node_colors - np.nanmin(node_colors)) / \
         (np.nanmax(node_colors) - np.nanmin(node_colors))
 

--- a/gtda/mapper/utils/visualization.py
+++ b/gtda/mapper/utils/visualization.py
@@ -138,8 +138,8 @@ def _get_node_colors(data, is_data_dataframe, node_elements,
             node_elements, color_data, summary_stat=node_color_statistic)
 
     # Normalise node colours in range [0,1] for colorscale mapping
-    node_colors = (node_colors - np.min(node_colors)) / \
-        (np.max(node_colors) - np.min(node_colors))
+    node_colors = (node_colors - np.nanmin(node_colors)) / \
+        (np.nanmax(node_colors) - np.nanmin(node_colors))
 
     return node_colors
 


### PR DESCRIPTION
#### Reference Issues/PRs
Aims to fix #284 .


#### What does this implement/fix? Explain your changes.
Allow `node_color_statistic` to have NaN entries, but throw a warning in that case.
#### Any other comments?
The warnings are not caught by the error logs in the interactive widget, but just displayed as usual. I did not manage to catch them there.