### PR TITLE
Bump joblib required version to 0.13

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ The latest stable version of giotto-tda requires:
 - Python (>= 3.6)
 - NumPy (>= 1.17.0)
 - SciPy (>= 0.17.0)
-- joblib (>= 0.11)
+- joblib (>= 0.13)
 - scikit-learn (>= 0.22.0)
 - python-igraph (>= 0.7.1.post6)
 - matplotlib (>= 3.0.3)

--- a/gtda/pipeline.py
+++ b/gtda/pipeline.py
@@ -111,20 +111,10 @@ class Pipeline(pipeline.Pipeline):
             step, param = pname.split('__', 1)
             fit_params_steps[step][param] = pval
         for step_idx, name, transformer in self._iter(with_final=False):
-            if hasattr(memory, 'location'):
-                # joblib >= 0.12
-                if memory.location is None:
-                    # we do not clone when caching is disabled to
-                    # preserve backward compatibility
-                    cloned_transformer = transformer
-                else:
-                    cloned_transformer = clone(transformer)
-            elif hasattr(memory, 'cachedir'):
-                # joblib < 0.11
-                if memory.cachedir is None:
-                    # we do not clone when caching is disabled to
-                    # preserve backward compatibility
-                    cloned_transformer = transformer
+            if hasattr(memory, 'location') and (memory.location is None):
+                # joblib >= 0.12. We do not clone when caching is disabled to
+                # preserve backward compatibility
+                cloned_transformer = transformer
             else:
                 cloned_transformer = clone(transformer)
             # Fit or load from cache the current transfomer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy >= 1.17.0
 scipy >= 0.17.0
-joblib >= 0.11
+joblib >= 0.13
 scikit-learn >= 0.22.0
 python-igraph >= 0.7.1.post6
 matplotlib >= 3.0.3


### PR DESCRIPTION
#### Reference Issues/PRs
#269


#### What does this implement/fix? Explain your changes.
As suggested by @rth in #269, this PR bumps the minimum required joblib version from the current v0.11 to v0.13 in `requirements.txt` and `README.rst`. Additionally, some lines have been removed from `gtda/pipeline.py` as they dealt with older versions of `joblib`.