### PR TITLE
clean setup.py installing dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,24 +127,6 @@ class CMakeBuild(build_ext):
         subprocess.check_call(['git', 'clone',
                                'https://github.com/pybind/pybind11.git',
                                dir_pybind11])
-        os.chdir(dir_pybind11)
-        dir_build = os.path.join(dir_pybind11, 'build')
-        os.mkdir(dir_build)
-        os.chdir(dir_build)
-        cmake_cmd1 = ['cmake', '-DPYBIND11_TEST=OFF', '..']
-        if platform.system() == "Windows":
-            cmake_cmd2 = ['cmake', '--install', '.']
-            if sys.maxsize > 2**32:
-                cmake_cmd1 += ['-A', 'x64']
-        else:
-            cmake_cmd2 = ['make', 'install']
-            cmake_cmd2_sudo = ['sudo', 'make', 'install']
-        subprocess.check_call(cmake_cmd1, cwd=dir_build)
-        try:
-            subprocess.check_call(cmake_cmd2, cwd=dir_build)
-        except:  # noqa
-            subprocess.check_call(cmake_cmd2_sudo, cwd=dir_build)
-        os.chdir(dir_start)
 
         subprocess.check_call(['git', 'submodule', 'update',
                                '--init', '--recursive'])


### PR DESCRIPTION
Remove from installing dependencies unnecessary action for our use cases

Signed-off-by: julian <julian.burellaperez@heig-vd.ch>

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/giotto-ai/giotto-tda/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

None

#### What does this implement/fix? Explain your changes.

This PR removes the installation procedure from pybind11. In our case installing pybind11 is unnecessary because we directly use the folder in `gtda/externals/pybind11`. 

#### Any other comments?

Now that the installation isn't performed, the script won't ask for admin privileges when `pip install -e .`.

<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
