### PR TITLE
Compare clusters in terms of their content, instead of labels

### DIFF
--- a/gtda/mapper/tests/test_cluster.py
+++ b/gtda/mapper/tests/test_cluster.py
@@ -141,11 +141,13 @@ def test_precomputed_distances(inp):
     preds = fh.fit_predict(pts)
 
     indices_cluster = set(preds)
+
     def get_partition_from_preds(preds):
         """From a vector of predictions (labels), get a set of frozensets,
         where each frozenset represents a cluster, and has the indices of rows
         of its elements."""
-        return set([frozenset(np.where(preds == c)[0]) for c in indices_cluster])
+        return set([frozenset(np.where(preds == c)[0])
+                    for c in indices_cluster])
 
     assert(get_partition_from_preds(preds)
            == get_partition_from_preds(preds_mat))

--- a/gtda/mapper/tests/test_cluster.py
+++ b/gtda/mapper/tests/test_cluster.py
@@ -128,8 +128,8 @@ def test_precomputed_distances(inp):
     as the clustering on points, that were used to calculate
     that distance matrix."""
     n_points_per_cluster, n_clusters, _, pts = inp
-    dist_matrix = distance_matrix(pts, pts, p=2)
 
+    dist_matrix = distance_matrix(pts, pts, p=2)
     fh_matrix = FirstHistogramGap(freq_threshold=0, max_fraction=None,
                                   n_bins_start=5, affinity='precomputed',
                                   memory=None, linkage='single')
@@ -140,4 +140,8 @@ def test_precomputed_distances(inp):
                            memory=None, linkage='single')
     preds = fh.fit_predict(pts)
 
-    assert_almost_equal(preds, preds_mat)
+    indices_cluster = set(preds)
+    def get_set_of_clusters(preds):
+        return set([frozenset(np.where(preds==c)[0]) for c in indices_cluster])
+
+    assert(get_set_of_clusters(preds) == get_set_of_clusters(preds_mat))

--- a/gtda/mapper/tests/test_cluster.py
+++ b/gtda/mapper/tests/test_cluster.py
@@ -141,7 +141,11 @@ def test_precomputed_distances(inp):
     preds = fh.fit_predict(pts)
 
     indices_cluster = set(preds)
-    def get_set_of_clusters(preds):
-        return set([frozenset(np.where(preds==c)[0]) for c in indices_cluster])
+    def get_partition_from_preds(preds):
+        """From a vector of predictions (labels), get a set of frozensets,
+        where each frozenset represents a cluster, and has the indices of rows
+        of its elements."""
+        return set([frozenset(np.where(preds == c)[0]) for c in indices_cluster])
 
-    assert(get_set_of_clusters(preds) == get_set_of_clusters(preds_mat))
+    assert(get_partition_from_preds(preds)
+           == get_partition_from_preds(preds_mat))


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #291.

#### What does this implement/fix? Explain your changes.
Compare a clustering algorithm by the partition it induces, instead of the labels directly.

