### PR TITLE
Remove packaging of source distribution

### DIFF
--- a/.azure-ci/docker_scripts.sh
+++ b/.azure-ci/docker_scripts.sh
@@ -47,4 +47,4 @@ pip uninstall -y giotto-tda-nightly
 
 # Build wheels
 pip install wheel
-python setup.py sdist bdist_wheel
+python setup.py bdist_wheel

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -165,7 +165,7 @@ jobs:
   - script: |
       set -e
       pip install wheel
-      python setup.py sdist bdist_wheel
+      python setup.py bdist_wheel
     displayName: 'Build the wheels'
 
   - script: pip install dist/*.whl
@@ -270,7 +270,7 @@ jobs:
       set -e
       sed -i $'s/\r$//' README.rst
       pip install wheel
-      python setup.py sdist bdist_wheel
+      python setup.py bdist_wheel
     displayName: 'Build the wheels'
 
   - bash: pip install dist/*.whl


### PR DESCRIPTION
#### Reference Issues/PRs
#308


#### What does this implement/fix? Explain your changes.
Removes packaging of the source distribution from the CI steps. This has the important result that both the stable and the nightly packages will no longer come with `tar.gz` files on PyPI. However, in view of #308 this is desirable when compared with the current state of affairs.


#### Any other comments?
Not a real fix for #308, it simply throws the baby out with the bathwater.