### PR TITLE
Move bindings modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.9)
-project(giotto_bindings LANGUAGES CXX)
+project(gtda_bindings LANGUAGES CXX)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/gtda/externals/pybind11)
 set(BINDINGS_DIR "gtda/externals/bindings")
@@ -13,38 +13,38 @@ find_package(OpenMP)
 #                               Ripser                                #
 #######################################################################
 
-pybind11_add_module(giotto_ripser "${BINDINGS_DIR}/ripser_bindings.cpp")
+pybind11_add_module(gtda_ripser "${BINDINGS_DIR}/ripser_bindings.cpp")
 if(OpenMP_FOUND)
-  target_link_libraries(giotto_ripser PRIVATE OpenMP::OpenMP_CXX)
+  target_link_libraries(gtda_ripser PRIVATE OpenMP::OpenMP_CXX)
 endif()
-target_compile_options(giotto_ripser PUBLIC -O3 -D_hypot=hypot)
-target_compile_options(giotto_ripser PUBLIC $<$<CONFIG:DEBUG>:-O2 -ggdb -D_GLIBCXX_DEBUG>)
+target_compile_options(gtda_ripser PUBLIC -O3 -D_hypot=hypot)
+target_compile_options(gtda_ripser PUBLIC $<$<CONFIG:DEBUG>:-O2 -ggdb -D_GLIBCXX_DEBUG>)
 # Cannot have two inlined namespace !
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-  target_compile_options(giotto_ripser PUBLIC -march=native -D_GLIBCXX_PARALLEL)
-  target_link_libraries(giotto_ripser PRIVATE)
+  target_compile_options(gtda_ripser PUBLIC -march=native -D_GLIBCXX_PARALLEL)
+  target_link_libraries(gtda_ripser PRIVATE)
 endif()
-target_compile_definitions(giotto_ripser PRIVATE USE_COEFFICIENTS=1 ASSEMBLE_REDUCTION_MATRIX=1)
+target_compile_definitions(gtda_ripser PRIVATE USE_COEFFICIENTS=1 ASSEMBLE_REDUCTION_MATRIX=1)
 
 #######################################################################
 #                             Wasserstein                             #
 #######################################################################
 
-pybind11_add_module(giotto_wasserstein "${BINDINGS_DIR}/wasserstein_bindings.cpp")
-target_link_libraries(giotto_wasserstein LINK_PUBLIC ${Boost_LIBRARIES})
-target_compile_options(giotto_wasserstein PUBLIC -Wall -O3)
-target_compile_options(giotto_wasserstein PUBLIC $<$<CONFIG:DEBUG>:-O2 -ggdb -D_GLIBCXX_DEBUG>)
-target_compile_definitions(giotto_wasserstein PRIVATE BOOST_RESULT_OF_USE_DECLTYPE=1 BOOST_ALL_NO_LIB=1 BOOST_SYSTEM_NO_DEPRECATED=1)
+pybind11_add_module(gtda_wasserstein "${BINDINGS_DIR}/wasserstein_bindings.cpp")
+target_link_libraries(gtda_wasserstein LINK_PUBLIC ${Boost_LIBRARIES})
+target_compile_options(gtda_wasserstein PUBLIC -Wall -O3)
+target_compile_options(gtda_wasserstein PUBLIC $<$<CONFIG:DEBUG>:-O2 -ggdb -D_GLIBCXX_DEBUG>)
+target_compile_definitions(gtda_wasserstein PRIVATE BOOST_RESULT_OF_USE_DECLTYPE=1 BOOST_ALL_NO_LIB=1 BOOST_SYSTEM_NO_DEPRECATED=1)
 
 #######################################################################
 #                             Bottleneck                              #
 #######################################################################
 
-pybind11_add_module(giotto_bottleneck "${BINDINGS_DIR}/bottleneck_bindings.cpp")
-target_link_libraries(giotto_bottleneck LINK_PUBLIC ${Boost_LIBRARIES})
-target_compile_options(giotto_bottleneck PUBLIC -Wall -O3)
-target_compile_options(giotto_bottleneck PUBLIC $<$<CONFIG:DEBUG>:-O2 -ggdb -D_GLIBCXX_DEBUG>)
-target_compile_definitions(giotto_bottleneck PRIVATE BOOST_RESULT_OF_USE_DECLTYPE=1 BOOST_ALL_NO_LIB=1 BOOST_SYSTEM_NO_DEPRECATED=1)
+pybind11_add_module(gtda_bottleneck "${BINDINGS_DIR}/bottleneck_bindings.cpp")
+target_link_libraries(gtda_bottleneck LINK_PUBLIC ${Boost_LIBRARIES})
+target_compile_options(gtda_bottleneck PUBLIC -Wall -O3)
+target_compile_options(gtda_bottleneck PUBLIC $<$<CONFIG:DEBUG>:-O2 -ggdb -D_GLIBCXX_DEBUG>)
+target_compile_definitions(gtda_bottleneck PRIVATE BOOST_RESULT_OF_USE_DECLTYPE=1 BOOST_ALL_NO_LIB=1 BOOST_SYSTEM_NO_DEPRECATED=1)
 
 set(GUDHI_SRC_DIR "gtda/externals/gudhi-devel/src")
 
@@ -52,196 +52,196 @@ set(GUDHI_SRC_DIR "gtda/externals/gudhi-devel/src")
 #                           Cubical Complex                           #
 #######################################################################
 
-pybind11_add_module(giotto_cubical_complex "${BINDINGS_DIR}/cubical_complex_bindings.cpp")
+pybind11_add_module(gtda_cubical_complex "${BINDINGS_DIR}/cubical_complex_bindings.cpp")
 if(OpenMP_FOUND)
-  target_link_libraries(giotto_cubical_complex PRIVATE OpenMP::OpenMP_CXX)
+  target_link_libraries(gtda_cubical_complex PRIVATE OpenMP::OpenMP_CXX)
 endif()
