### PR TITLE
Raise a warning or error on invalid overlap_frac in Onedcover

### DIFF
--- a/gtda/mapper/cover.py
+++ b/gtda/mapper/cover.py
@@ -93,12 +93,12 @@ class OneDimensionalCover(BaseEstimator, TransformerMixin):
         self.overlap_frac = overlap_frac
 
         if overlap_frac == 0.:
-            raise ValueError("The `overlap_frac` must be positive,"
-                             "as otherwise, the intervals will not cover"
+            raise ValueError("`overlap_frac` must be positive,"
+                             "as otherwise the intervals will not cover"
                              "the range")
         if overlap_frac <= 1e-8:
-            warnings.warn("The `overlap_frac` is close to zero,"
-                          "what might cause numerical issues and errors",
+            warnings.warn("`overlap_frac` is close to zero,"
+                          "which might cause numerical issues and errors",
                           RuntimeWarning)
 
     def _fit_uniform(self, X):

--- a/gtda/mapper/cover.py
+++ b/gtda/mapper/cover.py
@@ -3,6 +3,7 @@
 
 from functools import partial
 from itertools import product
+import warnings
 
 import numpy as np
 from scipy.stats import rankdata
@@ -84,12 +85,21 @@ class OneDimensionalCover(BaseEstimator, TransformerMixin):
 
     _hyperparameters = {'kind': [str, ['uniform', 'balanced']],
                         'n_intervals': [int, (1, np.inf)],
-                        'overlap_frac': [float, (0, 1)]}
+                        'overlap_frac': [float, (0., 1.)]}
 
     def __init__(self, kind='uniform', n_intervals=10, overlap_frac=0.1):
         self.kind = kind
         self.n_intervals = n_intervals
         self.overlap_frac = overlap_frac
+
+        if overlap_frac == 0.:
+            raise ValueError("The `overlap_frac` must be positive,"
+                             "as otherwise, the intervals will not cover"
+                             "the range")
+        if overlap_frac <= 1e-8:
+            warnings.warn("The `overlap_frac` is close to zero,"
+                          "what might cause numerical issues and errors",
+                          RuntimeWarning)
 
     def _fit_uniform(self, X):
         self.left_limits_, self.right_limits_ = self._find_interval_limits(

--- a/gtda/mapper/tests/test_cover.py
+++ b/gtda/mapper/tests/test_cover.py
@@ -36,7 +36,7 @@ def get_nb_intervals(draw):
 def get_overlap_fraction(draw):
     overlap = draw(floats(allow_nan=False,
                           allow_infinity=False,
-                          min_value=0., exclude_min=True,
+                          min_value=1e-6, exclude_min=True,
                           max_value=1., exclude_max=True),
                    )
     return overlap

--- a/gtda/mapper/tests/test_cover.py
+++ b/gtda/mapper/tests/test_cover.py
@@ -36,7 +36,7 @@ def get_nb_intervals(draw):
 def get_overlap_fraction(draw):
     overlap = draw(floats(allow_nan=False,
                           allow_infinity=False,
-                          min_value=1e-6, exclude_min=True,
+                          min_value=1e-8, exclude_min=True,
                           max_value=1., exclude_max=True),
                    )
     return overlap


### PR DESCRIPTION
#### Reference Issues/PRs
Hot fix for #313.

#### What does this implement/fix? Explain your changes.
Two modifications from the user perspective:
1. if `overlap_fraction=0.`, raise an error,
2. if it is small, but >0, produce a warning and continue with the execution. 

Are the thresholds that i set (for warning and error) ok?

#### Any other comments?
I believe  we should have a better solution in the long-term:
1. refactor validate_params,
2. decide how to treat this in the `transform` step.