### PR TITLE
Replace string formatting with f-strings except in setup and validation

### DIFF
--- a/examples/plotting.py
+++ b/examples/plotting.py
@@ -185,7 +185,7 @@ def plot_diagram(diagram, homology_dimensions=None):
                                showlegend=False, hoverinfo='none'))
     
     for i, dimension in enumerate(homology_dimensions):
-        name = "H{}".format(int(dimension))
+        name = f"H{int(dimension)}"
         subdiagram = _subdiagrams(np.asarray([diagram]), [dimension],
                                   remove_dim=True)[0]
         diff = (subdiagram[:, 1] != subdiagram[:, 0])
@@ -247,8 +247,8 @@ def plot_landscapes(landscapes, homology_dimensions=None, samplings=None):
     
     for i, dimension in enumerate(homology_dimensions):
         layout_dim = layout.copy()
-        layout_dim['title'] = "Persistence landscape for homology dimension" + \
-                              "{}".format(int(dimension))
+        layout_dim['title'] = f"Persistence landscape for homology "\
+                              f"dimension {int(dimension)}"
         fig = gobj.Figure(layout=layout_dim)
         fig.update_xaxes(zeroline=True, linewidth=1, linecolor='black',
                          mirror=False)
@@ -261,7 +261,7 @@ def plot_landscapes(landscapes, homology_dimensions=None, samplings=None):
                                        y=landscapes[i, layer, :],
                                        mode='lines', showlegend=False,
                                        hoverinfo='none',
-                                       name="layer {}".format(layer + 1)))
+                                       name=f"layer {layer + 1}"))
 
         fig.show()
 
@@ -386,8 +386,9 @@ def plot_betti_surfaces(betti_curves, samplings=None,
     else:
         for i, dimension in enumerate(homology_dimensions):
             fig = gobj.Figure()
-            fig.update_layout(scene=scene, title="Betti surface for homology "
-                                                 "dimension {}".format(int(dimension)))
+            fig.update_layout(scene=scene,
+                              title=f"Betti surface for homology "
+                                    f"dimension {int(dimension)}")
             fig.add_trace(gobj.Surface(x=samplings,
                                        y=np.arange(betti_curves.shape[0]),
                                        z=betti_curves[:, i, :],

--- a/gtda/diagrams/tests/test_features.py
+++ b/gtda/diagrams/tests/test_features.py
@@ -85,11 +85,11 @@ dims_gen = arrays(
 
 
 def _validate_distinct(X):
-    unique_values = [np.unique(x[0:2, :]) for x in X]
+    """Check if, in X, there is any persistence diagram for which all births
+    and deaths are equal."""
+    unique_values = [np.unique(x[:, 0:2]) for x in X]
     if np.any([len(u) < 2 for u in unique_values]):
-        raise ValueError("There should be at least two distinct points"
-                         "in the persistent diagrams:" +
-                         "now, only {} is present".format(*unique_values))
+        raise ValueError
     return 0
 
 

--- a/gtda/mapper/cluster.py
+++ b/gtda/mapper/cluster.py
@@ -295,11 +295,11 @@ class Agglomerative:
         memory = check_memory(self.memory)
 
         if self.linkage == "ward" and self.affinity != "euclidean":
-            raise ValueError("{} was provided as affinity. Ward can only work"
-                             "with Euclidean distances.".format(self.affinity))
+            raise ValueError(f"{self.affinity} was provided as affinity. "
+                             f"Ward can only work with Euclidean distances.")
         if self.linkage not in _TREE_BUILDERS:
-            raise ValueError("Unknown linkage type {}. Valid options are {}"
-                             .format(self.linkage, _TREE_BUILDERS.keys()))
+            raise ValueError(f"Unknown linkage type {self.linkage}. Valid "
+                             f"options are {_TREE_BUILDERS.keys()}")
         tree_builder = _TREE_BUILDERS[self.linkage]
 
         # Construct the tree

--- a/gtda/mapper/cover.py
+++ b/gtda/mapper/cover.py
@@ -286,8 +286,8 @@ class OneDimensionalCover(BaseEstimator, TransformerMixin):
         # in which case the fitted interval will be (-np.inf, np.inf).
         if only_one_pt and n_intervals > 1:
             raise ValueError(
-                "Only one unique filter value found, cannot fit {} > 1 "
-                "intervals.".format(n_intervals))
+                f"Only one unique filter value found, cannot fit "
+                f"{n_intervals} > 1 intervals.")
 
         left_limits, right_limits = \
             self._cover_limits(min_val, max_val, n_intervals, overlap_frac)
@@ -388,12 +388,12 @@ class CubicalCover(BaseEstimator, TransformerMixin):
         try:
             return getattr(clone(coverer), method_name)(X[:, [i]])
         except ValueError as ve:
-            if ve.args[0] == "Only one unique filter value found, cannot " \
-                             "fit {} > 1 intervals.".format(self.n_intervals):
+            if ve.args[0] == f"Only one unique filter value found, cannot " \
+                             f"fit {self.n_intervals} > 1 intervals.":
                 raise ValueError(
-                    "Only one unique filter value found along feature "
-                    "dimension {}, cannot fit {} > 1 intervals there.".format(
-                        i, self.n_intervals))
+                    f"Only one unique filter value found along feature "
+                    f"dimension {i}, cannot fit {self.n_intervals} > 1 "
+                    f"intervals there.")
             else:
                 raise ve
 
@@ -482,8 +482,8 @@ class CubicalCover(BaseEstimator, TransformerMixin):
         n_features = X.shape[1]
         if n_features != n_features_fit:
             raise DataDimensionalityWarning(
-                "Different number of columns between 'fit' ({}) and "
-                "'transform' ({}).".format(n_features_fit, n_features))
+                f"Different number of columns between 'fit' ({n_features_fit})"
+                f" and 'transform' ({n_features}).")
 
         if self.kind == 'balanced':
             # Test on the first coverer whether the left_limits_ and

--- a/gtda/mapper/pipeline.py
+++ b/gtda/mapper/pipeline.py
@@ -257,8 +257,8 @@ def make_mapper_pipeline(scaler=None,
     >>> # Find which points belong to first node of graph
     >>> node_id, node_elements = mapper_graph['node_metadata']['node_id'],
     ... mapper_graph['node_metadata']['node_elements']
-    >>> print('Node Id: {}, Node elements: {}, Data points: {}'
-              .format(node_id[0], node_elements[0], X[node_elements[0]]))
+    >>> print(f'Node Id: {node_id[0]}, Node elements: {node_elements[0]}, '
+              f'Data points: {X[node_elements[0]]}')
     Node Id: 0,
     Node elements: [8768],
     Data points: [[0.01838998 0.76928754 0.98199244 0.0074299 ]]

--- a/gtda/mapper/tests/test_cover.py
+++ b/gtda/mapper/tests/test_cover.py
@@ -67,8 +67,8 @@ def test_one_dimensional_cover_shape(filter_values, n_intervals):
         assert n_samples == unique_interval_masks.shape[0]
         assert n_intervals >= unique_interval_masks.shape[1]
     except ValueError as ve:
-        assert ve.args[0] == "Only one unique filter value found, cannot " \
-                             "fit {} > 1 intervals.".format(n_intervals)
+        assert ve.args[0] == f"Only one unique filter value found, cannot " \
+                             f"fit {n_intervals} > 1 intervals."
         assert (n_intervals > 1) and (len(np.unique(filter_values)) == 1)
 
 

--- a/gtda/mapper/utils/visualization.py
+++ b/gtda/mapper/utils/visualization.py
@@ -17,12 +17,11 @@ def _get_node_size(node_elements):
 
 def _get_node_text(graph):
     return [
-        ("Node ID:{}<br>Node size:{}").format(node_id, len(node_elements),)
+        f"Node ID:{node_id}<br>Node size:{len(node_elements)}"
         for node_id, node_elements in zip(
             graph["node_metadata"]["node_id"],
-            graph["node_metadata"]["node_elements"]
-        )
-    ]
+            graph["node_metadata"]["node_elements"])
+        ]
 
 
 def set_node_sizeref(node_elements, node_scale=12):
