### PR TITLE
Apply Gaussian filter in HeatKernel

### DIFF
--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -35,9 +35,9 @@ def landscapes(diagrams, sampling, n_layers):
     return fibers
 
 
-def _heat(heat, sampled_diag, sigma):
-    _sample_image(heat, sampled_diag)  # modifies `heat` inplace
-    heat = gaussian_filter(heat, sigma, mode="reflect")
+def _heat(image, sampled_diag, sigma):
+    _sample_image(image, sampled_diag)  # modifies `heat` inplace
+    image[:] = gaussian_filter(image, sigma, mode="reflect")
 
 
 def heats(diagrams, sampling, step_size, sigma):

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -73,11 +73,18 @@ def persistence_images(diagrams, sampling, step_size, weights, sigma):
         diagrams[:, :, axis] = np.array(
             (diagrams[:, :, axis] - sampling[0, axis]) / step_size[axis],
             dtype=int)
+    # Sample the image
+    [_sample_image(persistence_images_[i], sampled_diag)
+     for i, sampled_diag in enumerate(diagrams)]
 
-    [_heat(persistence_images_[i], sampled_diag, sigma)
-        for i, sampled_diag in enumerate(diagrams)]
-
+    # Apply the weights
     persistence_images_ *= weights / np.max(weights)
+
+    # Smoothen the weighted-image
+    for i, image in enumerate(persistence_images_):
+        persistence_images_[i] = gaussian_filter(image, sigma,
+                                                 mode="reflect")
+
     persistence_images_ = np.rot90(persistence_images_, k=1, axes=(1, 2))
     return persistence_images_
 

--- a/gtda/diagrams/tests/test_features.py
+++ b/gtda/diagrams/tests/test_features.py
@@ -139,7 +139,7 @@ def test_hk_positive(pts, dims):
 @given(pts_gen, dims_gen)
 def test_hk_big_sigma(pts, dims):
     """ We expect that with a huge sigma, the diagrams are so diluted that
-    they are almost 0. Effectively, verifies that the smoothing is really applied."""
+    they are almost 0. Effectively, verifies that the smoothing is applied."""
     n_bins = 10
     x = get_input(pts, dims)
 

--- a/gtda/diagrams/tests/test_features.py
+++ b/gtda/diagrams/tests/test_features.py
@@ -136,6 +136,19 @@ def test_hk_positive(pts, dims):
     assert np.all((np.tril(x_t[:, :, ::-1, :]) + 1e-13) >= 0.)
 
 
+@given(pts_gen, dims_gen)
+def test_hk_big_sigma(pts, dims):
+    """ We expect that with a huge sigma, the diagrams are so diluted that
+    they are almost 0. Effectively, verifies that the smoothing is really applied."""
+    n_bins = 10
+    x = get_input(pts, dims)
+
+    hk = HeatKernel(sigma=100*np.max(np.abs(x)), n_bins=n_bins)
+    x_t = hk.fit(x).transform(x)
+
+    assert np.all(np.abs(x_t) <= 1e-4)
+
+
 @given(pts_gen)
 def test_hk_with_diag_points(pts):
     """Add points on the diagonal, and verify that we have the same results


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #324.

#### What does this implement/fix? Explain your changes.
1. Make  sure that the sampled image in heat kernel is smoothed.
2. Refactor `persistence_image` so as the weights of  the points are taken into account **before** smoothing.
The point of PI seems to be to smoothen a 'dirac mass' with some weight, and not smoothen a dirac mass and apply some weighting on the domain.
3. Added a test to make sure that we still use smoothing on the `HeatKernel`.
