### PR TITLE
Run auditwheel repair for manylinux2010 wheels

### DIFF
--- a/.azure-ci/docker_scripts.sh
+++ b/.azure-ci/docker_scripts.sh
@@ -46,7 +46,7 @@ pip uninstall -y giotto-tda
 pip uninstall -y giotto-tda-nightly
 
 # Build wheels
-pip install "wheel~=0.34.1" "auditwheel~=3.1"
+pip install wheel==0.34.1 auditwheel==3.1.0
 python setup.py sdist bdist_wheel
 
 # Repair wheels with auditwheel

--- a/.azure-ci/docker_scripts.sh
+++ b/.azure-ci/docker_scripts.sh
@@ -51,3 +51,5 @@ python setup.py sdist bdist_wheel
 
 # Repair wheels with auditwheel
 auditwheel repair dist/*whl -w dist/
+# remove wheels that are not manylinux2010
+rm -rf dist/*-linux*.whl

--- a/.azure-ci/docker_scripts.sh
+++ b/.azure-ci/docker_scripts.sh
@@ -46,7 +46,7 @@ pip uninstall -y giotto-tda
 pip uninstall -y giotto-tda-nightly
 
 # Build wheels
-pip install wheel auditwheel
+pip install "wheel~=0.34.1" "auditwheel~=3.1"
 python setup.py sdist bdist_wheel
 
 # Repair wheels with auditwheel

--- a/.azure-ci/docker_scripts.sh
+++ b/.azure-ci/docker_scripts.sh
@@ -46,7 +46,7 @@ pip uninstall -y giotto-tda
 pip uninstall -y giotto-tda-nightly
 
 # Build wheels
-pip install wheel
+pip install wheel auditwheel
 python setup.py sdist bdist_wheel
 
 # Repair wheels with auditwheel

--- a/.azure-ci/docker_scripts.sh
+++ b/.azure-ci/docker_scripts.sh
@@ -48,3 +48,6 @@ pip uninstall -y giotto-tda-nightly
 # Build wheels
 pip install wheel
 python setup.py sdist bdist_wheel
+
+# Repair wheels with auditwheel
+auditwheel repair dist/*whl -w dist/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,6 @@ jobs:
       set -e
       python -m pip install --upgrade pip
       # remove wheels that are not manylinux2010
-      rm -rf dist/*-linux*.whl
       pip install dist/*manylinux2010*.whl
     displayName: 'Install the wheels'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ jobs:
       set -e
       python -m pip install --upgrade pip
       # remove wheels that are not manylinux2010
-      rm -rf dist/*-linux*.whl 
+      rm -rf dist/*-linux*.whl
       pip install dist/*manylinux2010*.whl
     displayName: 'Install the wheels'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ jobs:
   - script: |
       set -e
       python -m pip install --upgrade pip
-      pip install dist/*.whl
+      pip install dist/*manylinux2010*.whl
     displayName: 'Install the wheels'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,8 +93,7 @@ jobs:
   - bash: |
       set -e
       pip install twine
-      for f in dist/*linux* ; do sudo mv "$f" "${f/linux/manylinux2010}"; done
-      twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*
+      twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*manylinux2010*.whl
     condition: eq(variables['nightly_check'], 'true')
     displayName: 'Upload nightly wheels to PyPI'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,6 +54,8 @@ jobs:
   - script: |
       set -e
       python -m pip install --upgrade pip
+      # remove wheels that are not manylinux2010
+      rm -rf dist/*-linux*.whl 
       pip install dist/*manylinux2010*.whl
     displayName: 'Install the wheels'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,6 @@ jobs:
   - script: |
       set -e
       python -m pip install --upgrade pip
-      # remove wheels that are not manylinux2010
       pip install dist/*manylinux2010*.whl
     displayName: 'Install the wheels'
 


### PR DESCRIPTION
This applies https://github.com/pypa/auditwheel on the generated wheels for manylinux2010 (see https://www.python.org/dev/peps/pep-0571/#id53 ).
This ensures that the generated wheels include all the needed dynamic libraries.

 It used for instance used in the [multibuild](https://github.com/matthew-brett/multibuild) project [here](https://github.com/matthew-brett/multibuild/blob/815e2cdc9bee2a1cde50e0e3df7a59e79e1ddd76/manylinux_utils.sh#L51).

I'm not really sure if it would help with https://github.com/giotto-ai/giotto-tda/issues/308#issuecomment-588969060 but it shouldn't hurt.