### PR TITLE
Remove progress bars display in docker_scripts.sh

### DIFF
--- a/.azure-ci/docker_scripts.sh
+++ b/.azure-ci/docker_scripts.sh
@@ -7,6 +7,7 @@ echo "Start manylinux2010 docker build"
 PYTHON_PATH=$(eval find "/opt/python/*${python_ver}*" -print)
 export PATH="${PYTHON_PATH}/bin:${PATH}"
 pip install --upgrade pip==19.3.1 setuptools
+pip config set global.progress_bar off
 
 # Install CMake
 pip install cmake

--- a/.azure-ci/docker_scripts.sh
+++ b/.azure-ci/docker_scripts.sh
@@ -6,8 +6,8 @@ echo "Start manylinux2010 docker build"
 # Upgrade pip and setuptools. TODO: Monitor status of pip versions
 PYTHON_PATH=$(eval find "/opt/python/*${python_ver}*" -print)
 export PATH="${PYTHON_PATH}/bin:${PATH}"
-pip install --upgrade pip==19.3.1 setuptools
 pip config set global.progress_bar off
+pip install --upgrade pip==19.3.1 setuptools
 
 # Install CMake
 pip install cmake


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #297


#### What does this implement/fix? Explain your changes.
Sets the global `progress_bar` variable to `off` in the manylinux docker script to avoid verbose progress bar output in the Azure console. 