### PR TITLE
Avoid using plotting.py in mapper_quickstart

### DIFF
--- a/examples/mapper_quickstart.ipynb
+++ b/examples/mapper_quickstart.ipynb
@@ -34,7 +34,7 @@
     "import pandas as pd  # Not a requirement of giotto-tda, but is compatible with the gtda.mapper module\n",
     "\n",
     "# Data viz\n",
-    "from plotting import plot_point_cloud\n",
+    "import plotly.graph_objects as go\n",
     "\n",
     "# TDA magic\n",
     "from gtda.mapper import (\n",
@@ -70,9 +70,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data, _ = datasets.make_circles(n_samples=5000, noise=0.05, factor=0.3, random_state=42)\n",
-    "\n",
-    "plot_point_cloud(data)"
+    "data, _ = datasets.make_circles(n_samples=5000, noise=0.05, factor=0.3, random_state=42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = go.Figure(data=go.Scatter(x=data[:, 0], y=data[:, 1], mode='markers'))\n",
+    "fig.show()"
    ]
   },
   {
@@ -499,7 +507,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.1"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
#### Reference Issues/PRs
Prompted by a discussion in https://github.com/giotto-ai/giotto-tda/issues/330#issuecomment-591435029


#### What does this implement/fix? Explain your changes.
In `examples/mapper_quickstart.ipynb`, the usage of `plot_point_cloud` from `examples/plotting.py` was limited to a single cell for visualising the initial point cloud to which Mapper is applied. Users might trip over the need to have `plotting.py` downloaded in the same directory as the notebook. It is thus preferrable to fall back to a simpler solution based on simple `plotly` code.