-target_link_libraries(giotto_cubical_complex LINK_PUBLIC ${Boost_LIBRARIES})
-target_include_directories(giotto_cubical_complex PRIVATE "${GUDHI_SRC_DIR}/Bitmap_cubical_complex/include")
-target_include_directories(giotto_cubical_complex PRIVATE "${GUDHI_SRC_DIR}/python/include")
-target_compile_options(giotto_cubical_complex PUBLIC -Ofast -shared -pthread -fPIC -fwrapv -Wall -fno-strict-aliasing -frounding-math)
-target_compile_options(giotto_cubical_complex PUBLIC $<$<CONFIG:DEBUG>:-O2 -ggdb -D_GLIBCXX_DEBUG>)
+target_link_libraries(gtda_cubical_complex LINK_PUBLIC ${Boost_LIBRARIES})
+target_include_directories(gtda_cubical_complex PRIVATE "${GUDHI_SRC_DIR}/Bitmap_cubical_complex/include")
+target_include_directories(gtda_cubical_complex PRIVATE "${GUDHI_SRC_DIR}/python/include")
+target_compile_options(gtda_cubical_complex PUBLIC -Ofast -shared -pthread -fPIC -fwrapv -Wall -fno-strict-aliasing -frounding-math)
+target_compile_options(gtda_cubical_complex PUBLIC $<$<CONFIG:DEBUG>:-O2 -ggdb -D_GLIBCXX_DEBUG>)
 
 # Cannot have two inlined namespace !
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-  target_compile_options(giotto_cubical_complex PUBLIC -march=native -D_GLIBCXX_PARALLEL)
-  target_link_libraries(giotto_cubical_complex PRIVATE)
+  target_compile_options(gtda_cubical_complex PUBLIC -march=native -D_GLIBCXX_PARALLEL)
+  target_link_libraries(gtda_cubical_complex PRIVATE)
 endif()
 
-target_compile_definitions(giotto_cubical_complex PRIVATE BOOST_RESULT_OF_USE_DECLTYPE=1 BOOST_ALL_NO_LIB=1 BOOST_SYSTEM_NO_DEPRECATED=1)
+target_compile_definitions(gtda_cubical_complex PRIVATE BOOST_RESULT_OF_USE_DECLTYPE=1 BOOST_ALL_NO_LIB=1 BOOST_SYSTEM_NO_DEPRECATED=1)
 
 #######################################################################
 #                        Persistent Cohomology                        #
 #######################################################################
 
-pybind11_add_module(giotto_persistent_cohomology "${BINDINGS_DIR}/persistent_cohomology_bindings.cpp")
+pybind11_add_module(gtda_persistent_cohomology "${BINDINGS_DIR}/persistent_cohomology_bindings.cpp")
 if(OpenMP_FOUND)
-  target_link_libraries(giotto_persistent_cohomology PRIVATE OpenMP::OpenMP_CXX)
+  target_link_libraries(gtda_persistent_cohomology PRIVATE OpenMP::OpenMP_CXX)
 endif()