@@ -79,7 +78,7 @@ def _get_column_color_buttons(data, is_data_dataframe, node_elements,
                     'marker.cmax': [None, np.max(node_colors)],
                     'hoverlabel.bgcolor': [None, node_color_map]
                 }],
-                label='Column {}'.format(column),
+                label=f'Column {column}',
                 method='restyle'
             )
         )

--- a/gtda/pipeline.py
+++ b/gtda/pipeline.py
@@ -522,6 +522,6 @@ def make_pipeline(*steps, **kwargs):
     """
     memory = kwargs.pop('memory', None)
     if kwargs:
-        raise TypeError('Unknown keyword arguments: "{}"'
-                        .format(list(kwargs.keys())[0]))
+        raise TypeError(
+            f'Unknown keyword arguments: "{list(kwargs.keys())[0]}"')
     return Pipeline(pipeline._name_estimators(steps), memory=memory)

--- a/gtda/utils/_docs.py
+++ b/gtda/utils/_docs.py
@@ -14,22 +14,22 @@ outputs_end = '\n\n'
 
 def get_preamble_docs(docs):
     re_search = re.search(
-        '^(.*){}'.format(inputs_start), docs, flags=re.DOTALL)
+        f'^(.*){inputs_start}', docs, flags=re.DOTALL)
     return re_search.group(1)
 
 
 def get_inputs_docs(docs):
     re_search = re.search(
-        '{}(.*){}'.format(inputs_start, inputs_end), docs, flags=re.DOTALL)
+        f'{inputs_start}(.*){inputs_end}', docs, flags=re.DOTALL)
     return re_search.group(1)
 
 
 def get_outputs_docs(docs):
     re_search = re.search(
-        '{}(.*){}'.format(inputs_end, outputs_end), docs, flags=re.DOTALL)
+        f'{inputs_end}(.*){outputs_end}', docs, flags=re.DOTALL)
     if re_search is None:
         re_search = re.search(
-            '{}(.*)$'.format(inputs_end), docs, flags=re.DOTALL)
+            f'{inputs_end}(.*)$', docs, flags=re.DOTALL)
     return re_search.group(1)
 
 

--- a/setup.py
+++ b/setup.py
@@ -128,9 +128,9 @@ class CMakeBuild(build_ext):
         cfg = 'Debug' if self.debug else 'Release'
         build_args = ['--config', cfg]
 
-        if platform.system() == "Windows":
-            cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(
-                cfg.upper(), extdir)]
+        if platform.system() == 'Windows':
+            cmake_args += [f'-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{cfg.upper()}'
+                           f'={extdir}']
             if sys.maxsize > 2**32:
                 cmake_args += ['-A', 'x64']
             build_args += ['--', '/m']


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Since we require Python 3.6, f-strings can be used instead of string formatting methods. They are more readable and even slightly faster. This PR performs the change globally, with the only exceptions of `validation.py` -- because this needs refactoring anyway -- and `setup.py` -- because I was unable to deal with https://github.com/giotto-ai/giotto-tda/blob/d4e138c1a7014e961ed0e0011405a0a2f4a419e7/setup.py#L142