### PR TITLE
Keep flake8 checks only in macOS jobs

### DIFF
--- a/.azure-ci/docker_scripts.sh
+++ b/.azure-ci/docker_scripts.sh
@@ -37,9 +37,8 @@ export Boost_INCLUDE_DIR=/boost/include
 cd /io
 pip install -e ".[tests, doc]"
 
-# Test dev install with pytest and flake8
+# Test dev install with pytest
 pytest gtda --cov --cov-report xml
-flake8 --exit-zero /io/
 
 # Uninstall giotto-tda/giotto-tda-nightly dev
 pip uninstall -y giotto-tda

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,7 @@ jobs:
     env:
       python_ver: $(python_ver)
       CCACHE_DIR: $(CCACHE_DIR)
-    displayName: 'Run the docker, install and uninstall dev environment, test with pytest and flake8, build the wheels'
+    displayName: 'Run the docker, install and uninstall dev environment, test with pytest, build the wheels'
 
   - script: |
       set -e
@@ -59,7 +59,7 @@ jobs:
 
   - script: |
       set -e
-      pip install pytest pytest-cov pytest-azurepipelines pytest-benchmark flake8 hypothesis
+      pip install pytest pytest-cov pytest-azurepipelines pytest-benchmark hypothesis
       mkdir tmp_test_cov
       cd tmp_test_cov
       pytest --pyargs gtda --ignore-glob='*externals*' --no-cov --no-coverage-upload
@@ -149,8 +149,12 @@ jobs:
   - script: |
       set -e
       pytest gtda --cov --cov-report xml
+    displayName: 'Test dev install with pytest'
+
+  - script: |
+      set -e
       flake8
-    displayName: 'Test dev install with pytest and flake8'
+    displayName: 'Test dev install with flake8'
 
   - script: |
       set -e
@@ -255,8 +259,7 @@ jobs:
 
   - script: |
       pytest gtda --cov --cov-report xml || exit /b
-      flake8
-    displayName: 'Test dev install with pytest and flake8'
+    displayName: 'Test dev install with pytest'
 
   - script: |
       pip uninstall -y giotto-tda


### PR DESCRIPTION
#### Reference Issues/PRs
Implements suggestion in https://github.com/giotto-ai/giotto-tda/pull/273#discussion_r381205949


#### What does this implement/fix? Explain your changes.
There is no need to run `flake8` in every OS. With this PR, `flake8` is run on dev installs only on macOS jobs (same reasoning as in https://github.com/giotto-ai/giotto-tda/pull/296#pullrequestreview-360236967).