-target_link_libraries(giotto_persistent_cohomology LINK_PUBLIC ${Boost_LIBRARIES})
-target_include_directories(giotto_persistent_cohomology PRIVATE "${GUDHI_SRC_DIR}/Persistent_cohomology/include")
-target_include_directories(giotto_persistent_cohomology PRIVATE "${GUDHI_SRC_DIR}/common/include")
-target_include_directories(giotto_persistent_cohomology PRIVATE "${GUDHI_SRC_DIR}/Bitmap_cubical_complex/include")
-target_include_directories(giotto_persistent_cohomology PRIVATE "${GUDHI_SRC_DIR}/python/include")
-target_compile_options(giotto_persistent_cohomology PUBLIC -Ofast -shared -pthread -fPIC -fwrapv -Wall -fno-strict-aliasing
+target_link_libraries(gtda_persistent_cohomology LINK_PUBLIC ${Boost_LIBRARIES})
+target_include_directories(gtda_persistent_cohomology PRIVATE "${GUDHI_SRC_DIR}/Persistent_cohomology/include")
+target_include_directories(gtda_persistent_cohomology PRIVATE "${GUDHI_SRC_DIR}/common/include")
+target_include_directories(gtda_persistent_cohomology PRIVATE "${GUDHI_SRC_DIR}/Bitmap_cubical_complex/include")
+target_include_directories(gtda_persistent_cohomology PRIVATE "${GUDHI_SRC_DIR}/python/include")
+target_compile_options(gtda_persistent_cohomology PUBLIC -Ofast -shared -pthread -fPIC -fwrapv -Wall -fno-strict-aliasing
   -frounding-math)
-target_compile_options(giotto_persistent_cohomology PUBLIC $<$<CONFIG:DEBUG>:-O2 -ggdb -D_GLIBCXX_DEBUG>)
+target_compile_options(gtda_persistent_cohomology PUBLIC $<$<CONFIG:DEBUG>:-O2 -ggdb -D_GLIBCXX_DEBUG>)
 
 # Cannot have two inlined namespace !
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-  target_compile_options(giotto_persistent_cohomology PUBLIC -march=native -D_GLIBCXX_PARALLEL)
-  target_link_libraries(giotto_persistent_cohomology PRIVATE)
+  target_compile_options(gtda_persistent_cohomology PUBLIC -march=native -D_GLIBCXX_PARALLEL)
+  target_link_libraries(gtda_persistent_cohomology PRIVATE)
 endif()
-target_compile_definitions(giotto_persistent_cohomology PRIVATE BOOST_RESULT_OF_USE_DECLTYPE=1 BOOST_ALL_NO_LIB=1 BOOST_SYSTEM_NO_DEPRECATED=1)
+target_compile_definitions(gtda_persistent_cohomology PRIVATE BOOST_RESULT_OF_USE_DECLTYPE=1 BOOST_ALL_NO_LIB=1 BOOST_SYSTEM_NO_DEPRECATED=1)
 
 #######################################################################
 #                            Simplex Tree                             #
 #######################################################################
 
-pybind11_add_module(giotto_simplex_tree "${BINDINGS_DIR}/simplex_tree_bindings.cpp")
+pybind11_add_module(gtda_simplex_tree "${BINDINGS_DIR}/simplex_tree_bindings.cpp")
 if(OpenMP_FOUND)
-  target_link_libraries(giotto_simplex_tree PRIVATE OpenMP::OpenMP_CXX)
+  target_link_libraries(gtda_simplex_tree PRIVATE OpenMP::OpenMP_CXX)
 endif()
-target_link_libraries(giotto_simplex_tree LINK_PUBLIC ${Boost_LIBRARIES})
-target_include_directories(giotto_simplex_tree PRIVATE "${GUDHI_SRC_DIR}/Simplex_tree/include")
-target_include_directories(giotto_simplex_tree PRIVATE "${GUDHI_SRC_DIR}/common/include")
-target_include_directories(giotto_simplex_tree PRIVATE "${GUDHI_SRC_DIR}/Cech_complex/include")
-target_include_directories(giotto_simplex_tree PRIVATE "${GUDHI_SRC_DIR}/Persistent_cohomology/include")
-target_include_directories(giotto_simplex_tree PRIVATE "${GUDHI_SRC_DIR}/Subsampling/include")
-target_include_directories(giotto_simplex_tree PRIVATE "${GUDHI_SRC_DIR}/python/include")
-target_compile_options(giotto_simplex_tree PUBLIC -Ofast -shared -pthread -fPIC
+target_link_libraries(gtda_simplex_tree LINK_PUBLIC ${Boost_LIBRARIES})
+target_include_directories(gtda_simplex_tree PRIVATE "${GUDHI_SRC_DIR}/Simplex_tree/include")
+target_include_directories(gtda_simplex_tree PRIVATE "${GUDHI_SRC_DIR}/common/include")
+target_include_directories(gtda_simplex_tree PRIVATE "${GUDHI_SRC_DIR}/Cech_complex/include")
+target_include_directories(gtda_simplex_tree PRIVATE "${GUDHI_SRC_DIR}/Persistent_cohomology/include")
+target_include_directories(gtda_simplex_tree PRIVATE "${GUDHI_SRC_DIR}/Subsampling/include")
+target_include_directories(gtda_simplex_tree PRIVATE "${GUDHI_SRC_DIR}/python/include")
+target_compile_options(gtda_simplex_tree PUBLIC -Ofast -shared -pthread -fPIC
   -fwrapv -Wall -fno-strict-aliasing -frounding-math)
-target_compile_options(giotto_simplex_tree PUBLIC $<$<CONFIG:DEBUG>:-O2 -ggdb -D_GLIBCXX_DEBUG>)
+target_compile_options(gtda_simplex_tree PUBLIC $<$<CONFIG:DEBUG>:-O2 -ggdb -D_GLIBCXX_DEBUG>)
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-  target_compile_options(giotto_simplex_tree PUBLIC -march=native -D_GLIBCXX_PARALLEL)
-  target_link_libraries(giotto_simplex_tree PRIVATE)
+  target_compile_options(gtda_simplex_tree PUBLIC -march=native -D_GLIBCXX_PARALLEL)
+  target_link_libraries(gtda_simplex_tree PRIVATE)
 endif()
-target_compile_definitions(giotto_simplex_tree PRIVATE BOOST_RESULT_OF_USE_DECLTYPE=1 BOOST_ALL_NO_LIB=1 BOOST_SYSTEM_NO_DEPRECATED=1)
+target_compile_definitions(gtda_simplex_tree PRIVATE BOOST_RESULT_OF_USE_DECLTYPE=1 BOOST_ALL_NO_LIB=1 BOOST_SYSTEM_NO_DEPRECATED=1)
 
 #######################################################################
 #                      Periodic Cubical Complex                       #
 #######################################################################
 
-pybind11_add_module(giotto_periodic_cubical_complex "${BINDINGS_DIR}/periodic_cubical_complex_bindings.cpp")
+pybind11_add_module(gtda_periodic_cubical_complex "${BINDINGS_DIR}/periodic_cubical_complex_bindings.cpp")
 if(OpenMP_FOUND)
-  target_link_libraries(giotto_periodic_cubical_complex PRIVATE OpenMP::OpenMP_CXX)
+  target_link_libraries(gtda_periodic_cubical_complex PRIVATE OpenMP::OpenMP_CXX)
 endif()
-target_link_libraries(giotto_periodic_cubical_complex LINK_PUBLIC ${Boost_LIBRARIES})
-target_include_directories(giotto_periodic_cubical_complex PRIVATE "${GUDHI_SRC_DIR}/Bitmap_cubical_complex/include")
-target_include_directories(giotto_periodic_cubical_complex PRIVATE "${GUDHI_SRC_DIR}/Persistent_cohomology/include")
-target_include_directories(giotto_periodic_cubical_complex PRIVATE "${GUDHI_SRC_DIR}/python/include")
-target_include_directories(giotto_periodic_cubical_complex PRIVATE "${GUDHI_SRC_DIR}/common/include")
-target_compile_options(giotto_periodic_cubical_complex PUBLIC -Ofast -shared -pthread -fPIC -fwrapv -Wall -fno-strict-aliasing -frounding-math)
-target_compile_options(giotto_periodic_cubical_complex PUBLIC $<$<CONFIG:DEBUG>:-O2 -ggdb -D_GLIBCXX_DEBUG>)
+target_link_libraries(gtda_periodic_cubical_complex LINK_PUBLIC ${Boost_LIBRARIES})
+target_include_directories(gtda_periodic_cubical_complex PRIVATE "${GUDHI_SRC_DIR}/Bitmap_cubical_complex/include")
+target_include_directories(gtda_periodic_cubical_complex PRIVATE "${GUDHI_SRC_DIR}/Persistent_cohomology/include")
+target_include_directories(gtda_periodic_cubical_complex PRIVATE "${GUDHI_SRC_DIR}/python/include")
+target_include_directories(gtda_periodic_cubical_complex PRIVATE "${GUDHI_SRC_DIR}/common/include")
+target_compile_options(gtda_periodic_cubical_complex PUBLIC -Ofast -shared -pthread -fPIC -fwrapv -Wall -fno-strict-aliasing -frounding-math)
+target_compile_options(gtda_periodic_cubical_complex PUBLIC $<$<CONFIG:DEBUG>:-O2 -ggdb -D_GLIBCXX_DEBUG>)
 
 # Cannot have two inlined namespace !
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-  target_compile_options(giotto_periodic_cubical_complex PUBLIC -march=native -D_GLIBCXX_PARALLEL)
-  target_link_libraries(giotto_periodic_cubical_complex PRIVATE)
+  target_compile_options(gtda_periodic_cubical_complex PUBLIC -march=native -D_GLIBCXX_PARALLEL)
+  target_link_libraries(gtda_periodic_cubical_complex PRIVATE)
 endif()
 
-target_compile_definitions(giotto_periodic_cubical_complex PRIVATE BOOST_RESULT_OF_USE_DECLTYPE=1 BOOST_ALL_NO_LIB=1 BOOST_SYSTEM_NO_DEPRECATED=1)
+target_compile_definitions(gtda_periodic_cubical_complex PRIVATE BOOST_RESULT_OF_USE_DECLTYPE=1 BOOST_ALL_NO_LIB=1 BOOST_SYSTEM_NO_DEPRECATED=1)
 
 #######################################################################
 #                           Witness Complex                           #
 #######################################################################
 
-pybind11_add_module(giotto_witness_complex "${BINDINGS_DIR}/witness_complex_bindings.cpp")
+pybind11_add_module(gtda_witness_complex "${BINDINGS_DIR}/witness_complex_bindings.cpp")
 if(OpenMP_FOUND)
-  target_link_libraries(giotto_witness_complex PRIVATE OpenMP::OpenMP_CXX)
+  target_link_libraries(gtda_witness_complex PRIVATE OpenMP::OpenMP_CXX)
 endif()
-target_link_libraries(giotto_witness_complex LINK_PUBLIC ${Boost_LIBRARIES})
-target_include_directories(giotto_witness_complex PRIVATE "${GUDHI_SRC_DIR}/Witness_complex/include")
-target_include_directories(giotto_witness_complex PRIVATE "${GUDHI_SRC_DIR}/Simplex_tree/include")
-target_include_directories(giotto_witness_complex PRIVATE "${GUDHI_SRC_DIR}/Cech_complex/include")
-target_include_directories(giotto_witness_complex PRIVATE "${GUDHI_SRC_DIR}/Persistent_cohomology/include")
-target_include_directories(giotto_witness_complex PRIVATE "${GUDHI_SRC_DIR}/python/include")
-target_include_directories(giotto_witness_complex PRIVATE "${GUDHI_SRC_DIR}/common/include")
-target_compile_options(giotto_witness_complex PUBLIC -Ofast -shared -pthread -fPIC -fwrapv -Wall -fno-strict-aliasing -frounding-math)
-target_compile_options(giotto_witness_complex PUBLIC $<$<CONFIG:DEBUG>:-O2 -ggdb -D_GLIBCXX_DEBUG>)
+target_link_libraries(gtda_witness_complex LINK_PUBLIC ${Boost_LIBRARIES})
+target_include_directories(gtda_witness_complex PRIVATE "${GUDHI_SRC_DIR}/Witness_complex/include")
+target_include_directories(gtda_witness_complex PRIVATE "${GUDHI_SRC_DIR}/Simplex_tree/include")
+target_include_directories(gtda_witness_complex PRIVATE "${GUDHI_SRC_DIR}/Cech_complex/include")
+target_include_directories(gtda_witness_complex PRIVATE "${GUDHI_SRC_DIR}/Persistent_cohomology/include")
+target_include_directories(gtda_witness_complex PRIVATE "${GUDHI_SRC_DIR}/python/include")
+target_include_directories(gtda_witness_complex PRIVATE "${GUDHI_SRC_DIR}/common/include")
+target_compile_options(gtda_witness_complex PUBLIC -Ofast -shared -pthread -fPIC -fwrapv -Wall -fno-strict-aliasing -frounding-math)
+target_compile_options(gtda_witness_complex PUBLIC $<$<CONFIG:DEBUG>:-O2 -ggdb -D_GLIBCXX_DEBUG>)
 
 # Cannot have two inlined namespace !
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-  target_compile_options(giotto_witness_complex PUBLIC -march=native -D_GLIBCXX_PARALLEL)
-  target_link_libraries(giotto_witness_complex PRIVATE)
+  target_compile_options(gtda_witness_complex PUBLIC -march=native -D_GLIBCXX_PARALLEL)
+  target_link_libraries(gtda_witness_complex PRIVATE)
 endif()
 
-target_compile_definitions(giotto_witness_complex PRIVATE BOOST_RESULT_OF_USE_DECLTYPE=1 BOOST_ALL_NO_LIB=1 BOOST_SYSTEM_NO_DEPRECATED=1)
+target_compile_definitions(gtda_witness_complex PRIVATE BOOST_RESULT_OF_USE_DECLTYPE=1 BOOST_ALL_NO_LIB=1 BOOST_SYSTEM_NO_DEPRECATED=1)
 
 #######################################################################
 #                       Strong Witness Complex                        #
 #######################################################################
 
-pybind11_add_module(giotto_strong_witness_complex "${BINDINGS_DIR}/strong_witness_complex_bindings.cpp")
+pybind11_add_module(gtda_strong_witness_complex "${BINDINGS_DIR}/strong_witness_complex_bindings.cpp")
 if(OpenMP_FOUND)
-  target_link_libraries(giotto_strong_witness_complex PRIVATE OpenMP::OpenMP_CXX)
+  target_link_libraries(gtda_strong_witness_complex PRIVATE OpenMP::OpenMP_CXX)
 endif()
-target_link_libraries(giotto_strong_witness_complex LINK_PUBLIC ${Boost_LIBRARIES})
-target_include_directories(giotto_strong_witness_complex PRIVATE "${GUDHI_SRC_DIR}/Witness_complex/include")
-target_include_directories(giotto_strong_witness_complex PRIVATE "${GUDHI_SRC_DIR}/Simplex_tree/include")
-target_include_directories(giotto_strong_witness_complex PRIVATE "${GUDHI_SRC_DIR}/Cech_complex/include")
-target_include_directories(giotto_strong_witness_complex PRIVATE "${GUDHI_SRC_DIR}/Persistent_cohomology/include")
-target_include_directories(giotto_strong_witness_complex PRIVATE "${GUDHI_SRC_DIR}/python/include")
-target_include_directories(giotto_strong_witness_complex PRIVATE "${GUDHI_SRC_DIR}/common/include")
-target_compile_options(giotto_strong_witness_complex PUBLIC -Ofast -shared -pthread -fPIC -fwrapv -Wall -fno-strict-aliasing -frounding-math)
-target_compile_options(giotto_strong_witness_complex PUBLIC $<$<CONFIG:DEBUG>:-O2 -ggdb -D_GLIBCXX_DEBUG>)
+target_link_libraries(gtda_strong_witness_complex LINK_PUBLIC ${Boost_LIBRARIES})
+target_include_directories(gtda_strong_witness_complex PRIVATE "${GUDHI_SRC_DIR}/Witness_complex/include")
+target_include_directories(gtda_strong_witness_complex PRIVATE "${GUDHI_SRC_DIR}/Simplex_tree/include")
+target_include_directories(gtda_strong_witness_complex PRIVATE "${GUDHI_SRC_DIR}/Cech_complex/include")
+target_include_directories(gtda_strong_witness_complex PRIVATE "${GUDHI_SRC_DIR}/Persistent_cohomology/include")
+target_include_directories(gtda_strong_witness_complex PRIVATE "${GUDHI_SRC_DIR}/python/include")
+target_include_directories(gtda_strong_witness_complex PRIVATE "${GUDHI_SRC_DIR}/common/include")
+target_compile_options(gtda_strong_witness_complex PUBLIC -Ofast -shared -pthread -fPIC -fwrapv -Wall -fno-strict-aliasing -frounding-math)
+target_compile_options(gtda_strong_witness_complex PUBLIC $<$<CONFIG:DEBUG>:-O2 -ggdb -D_GLIBCXX_DEBUG>)
 
 # Cannot have two inlined namespace !
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-  target_compile_options(giotto_strong_witness_complex PUBLIC -march=native -D_GLIBCXX_PARALLEL)
-  target_link_libraries(giotto_strong_witness_complex PRIVATE)
+  target_compile_options(gtda_strong_witness_complex PUBLIC -march=native -D_GLIBCXX_PARALLEL)
+  target_link_libraries(gtda_strong_witness_complex PRIVATE)
 endif()
 
-target_compile_definitions(giotto_strong_witness_complex PRIVATE BOOST_RESULT_OF_USE_DECLTYPE=1 BOOST_ALL_NO_LIB=1 BOOST_SYSTEM_NO_DEPRECATED=1)
+target_compile_definitions(gtda_strong_witness_complex PRIVATE BOOST_RESULT_OF_USE_DECLTYPE=1 BOOST_ALL_NO_LIB=1 BOOST_SYSTEM_NO_DEPRECATED=1)
 
 #######################################################################
 #                             RipsComplex                             #
 #######################################################################
 
-pybind11_add_module(giotto_sparse_rips_complex "${BINDINGS_DIR}/rips_complex_bindings.cpp")
+pybind11_add_module(gtda_sparse_rips_complex "${BINDINGS_DIR}/rips_complex_bindings.cpp")
 if(OpenMP_FOUND)
-  target_link_libraries(giotto_sparse_rips_complex PRIVATE OpenMP::OpenMP_CXX)
+  target_link_libraries(gtda_sparse_rips_complex PRIVATE OpenMP::OpenMP_CXX)
 endif()
-target_link_libraries(giotto_sparse_rips_complex LINK_PUBLIC ${Boost_LIBRARIES})
-target_include_directories(giotto_sparse_rips_complex PRIVATE "${GUDHI_SRC_DIR}/Simplex_tree/include")
-target_include_directories(giotto_sparse_rips_complex PRIVATE "${GUDHI_SRC_DIR}/common/include")
-target_include_directories(giotto_sparse_rips_complex PRIVATE "${GUDHI_SRC_DIR}/Cech_complex/include")
-target_include_directories(giotto_sparse_rips_complex PRIVATE "${GUDHI_SRC_DIR}/Persistent_cohomology/include")
-target_include_directories(giotto_sparse_rips_complex PRIVATE "${GUDHI_SRC_DIR}/Rips_complex/include")
-target_include_directories(giotto_sparse_rips_complex PRIVATE "${GUDHI_SRC_DIR}/Subsampling/include")
-target_include_directories(giotto_sparse_rips_complex PRIVATE "${GUDHI_SRC_DIR}/python/include")
-target_compile_options(giotto_sparse_rips_complex PUBLIC -Ofast -shared -pthread -fPIC
+target_link_libraries(gtda_sparse_rips_complex LINK_PUBLIC ${Boost_LIBRARIES})
+target_include_directories(gtda_sparse_rips_complex PRIVATE "${GUDHI_SRC_DIR}/Simplex_tree/include")
+target_include_directories(gtda_sparse_rips_complex PRIVATE "${GUDHI_SRC_DIR}/common/include")
+target_include_directories(gtda_sparse_rips_complex PRIVATE "${GUDHI_SRC_DIR}/Cech_complex/include")
+target_include_directories(gtda_sparse_rips_complex PRIVATE "${GUDHI_SRC_DIR}/Persistent_cohomology/include")
+target_include_directories(gtda_sparse_rips_complex PRIVATE "${GUDHI_SRC_DIR}/Rips_complex/include")
+target_include_directories(gtda_sparse_rips_complex PRIVATE "${GUDHI_SRC_DIR}/Subsampling/include")
+target_include_directories(gtda_sparse_rips_complex PRIVATE "${GUDHI_SRC_DIR}/python/include")
+target_compile_options(gtda_sparse_rips_complex PUBLIC -Ofast -shared -pthread -fPIC
   -fwrapv -Wall -fno-strict-aliasing -frounding-math)
-target_compile_options(giotto_sparse_rips_complex PUBLIC $<$<CONFIG:DEBUG>:-O2 -ggdb -D_GLIBCXX_DEBUG>)
+target_compile_options(gtda_sparse_rips_complex PUBLIC $<$<CONFIG:DEBUG>:-O2 -ggdb -D_GLIBCXX_DEBUG>)
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-  target_compile_options(giotto_sparse_rips_complex PUBLIC -march=native -D_GLIBCXX_PARALLEL)
-  target_link_libraries(giotto_sparse_rips_complex PRIVATE)
+  target_compile_options(gtda_sparse_rips_complex PUBLIC -march=native -D_GLIBCXX_PARALLEL)
+  target_link_libraries(gtda_sparse_rips_complex PRIVATE)
 endif()
 
-target_compile_definitions(giotto_sparse_rips_complex PRIVATE BOOST_RESULT_OF_USE_DECLTYPE=1 BOOST_ALL_NO_LIB=1 BOOST_SYSTEM_NO_DEPRECATED=1)
+target_compile_definitions(gtda_sparse_rips_complex PRIVATE BOOST_RESULT_OF_USE_DECLTYPE=1 BOOST_ALL_NO_LIB=1 BOOST_SYSTEM_NO_DEPRECATED=1)
 
 #######################################################################
 #                            Cech Complex                             #
 #######################################################################
 
-pybind11_add_module(giotto_cech_complex "${BINDINGS_DIR}/cech_complex_bindings.cpp")
+pybind11_add_module(gtda_cech_complex "${BINDINGS_DIR}/cech_complex_bindings.cpp")
 if(OpenMP_FOUND)
-  target_link_libraries(giotto_cech_complex PRIVATE OpenMP::OpenMP_CXX)
+  target_link_libraries(gtda_cech_complex PRIVATE OpenMP::OpenMP_CXX)
 endif()
-target_link_libraries(giotto_cech_complex LINK_PUBLIC ${Boost_LIBRARIES})
-target_include_directories(giotto_cech_complex PRIVATE "${GUDHI_SRC_DIR}/Simplex_tree/include")
-target_include_directories(giotto_cech_complex PRIVATE "${GUDHI_SRC_DIR}/Cech_complex/include")
-target_include_directories(giotto_cech_complex PRIVATE "${GUDHI_SRC_DIR}/Persistent_cohomology/include")
-target_include_directories(giotto_cech_complex PRIVATE "${GUDHI_SRC_DIR}/python/include")
-target_include_directories(giotto_cech_complex PRIVATE "${GUDHI_SRC_DIR}/common/include")
-target_compile_options(giotto_cech_complex PUBLIC -Ofast -shared -pthread -fPIC -fwrapv -Wall -fno-strict-aliasing -frounding-math)
-target_compile_options(giotto_cech_complex PUBLIC $<$<CONFIG:DEBUG>:-O2 -ggdb -D_GLIBCXX_DEBUG>)
+target_link_libraries(gtda_cech_complex LINK_PUBLIC ${Boost_LIBRARIES})
+target_include_directories(gtda_cech_complex PRIVATE "${GUDHI_SRC_DIR}/Simplex_tree/include")
+target_include_directories(gtda_cech_complex PRIVATE "${GUDHI_SRC_DIR}/Cech_complex/include")
+target_include_directories(gtda_cech_complex PRIVATE "${GUDHI_SRC_DIR}/Persistent_cohomology/include")
+target_include_directories(gtda_cech_complex PRIVATE "${GUDHI_SRC_DIR}/python/include")
+target_include_directories(gtda_cech_complex PRIVATE "${GUDHI_SRC_DIR}/common/include")
+target_compile_options(gtda_cech_complex PUBLIC -Ofast -shared -pthread -fPIC -fwrapv -Wall -fno-strict-aliasing -frounding-math)
+target_compile_options(gtda_cech_complex PUBLIC $<$<CONFIG:DEBUG>:-O2 -ggdb -D_GLIBCXX_DEBUG>)
 
 # Cannot have two inlined namespace !
 if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-  target_compile_options(giotto_cech_complex PUBLIC -march=native -D_GLIBCXX_PARALLEL)
-  target_link_libraries(giotto_cech_complex PRIVATE)
+  target_compile_options(gtda_cech_complex PUBLIC -march=native -D_GLIBCXX_PARALLEL)
+  target_link_libraries(gtda_cech_complex PRIVATE)
 endif()
 
-target_compile_definitions(giotto_cech_complex PRIVATE BOOST_RESULT_OF_USE_DECLTYPE=1 BOOST_ALL_NO_LIB=1 BOOST_SYSTEM_NO_DEPRECATED=1)
+target_compile_definitions(gtda_cech_complex PRIVATE BOOST_RESULT_OF_USE_DECLTYPE=1 BOOST_ALL_NO_LIB=1 BOOST_SYSTEM_NO_DEPRECATED=1)

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -1,8 +1,8 @@
 # License: GNU AGPLv3
 
 import numpy as np
-from ..externals.modules.giotto_bottleneck import bottleneck_distance
-from ..externals.modules.giotto_wasserstein import wasserstein_distance
+from ..externals.modules.gtda_bottleneck import bottleneck_distance
+from ..externals.modules.gtda_wasserstein import wasserstein_distance
 from joblib import Parallel, delayed, effective_n_jobs
 from scipy.ndimage import gaussian_filter
 from scipy.spatial.distance import cdist, pdist, squareform

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -1,8 +1,8 @@
 # License: GNU AGPLv3
 
 import numpy as np
-from gtda.externals.modules.giotto_bottleneck import bottleneck_distance
-from gtda.externals.modules.giotto_wasserstein import wasserstein_distance
+from ..externals.modules.giotto_bottleneck import bottleneck_distance
+from ..externals.modules.giotto_wasserstein import wasserstein_distance
 from joblib import Parallel, delayed, effective_n_jobs
 from scipy.ndimage import gaussian_filter
 from scipy.spatial.distance import cdist, pdist, squareform

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -1,8 +1,8 @@
 # License: GNU AGPLv3
 
 import numpy as np
-from giotto_bottleneck import bottleneck_distance
-from giotto_wasserstein import wasserstein_distance
+from gtda.externals.modules.giotto_bottleneck import bottleneck_distance
+from gtda.externals.modules.giotto_wasserstein import wasserstein_distance
 from joblib import Parallel, delayed, effective_n_jobs
 from scipy.ndimage import gaussian_filter
 from scipy.spatial.distance import cdist, pdist, squareform

--- a/gtda/externals/bindings/bottleneck_bindings.cpp
+++ b/gtda/externals/bindings/bottleneck_bindings.cpp
@@ -21,7 +21,7 @@ double bottleneck_distance(const std::vector<std::pair<double, double>>& dgm1,
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(giotto_bottleneck, m) {
+PYBIND11_MODULE(gtda_bottleneck, m) {
   m.doc() = "bottleneck dionysus implementation";
   using namespace pybind11::literals;
   m.def("bottleneck_distance", &bottleneck_distance, "dgm1"_a, "dgm2"_a,

--- a/gtda/externals/bindings/cech_complex_bindings.cpp
+++ b/gtda/externals/bindings/cech_complex_bindings.cpp
@@ -51,7 +51,7 @@ class Cech_complex_interface {
 }  // namespace cech_complex
 }  // namespace Gudhi
 
-PYBIND11_MODULE(giotto_cech_complex, m) {
+PYBIND11_MODULE(gtda_cech_complex, m) {
   using namespace pybind11::literals;
   using Simplex_tree =
       Gudhi::Simplex_tree<Gudhi::Simplex_tree_options_fast_persistence>;

--- a/gtda/externals/bindings/cubical_complex_bindings.cpp
+++ b/gtda/externals/bindings/cubical_complex_bindings.cpp
@@ -17,7 +17,7 @@
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(giotto_cubical_complex, m) {
+PYBIND11_MODULE(gtda_cubical_complex, m) {
   using namespace pybind11::literals;
   using Cubical_complex_interface_inst =
       Gudhi::cubical_complex::Cubical_complex_interface<>;

--- a/gtda/externals/bindings/periodic_cubical_complex_bindings.cpp
+++ b/gtda/externals/bindings/periodic_cubical_complex_bindings.cpp
@@ -18,7 +18,7 @@
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(giotto_periodic_cubical_complex, m) {
+PYBIND11_MODULE(gtda_periodic_cubical_complex, m) {
   using Periodic_cubical_complex_inst =
       Gudhi::cubical_complex::Cubical_complex_interface<
           Gudhi::cubical_complex::

--- a/gtda/externals/bindings/persistent_cohomology_bindings.cpp
+++ b/gtda/externals/bindings/persistent_cohomology_bindings.cpp
@@ -11,7 +11,7 @@
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(giotto_persistent_cohomology, m) {
+PYBIND11_MODULE(gtda_persistent_cohomology, m) {
   using Persistent_cohomology_interface_inst =
       Gudhi::Persistent_cohomology_interface<
           Gudhi::cubical_complex::Cubical_complex_interface<>>;

--- a/gtda/externals/bindings/rips_complex_bindings.cpp
+++ b/gtda/externals/bindings/rips_complex_bindings.cpp
@@ -10,7 +10,7 @@
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(giotto_sparse_rips_complex, m) {
+PYBIND11_MODULE(gtda_sparse_rips_complex, m) {
   py::class_<Gudhi::rips_complex::Rips_complex_interface>(
       m, "Rips_complex_interface")
       .def(py::init<>())

--- a/gtda/externals/bindings/ripser_bindings.cpp
+++ b/gtda/externals/bindings/ripser_bindings.cpp
@@ -12,7 +12,7 @@
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(giotto_ripser, m) {
+PYBIND11_MODULE(gtda_ripser, m) {
   m.doc() = "Ripser python interface";
   py::class_<ripserResults>(m, "ripserResults")
       .def_readwrite("births_and_deaths_by_dim",

--- a/gtda/externals/bindings/simplex_tree_bindings.cpp
+++ b/gtda/externals/bindings/simplex_tree_bindings.cpp
@@ -13,7 +13,7 @@
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(giotto_simplex_tree, m) {
+PYBIND11_MODULE(gtda_simplex_tree, m) {
   // Simplex_tree_interface_full_featured
   using simplex_tree_interface_inst = Gudhi::Simplex_tree_interface<>;
   py::class_<simplex_tree_interface_inst>(

--- a/gtda/externals/bindings/strong_witness_complex_bindings.cpp
+++ b/gtda/externals/bindings/strong_witness_complex_bindings.cpp
@@ -11,7 +11,7 @@
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(giotto_strong_witness_complex, m) {
+PYBIND11_MODULE(gtda_strong_witness_complex, m) {
   using simplex_tree_interface_inst = Gudhi::Simplex_tree_interface<>;
   using strong_witness_interface_inst =
       Gudhi::witness_complex::Strong_witness_complex_interface;

--- a/gtda/externals/bindings/wasserstein_bindings.cpp
+++ b/gtda/externals/bindings/wasserstein_bindings.cpp
@@ -27,7 +27,7 @@ double wasserstein_distance(const std::vector<std::pair<double, double>>& dgm1,
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(giotto_wasserstein, m) {
+PYBIND11_MODULE(gtda_wasserstein, m) {
   m.doc() = "wasserstein dionysus implementation";
   using namespace pybind11::literals;
   m.def("wasserstein_distance", &wasserstein_distance, "dgm1"_a, "dgm2"_a,

--- a/gtda/externals/bindings/witness_complex_bindings.cpp
+++ b/gtda/externals/bindings/witness_complex_bindings.cpp
@@ -11,7 +11,7 @@
 
 namespace py = pybind11;
 
-PYBIND11_MODULE(giotto_witness_complex, m) {
+PYBIND11_MODULE(gtda_witness_complex, m) {
   using simplex_tree_interface_inst = Gudhi::Simplex_tree_interface<>;
   using witness_interface_inst =
       Gudhi::witness_complex::Witness_complex_interface;

--- a/gtda/externals/python/cech_complex_interface.py
+++ b/gtda/externals/python/cech_complex_interface.py
@@ -1,4 +1,4 @@
-from ..modules.giotto_cech_complex import Cech_complex_interface
+from ..modules.gtda_cech_complex import Cech_complex_interface
 from . import SimplexTree
 
 

--- a/gtda/externals/python/cech_complex_interface.py
+++ b/gtda/externals/python/cech_complex_interface.py
@@ -1,4 +1,4 @@
-from giotto_cech_complex import Cech_complex_interface
+from gtda.externals.modules.giotto_cech_complex import Cech_complex_interface
 from . import SimplexTree
 
 

--- a/gtda/externals/python/cech_complex_interface.py
+++ b/gtda/externals/python/cech_complex_interface.py
@@ -1,4 +1,4 @@
-from gtda.externals.modules.giotto_cech_complex import Cech_complex_interface
+from ..modules.giotto_cech_complex import Cech_complex_interface
 from . import SimplexTree
 
 

--- a/gtda/externals/python/cubical_complex_interface.py
+++ b/gtda/externals/python/cubical_complex_interface.py
@@ -1,9 +1,9 @@
 import os
 import numpy as np
-from ..modules.giotto_cubical_complex \
+from ..modules.gtda_cubical_complex \
     import Cubical_complex_interface \
     as Bitmap_cubical_complex_base_interface
-from ..modules.giotto_persistent_cohomology \
+from ..modules.gtda_persistent_cohomology \
     import Persistent_cohomology_interface \
     as Cubical_complex_persistence_interface
 

--- a/gtda/externals/python/cubical_complex_interface.py
+++ b/gtda/externals/python/cubical_complex_interface.py
@@ -1,9 +1,9 @@
 import os
 import numpy as np
-from giotto_cubical_complex \
+from gtda.externals.modules.giotto_cubical_complex \
     import Cubical_complex_interface \
     as Bitmap_cubical_complex_base_interface
-from giotto_persistent_cohomology \
+from gtda.externals.modules.giotto_persistent_cohomology \
     import Persistent_cohomology_interface \
     as Cubical_complex_persistence_interface
 

--- a/gtda/externals/python/cubical_complex_interface.py
+++ b/gtda/externals/python/cubical_complex_interface.py
@@ -1,9 +1,9 @@
 import os
 import numpy as np
-from gtda.externals.modules.giotto_cubical_complex \
+from ..modules.giotto_cubical_complex \
     import Cubical_complex_interface \
     as Bitmap_cubical_complex_base_interface
-from gtda.externals.modules.giotto_persistent_cohomology \
+from ..modules.giotto_persistent_cohomology \
     import Persistent_cohomology_interface \
     as Cubical_complex_persistence_interface
 

--- a/gtda/externals/python/periodic_cubical_complex_interface.py
+++ b/gtda/externals/python/periodic_cubical_complex_interface.py
@@ -1,6 +1,6 @@
 import os
 import numpy as np
-from giotto_periodic_cubical_complex import \
+from gtda.externals.modules.giotto_periodic_cubical_complex import \
     Periodic_cubical_complex_base_interface, \
     Periodic_cubical_complex_persistence_interface
 

--- a/gtda/externals/python/periodic_cubical_complex_interface.py
+++ b/gtda/externals/python/periodic_cubical_complex_interface.py
@@ -1,6 +1,6 @@
 import os
 import numpy as np
-from ..modules.giotto_periodic_cubical_complex import \
+from ..modules.gtda_periodic_cubical_complex import \
     Periodic_cubical_complex_base_interface, \
     Periodic_cubical_complex_persistence_interface
 

--- a/gtda/externals/python/periodic_cubical_complex_interface.py
+++ b/gtda/externals/python/periodic_cubical_complex_interface.py
@@ -1,6 +1,6 @@
 import os
 import numpy as np
-from gtda.externals.modules.giotto_periodic_cubical_complex import \
+from ..modules.giotto_periodic_cubical_complex import \
     Periodic_cubical_complex_base_interface, \
     Periodic_cubical_complex_persistence_interface
 

--- a/gtda/externals/python/rips_complex_interface.py
+++ b/gtda/externals/python/rips_complex_interface.py
@@ -1,4 +1,4 @@
-from ..modules.giotto_sparse_rips_complex \
+from ..modules.gtda_sparse_rips_complex \
     import Rips_complex_interface
 from . import SimplexTree
 

--- a/gtda/externals/python/rips_complex_interface.py
+++ b/gtda/externals/python/rips_complex_interface.py
@@ -1,4 +1,5 @@
-from giotto_sparse_rips_complex import Rips_complex_interface
+from gtda.externals.modules.giotto_sparse_rips_complex \
+    import Rips_complex_interface
 from . import SimplexTree
 
 

--- a/gtda/externals/python/rips_complex_interface.py
+++ b/gtda/externals/python/rips_complex_interface.py
@@ -1,4 +1,4 @@
-from gtda.externals.modules.giotto_sparse_rips_complex \
+from ..modules.giotto_sparse_rips_complex \
     import Rips_complex_interface
 from . import SimplexTree
 

--- a/gtda/externals/python/ripser_interface.py
+++ b/gtda/externals/python/ripser_interface.py
@@ -1,7 +1,7 @@
 from scipy import sparse
 import numpy as np
 from sklearn.metrics.pairwise import pairwise_distances
-from ..modules.giotto_ripser import rips_dm, rips_dm_sparse
+from ..modules.gtda_ripser import rips_dm, rips_dm_sparse
 
 
 def DRFDM(DParam, maxHomDim, thresh=-1, coeff=2, do_cocycles=1):

--- a/gtda/externals/python/ripser_interface.py
+++ b/gtda/externals/python/ripser_interface.py
@@ -1,7 +1,7 @@
 from scipy import sparse
 import numpy as np
 from sklearn.metrics.pairwise import pairwise_distances
-from gtda.externals.modules.giotto_ripser import rips_dm, rips_dm_sparse
+from ..modules.giotto_ripser import rips_dm, rips_dm_sparse
 
 
 def DRFDM(DParam, maxHomDim, thresh=-1, coeff=2, do_cocycles=1):

--- a/gtda/externals/python/ripser_interface.py
+++ b/gtda/externals/python/ripser_interface.py
@@ -1,7 +1,7 @@
 from scipy import sparse
 import numpy as np
 from sklearn.metrics.pairwise import pairwise_distances
-from giotto_ripser import rips_dm, rips_dm_sparse
+from gtda.externals.modules.giotto_ripser import rips_dm, rips_dm_sparse
 
 
 def DRFDM(DParam, maxHomDim, thresh=-1, coeff=2, do_cocycles=1):

--- a/gtda/externals/python/simplex_tree_interface.py
+++ b/gtda/externals/python/simplex_tree_interface.py
@@ -1,5 +1,5 @@
 import numpy as np
-from ..modules.giotto_simplex_tree import *
+from ..modules.gtda_simplex_tree import *
 
 
 class SimplexTree:

--- a/gtda/externals/python/simplex_tree_interface.py
+++ b/gtda/externals/python/simplex_tree_interface.py
@@ -1,5 +1,5 @@
 import numpy as np
-from gtda.externals.modules.giotto_simplex_tree import *
+from ..modules.giotto_simplex_tree import *
 
 
 class SimplexTree:

--- a/gtda/externals/python/simplex_tree_interface.py
+++ b/gtda/externals/python/simplex_tree_interface.py
@@ -1,5 +1,5 @@
 import numpy as np
-from giotto_simplex_tree import *
+from gtda.externals.modules.giotto_simplex_tree import *
 
 
 class SimplexTree:

--- a/gtda/externals/python/strong_witness_complex_interface.py
+++ b/gtda/externals/python/strong_witness_complex_interface.py
@@ -1,4 +1,5 @@
-from giotto_strong_witness_complex import Strong_witness_complex_interface
+from gtda.externals.modules.giotto_strong_witness_complex \
+    import Strong_witness_complex_interface
 from . import SimplexTree
 
 

--- a/gtda/externals/python/strong_witness_complex_interface.py
+++ b/gtda/externals/python/strong_witness_complex_interface.py
@@ -1,4 +1,4 @@
-from gtda.externals.modules.giotto_strong_witness_complex \
+from ..modules.giotto_strong_witness_complex \
     import Strong_witness_complex_interface
 from . import SimplexTree
 

--- a/gtda/externals/python/strong_witness_complex_interface.py
+++ b/gtda/externals/python/strong_witness_complex_interface.py
@@ -1,4 +1,4 @@
-from ..modules.giotto_strong_witness_complex \
+from ..modules.gtda_strong_witness_complex \
     import Strong_witness_complex_interface
 from . import SimplexTree
 

--- a/gtda/externals/python/witness_complex_interface.py
+++ b/gtda/externals/python/witness_complex_interface.py
@@ -1,4 +1,4 @@
-from gtda.externals.modules.giotto_witness_complex \
+from ..modules.giotto_witness_complex \
     import Witness_complex_interface
 from . import SimplexTree
 

--- a/gtda/externals/python/witness_complex_interface.py
+++ b/gtda/externals/python/witness_complex_interface.py
@@ -1,4 +1,5 @@
-from giotto_witness_complex import Witness_complex_interface
+from gtda.externals.modules.giotto_witness_complex \
+    import Witness_complex_interface
 from . import SimplexTree
 
 

--- a/gtda/externals/python/witness_complex_interface.py
+++ b/gtda/externals/python/witness_complex_interface.py
@@ -1,4 +1,4 @@
-from ..modules.giotto_witness_complex \
+from ..modules.gtda_witness_complex \
     import Witness_complex_interface
 from . import SimplexTree
 

--- a/setup.py
+++ b/setup.py
@@ -111,8 +111,8 @@ class CMakeBuild(build_ext):
                                '--init', '--recursive'])
 
     def build_extension(self, ext):
-        extdir = os.path.abspath(os.path.dirname(
-            self.get_ext_fullpath(ext.name)))
+        extdir = os.path.abspath(os.path.join(os.path.dirname(
+            self.get_ext_fullpath(ext.name)), 'gtda', 'externals', 'modules'))
         cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
                       '-DPYTHON_EXECUTABLE=' + sys.executable]
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/giotto-ai/giotto-tda/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#256 

#### What does this implement/fix? Explain your changes.

This PR moves all libraries generated by the compilation from the root folder to `gtda/externals/modules`.
As explained in issue #256, before users could directly import modules generated with the bindings.

```python
from giotto_bottleneck import bottleneck_distance
```

Now, they need to go through `gtda`
```python
from gtda.externals.modules import bottleneck_distance
```

#### Any other comments?

Let me know if you want them into a different folder before merging.
BTW, we could directly update modules names if necessary (add to this PR or create a new one)

<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
