### PR TITLE
[WIP] Add plotting.py to utils and remove it from examples

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -295,13 +295,15 @@ Graph processing
    meta_transformers.LandscapeGenerator
 
 
-:mod:`gtda.utils`: Validation
-=============================
+:mod:`gtda.utils`: Utilities
+============================
 
 .. automodule:: gtda.utils
    :no-members:
    :no-inherited-members:
 
+Validation
+----------
 .. currentmodule:: gtda
 
 .. autosummary::
@@ -311,6 +313,20 @@ Graph processing
    utils.check_diagram
    utils.validate_params
    utils.validate_metric_params
+
+Plotting
+--------
+.. currentmodule:: gtda
+
+.. autosummary::
+   :toctree: generated/
+   :template: function.rst
+
+   utils.plot_point_cloud
+   utils.plot_diagram
+   utils.plot_landscapes
+   utils.plot_betti_curves
+   utils.plot_betti_surfaces
 
 ..
    :mod:`gtda.images`: Images

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -1,10 +1,10 @@
 .. image:: https://www.giotto.ai/static/vector/logo.svg
    :width: 850
 
-Examples, tutorials and plotting utilities
-==========================================
+Examples and tutorials
+======================
 
-In this folder you can find basic tutorials and examples to get started quickly with giotto-tda. Additionally, ``plotting.py`` contains utilities for plotting the outputs of several computations you can perform with giotto-tda.
+In this folder you can find basic tutorials and examples to get started quickly with giotto-tda.
 
 Classifying Shapes
 ------------------

--- a/examples/classifying_shapes.ipynb
+++ b/examples/classifying_shapes.ipynb
@@ -40,7 +40,7 @@
    "source": [
     "# Plotting functions\n",
     "\n",
-    "The *plotting.py* file is required to use the following plotting functions. It can be found in the *examples* folder on out github <https://github.com/giotto-ai/giotto-tda>."
+    "We will use several plotting functions which can be found in `gtda.utils`."
    ]
   },
   {
@@ -49,10 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Plotting functions\n",
-    "from plotting import plot_diagram, plot_landscapes\n",
-    "from plotting import plot_betti_surfaces, plot_betti_curves\n",
-    "from plotting import plot_point_cloud"
+    "from gtda.utils import plot_point_cloud, plot_diagram, plot_landscapes, plot_betti_surfaces, plot_betti_curves"
    ]
   },
   {

--- a/examples/lorenz_attractor.ipynb
+++ b/examples/lorenz_attractor.ipynb
@@ -45,7 +45,7 @@
    "source": [
     "# Plotting functions\n",
     "\n",
-    "The *plotting.py* file is required to use the following plotting functions. It can be found in the *examples* folder on out github."
+    "We will use several plotting functions which can be found in `gtda.utils`."
    ]
   },
   {
@@ -54,10 +54,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Plotting functions\n",
-    "from plotting import plot_diagram, plot_landscapes\n",
-    "from plotting import plot_betti_surfaces, plot_betti_curves\n",
-    "from plotting import plot_point_cloud"
+    "from gtda.utils import plot_point_cloud, plot_diagram, plot_landscapes, plot_betti_surfaces, plot_betti_curves"
    ]
   },
   {

--- a/gtda/utils/__init__.py
+++ b/gtda/utils/__init__.py
@@ -3,11 +3,18 @@ validation functions."""
 
 from .validation import check_diagram, check_graph
 from .validation import validate_metric_params, validate_params
+from .plotting import plot_point_cloud, plot_diagram, plot_landscapes, \
+    plot_betti_curves, plot_betti_surfaces
 
 
 __all__ = [
     'check_diagram',
     'check_graph',
     'validate_metric_params',
-    'validate_params'
+    'validate_params',
+    'plot_point_cloud',
+    'plot_diagram',
+    'plot_landscapes',
+    'plot_betti_curves',
+    'plot_betti_surfaces'
 ]

--- a/gtda/utils/plotting.py
+++ b/gtda/utils/plotting.py
@@ -1,9 +1,9 @@
-"""Plot functions """
+"""Plotting functions."""
 # License: GNU AGPLv3
 
 import numpy as np
 import plotly.graph_objs as gobj
-from gtda.diagrams._utils import _subdiagrams
+from ..diagrams._utils import _subdiagrams
 
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
#### Reference Issues/PRs
#332, #306, #159


#### What does this implement/fix? Explain your changes.
Removes `plotting.py` from `examples` and promotes it to a submodule in `gtda.utils`. This is only to be regarded as a temporary solution to aid #306 and will be superseded by the API additions which will come out of the discussion in #159.

*Important*: This change breaks the notebooks for current users. @wreise: If you could proceed with #306 by pointing to another branch of the official repo, we could create one now from `master` and make this PR there instead.