### PR TITLE
Refactor validate_params

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -374,4 +374,3 @@ Binary image filtrations
 
    utils.check_diagram
    utils.validate_params
-   utils.validate_metric_params

--- a/examples/plotting.py
+++ b/examples/plotting.py
@@ -22,7 +22,7 @@ def plot_point_cloud(point_cloud, dimension=None):
     dimension : int or None, default : ``None``
         This parameter sets the dimension of the resulting plot. If ``None``,
         the dimension will be chosen between 2 and 3 depending on
-        ``n_dimensions`` see Input).
+        ``n_dimensions``, see Parameters).
 
     """
     if dimension is None:

--- a/gtda/base.py
+++ b/gtda/base.py
@@ -46,7 +46,7 @@ class TransformerResamplerMixin:
         ----------
         X : ndarray of shape (n_samples, ...)
             Input data.
-        y : ndarray of shape (n_samples, )
+        y : ndarray of shape (n_samples,)
             Target data.
 
         Returns
@@ -65,7 +65,7 @@ class TransformerResamplerMixin:
         ----------
         X : ndarray of shape (n_samples, ...)
             Input data.
-        y : ndarray of shape (n_samples, )
+        y : ndarray of shape (n_samples,)
             Target data.
 
         Returns

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -19,7 +19,7 @@ _AVAILABLE_METRICS = {
     'bottleneck': {
         'delta': {'type': Real, 'in': Interval(0, 1, closed='both')}},
     'wasserstein': {
-        'p': {'type': int, 'in': Interval(1, np.inf, closed='left')},
+        'p': {'type': Real, 'in': Interval(1, np.inf, closed='left')},
         'delta': {'type': Real, 'in': Interval(0, 1, closed='right')}},
     'betti': {
         'p': {'type': Real, 'in': Interval(1, np.inf, closed='both')},

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -63,8 +63,8 @@ def betti_curves(diagrams, sampling):
 def landscapes(diagrams, sampling, n_layers):
     n_points = diagrams.shape[1]
 
-    midpoints = (diagrams[:, :, 1] + diagrams[:, :, 0]) / 2.0
-    heights = (diagrams[:, :, 1] - diagrams[:, :, 0]) / 2.0
+    midpoints = (diagrams[:, :, 1] + diagrams[:, :, 0]) / 2.
+    heights = (diagrams[:, :, 1] - diagrams[:, :, 0]) / 2.
     fibers = np.maximum(-np.abs(sampling - midpoints) + heights, 0)
     top_pos = range(-min(n_layers, n_points), 0)
     fibers.partition(top_pos, axis=2)
@@ -161,7 +161,7 @@ def wasserstein_distances(diagrams_1, diagrams_2, p=2, delta=0.01, **kwargs):
 
 
 def betti_distances(diagrams_1, diagrams_2, sampling,
-                    step_size, p=2.0, **kwargs):
+                    step_size, p=2., **kwargs):
     betti_curves_1 = betti_curves(diagrams_1, sampling)
     if np.array_equal(diagrams_1, diagrams_2):
         unnorm_dist = squareform(pdist(betti_curves_1,
@@ -285,34 +285,34 @@ def _parallel_pairwise(X1, X2, metric, metric_params,
 
 
 def bottleneck_amplitudes(diagrams, **kwargs):
-    dists_to_diago = np.sqrt(2) / 2.0 * (diagrams[:, :, 1] - diagrams[:, :, 0])
+    dists_to_diago = np.sqrt(2) / 2. * (diagrams[:, :, 1] - diagrams[:, :, 0])
     return np.linalg.norm(dists_to_diago, axis=1, ord=np.inf)
 
 
-def wasserstein_amplitudes(diagrams, p=2.0, **kwargs):
-    dists_to_diago = np.sqrt(2) / 2.0 * (diagrams[:, :, 1] - diagrams[:, :, 0])
+def wasserstein_amplitudes(diagrams, p=2., **kwargs):
+    dists_to_diago = np.sqrt(2) / 2. * (diagrams[:, :, 1] - diagrams[:, :, 0])
     return np.linalg.norm(dists_to_diago, axis=1, ord=p)
 
 
-def betti_amplitudes(diagrams, sampling, step_size, p=2.0, **kwargs):
+def betti_amplitudes(diagrams, sampling, step_size, p=2., **kwargs):
     bcs = betti_curves(diagrams, sampling)
     return (step_size ** (1 / p)) * np.linalg.norm(bcs, axis=1, ord=p)
 
 
-def landscape_amplitudes(diagrams, sampling, step_size, p=2.0, n_layers=1,
+def landscape_amplitudes(diagrams, sampling, step_size, p=2., n_layers=1,
                          **kwargs):
     ls = landscapes(diagrams, sampling, n_layers).reshape(len(diagrams),
                                                           -1)
     return (step_size ** (1 / p)) * np.linalg.norm(ls, axis=1, ord=p)
 
 
-def heat_amplitudes(diagrams, sampling, step_size, sigma=1.0, p=2.0, **kwargs):
+def heat_amplitudes(diagrams, sampling, step_size, sigma=1., p=2., **kwargs):
     heat = heats(diagrams, sampling, step_size, sigma)
     return np.linalg.norm(heat, axis=(1, 2), ord=p)
 
 
 def persistence_image_amplitudes(diagrams, sampling, step_size,
-                                 weight_function=lambda x: x, sigma=1.0, p=2.0,
+                                 weight_function=lambda x: x, sigma=1., p=2.,
                                  **kwargs):
     persistence_image = persistence_images(diagrams, sampling, step_size,
                                            weight_function, sigma)

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -1,8 +1,9 @@
 # License: GNU AGPLv3
 
+from numbers import Real
+from types import FunctionType
+
 import numpy as np
-from ..externals.modules.gtda_bottleneck import bottleneck_distance
-from ..externals.modules.gtda_wasserstein import wasserstein_distance
 from joblib import Parallel, delayed, effective_n_jobs
 from scipy.ndimage import gaussian_filter
 from scipy.spatial.distance import cdist, pdist, squareform
@@ -10,23 +11,40 @@ from sklearn.utils import gen_even_slices
 from sklearn.utils.validation import _num_samples
 
 from ._utils import _subdiagrams, _sample_image
+from ..externals.modules.gtda_bottleneck import bottleneck_distance
+from ..externals.modules.gtda_wasserstein import wasserstein_distance
+from ..utils.intervals import Interval
 
+_AVAILABLE_METRICS = {
+    'bottleneck': {
+        'delta': {'type': Real, 'in': Interval(0, 1, closed='both')}},
+    'wasserstein': {
+        'p': {'type': int, 'in': Interval(1, np.inf, closed='left')},
+        'delta': {'type': Real, 'in': Interval(0, 1, closed='right')}},
+    'betti': {
+        'p': {'type': Real, 'in': Interval(1, np.inf, closed='both')},
+        'n_bins': {'type': int, 'in': Interval(1, np.inf, closed='left')}},
+    'landscape': {
+        'p': {'type': Real, 'in': Interval(1, np.inf, closed='both')},
+        'n_bins': {'type': int, 'in': Interval(1, np.inf, closed='left')},
+        'n_layers': {'type': int, 'in': Interval(1, np.inf, closed='left')}},
+    'heat': {
+        'p': {'type': Real, 'in': Interval(1, np.inf, closed='both')},
+        'n_bins': {'type': int, 'in': Interval(1, np.inf, closed='left')},
+        'sigma': {'type': Real, 'in': Interval(0, np.inf, closed='neither')}},
+    'persistence_image': {
+        'p': {'type': Real, 'in': Interval(1, np.inf, closed='both')},
+        'n_bins': {'type': int, 'in': Interval(1, np.inf, closed='left')},
+        'sigma': {'type': Real, 'in': Interval(0, np.inf, closed='neither')},
+        'weight_function': {'type': FunctionType, 'in': None}},
+    'silhouette': {
+        'power': {'type': Real, 'in': Interval(0, np.inf, closed='right')},
+        'p': {'type': Real, 'in': Interval(1, np.inf, closed='both')},
+        'n_bins': {'type': int, 'in': Interval(1, np.inf, closed='left')}}}
 
-def silhouettes(diagrams, sampling, order, **kwargs):
-    """Input: a batch of persistence diagrams with a sampling (3d array
-    returned by _bin) of a one-dimensional range.
-    """
-    sampling = np.transpose(sampling, axes=(1, 2, 0))
-    weights = np.diff(diagrams, axis=2)[:, :, [0]]
-    if order > 8.:
-        weights = weights/np.max(weights, axis=1, keepdims=True)
-    weights = weights**order
-    total_weights = np.sum(weights, axis=1)
-    midpoints = (diagrams[:, :, [1]] + diagrams[:, :, [0]]) / 2.
-    heights = (diagrams[:, :, [1]] - diagrams[:, :, [0]]) / 2.
-    fibers = np.maximum(-np.abs(sampling - midpoints) + heights, 0)
-    fibers_weighted_sum = np.sum(weights*fibers, axis=1)/total_weights
-    return fibers_weighted_sum
+_AVAILABLE_AMPLITUDE_METRICS = _AVAILABLE_METRICS.copy()
+for metric in ['bottleneck', 'wasserstein']:
+    _AVAILABLE_AMPLITUDE_METRICS[metric].pop('delta')
 
 
 def betti_curves(diagrams, sampling):
@@ -74,17 +92,6 @@ def heats(diagrams, sampling, step_size, sigma):
     return heats_
 
 
-def silhouette_distances(diagrams_1, diagrams_2, sampling, step_size,
-                         p=2., **kwargs):
-    silhouette_1 = silhouettes(diagrams_1, sampling, p)
-    if np.array_equal(diagrams_1, diagrams_2):
-        unnorm_dist = squareform(pdist(silhouette_1, 'minkowski', p=p))
-    else:
-        silhouette_2 = silhouettes(diagrams_2, sampling, p)
-        unnorm_dist = cdist(silhouette_1, silhouette_2, 'minkowski', p=p)
-    return (step_size ** (1 / p)) * unnorm_dist
-
-
 def persistence_images(diagrams, sampling, step_size, weights, sigma):
     persistence_images_ = np.zeros((diagrams.shape[0],
                                     sampling.shape[0], sampling.shape[0]))
@@ -117,6 +124,37 @@ def persistence_images(diagrams, sampling, step_size, weights, sigma):
     return persistence_images_
 
 
+def silhouettes(diagrams, sampling, power, **kwargs):
+    """Input: a batch of persistence diagrams with a sampling (3d array
+    returned by _bin) of a one-dimensional range.
+    """
+    sampling = np.transpose(sampling, axes=(1, 2, 0))
+    weights = np.diff(diagrams, axis=2)[:, :, [0]]
+    if power > 8.:
+        weights = weights/np.max(weights, axis=1, keepdims=True)
+    weights = weights**power
+    total_weights = np.sum(weights, axis=1)
+    midpoints = (diagrams[:, :, [1]] + diagrams[:, :, [0]]) / 2.
+    heights = (diagrams[:, :, [1]] - diagrams[:, :, [0]]) / 2.
+    fibers = np.maximum(-np.abs(sampling - midpoints) + heights, 0)
+    fibers_weighted_sum = np.sum(weights*fibers, axis=1)/total_weights
+    return fibers_weighted_sum
+
+
+def bottleneck_distances(diagrams_1, diagrams_2, delta=0.01, **kwargs):
+    return np.array([[bottleneck_distance(
+        diagram_1[diagram_1[:, 0] != diagram_1[:, 1]],
+        diagram_2[diagram_2[:, 0] != diagram_2[:, 1]],
+        delta) for diagram_2 in diagrams_2] for diagram_1 in diagrams_1])
+
+
+def wasserstein_distances(diagrams_1, diagrams_2, p=2, delta=0.01, **kwargs):
+    return np.array([[wasserstein_distance(
+        diagram_1[diagram_1[:, 0] != diagram_1[:, 1]],
+        diagram_2[diagram_2[:, 0] != diagram_2[:, 1]],
+        p, delta,) for diagram_2 in diagrams_2] for diagram_1 in diagrams_1])
+
+
 def betti_distances(diagrams_1, diagrams_2, sampling,
                     step_size, p=2.0, **kwargs):
     betti_curves_1 = betti_curves(diagrams_1, sampling)
@@ -131,7 +169,7 @@ def betti_distances(diagrams_1, diagrams_2, sampling,
 
 
 def landscape_distances(diagrams_1, diagrams_2, sampling, step_size,
-                        p=2.0, n_layers=1, **kwargs):
+                        p=2., n_layers=1, **kwargs):
     n_samples_1, n_points_1 = diagrams_1.shape[:2]
     n_layers_1 = min(n_layers, n_points_1)
     if np.array_equal(diagrams_1, diagrams_2):
@@ -150,22 +188,8 @@ def landscape_distances(diagrams_1, diagrams_2, sampling, step_size,
     return (step_size ** (1 / p)) * unnorm_dist
 
 
-def bottleneck_distances(diagrams_1, diagrams_2, delta=0.01, **kwargs):
-    return np.array([[bottleneck_distance(
-        diagram_1[diagram_1[:, 0] != diagram_1[:, 1]],
-        diagram_2[diagram_2[:, 0] != diagram_2[:, 1]],
-        delta) for diagram_2 in diagrams_2] for diagram_1 in diagrams_1])
-
-
-def wasserstein_distances(diagrams_1, diagrams_2, p=2, delta=0.01, **kwargs):
-    return np.array([[wasserstein_distance(
-        diagram_1[diagram_1[:, 0] != diagram_1[:, 1]],
-        diagram_2[diagram_2[:, 0] != diagram_2[:, 1]],
-        p, delta,) for diagram_2 in diagrams_2] for diagram_1 in diagrams_1])
-
-
 def heat_distances(diagrams_1, diagrams_2, sampling, step_size,
-                   sigma=1.0, p=2.0, **kwargs):
+                   sigma=1., p=2., **kwargs):
     heat_1 = heats(diagrams_1, sampling, step_size, sigma).reshape(
         diagrams_1.shape[0], -1)
     if np.array_equal(diagrams_1, diagrams_2):
@@ -178,7 +202,7 @@ def heat_distances(diagrams_1, diagrams_2, sampling, step_size,
 
 
 def persistence_image_distances(diagrams_1, diagrams_2, sampling, step_size,
-                                weight_function=lambda x: x, sigma=1.0, p=2.0,
+                                weight_function=lambda x: x, sigma=1., p=2.,
                                 **kwargs):
     sampling_ = np.copy(sampling.reshape((-1,)))
     weights = weight_function(sampling_ - sampling_[0])
@@ -194,6 +218,17 @@ def persistence_image_distances(diagrams_1, diagrams_2, sampling, step_size,
                                                  diagrams_2.shape[0], -1)
     unnorm_dist = cdist(persistence_image_1, persistence_image_2,
                         "minkowski", p=p)
+    return (step_size ** (1 / p)) * unnorm_dist
+
+
+def silhouette_distances(diagrams_1, diagrams_2, sampling, step_size,
+                         power=2., p=2., **kwargs):
+    silhouette_1 = silhouettes(diagrams_1, sampling, power)
+    if np.array_equal(diagrams_1, diagrams_2):
+        unnorm_dist = squareform(pdist(silhouette_1, 'minkowski', p=p))
+    else:
+        silhouette_2 = silhouettes(diagrams_2, sampling, power)
+        unnorm_dist = cdist(silhouette_1, silhouette_2, 'minkowski', p=p)
     return (step_size ** (1 / p)) * unnorm_dist
 
 
@@ -244,9 +279,14 @@ def _parallel_pairwise(X1, X2, metric, metric_params,
     return distance_matrices
 
 
-def silhouette_amplitudes(diagrams, sampling, step_size, p=2., **kwargs):
-    sht = silhouettes(diagrams, sampling, p)
-    return (step_size ** (1 / p)) * np.linalg.norm(sht, axis=1, ord=p)
+def bottleneck_amplitudes(diagrams, **kwargs):
+    dists_to_diago = np.sqrt(2) / 2.0 * (diagrams[:, :, 1] - diagrams[:, :, 0])
+    return np.linalg.norm(dists_to_diago, axis=1, ord=np.inf)
+
+
+def wasserstein_amplitudes(diagrams, p=2.0, **kwargs):
+    dists_to_diago = np.sqrt(2) / 2.0 * (diagrams[:, :, 1] - diagrams[:, :, 0])
+    return np.linalg.norm(dists_to_diago, axis=1, ord=p)
 
 
 def betti_amplitudes(diagrams, sampling, step_size, p=2.0, **kwargs):
@@ -261,16 +301,6 @@ def landscape_amplitudes(diagrams, sampling, step_size, p=2.0, n_layers=1,
     return (step_size ** (1 / p)) * np.linalg.norm(ls, axis=1, ord=p)
 
 
-def bottleneck_amplitudes(diagrams, **kwargs):
-    dists_to_diago = np.sqrt(2) / 2.0 * (diagrams[:, :, 1] - diagrams[:, :, 0])
-    return np.linalg.norm(dists_to_diago, axis=1, ord=np.inf)
-
-
-def wasserstein_amplitudes(diagrams, p=2.0, **kwargs):
-    dists_to_diago = np.sqrt(2) / 2.0 * (diagrams[:, :, 1] - diagrams[:, :, 0])
-    return np.linalg.norm(dists_to_diago, axis=1, ord=p)
-
-
 def heat_amplitudes(diagrams, sampling, step_size, sigma=1.0, p=2.0, **kwargs):
     heat = heats(diagrams, sampling, step_size, sigma)
     return np.linalg.norm(heat, axis=(1, 2), ord=p)
@@ -282,6 +312,12 @@ def persistence_image_amplitudes(diagrams, sampling, step_size,
     persistence_image = persistence_images(diagrams, sampling, step_size,
                                            weight_function, sigma)
     return np.linalg.norm(persistence_image, axis=(1, 2), ord=p)
+
+
+def silhouette_amplitudes(diagrams, sampling, step_size, power=2., p=2.,
+                          **kwargs):
+    sht = silhouettes(diagrams, sampling, power)
+    return (step_size ** (1 / p)) * np.linalg.norm(sht, axis=1, ord=p)
 
 
 implemented_amplitude_recipes = {
@@ -301,8 +337,7 @@ def _arrays_wrapper(amplitude_func, amplitude_arrays, slice_, dim,
                                                         **kwargs)
 
 
-def _parallel_amplitude(X, metric, metric_params,
-                        homology_dimensions, n_jobs):
+def _parallel_amplitude(X, metric, metric_params, homology_dimensions, n_jobs):
     amplitude_func = implemented_amplitude_recipes[metric]
     effective_metric_params = metric_params.copy()
     none_dict = {dim: None for dim in homology_dimensions}

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -42,9 +42,14 @@ _AVAILABLE_METRICS = {
         'p': {'type': Real, 'in': Interval(1, np.inf, closed='both')},
         'n_bins': {'type': int, 'in': Interval(1, np.inf, closed='left')}}}
 
-_AVAILABLE_AMPLITUDE_METRICS = _AVAILABLE_METRICS.copy()
-for metric in ['bottleneck', 'wasserstein']:
-    _AVAILABLE_AMPLITUDE_METRICS[metric].pop('delta')
+_AVAILABLE_AMPLITUDE_METRICS = dict()
+for metric, metric_params in _AVAILABLE_METRICS.items():
+    if metric not in ['bottleneck', 'wasserstein']:
+        _AVAILABLE_AMPLITUDE_METRICS[metric] = metric_params.copy()
+    else:
+        _AVAILABLE_AMPLITUDE_METRICS[metric] = \
+            {name: descr for name, descr in metric_params.items()
+             if name != 'delta'}
 
 
 def betti_curves(diagrams, sampling):

--- a/gtda/diagrams/distance.py
+++ b/gtda/diagrams/distance.py
@@ -407,9 +407,9 @@ class Amplitude(BaseEstimator, TransformerMixin):
 
         """
         check_is_fitted(self)
-        X = check_diagram(X, copy=True)
+        Xt = check_diagram(X, copy=True)
 
-        Xt = _parallel_amplitude(X, self.metric,
+        Xt = _parallel_amplitude(Xt, self.metric,
                                  self.effective_metric_params_,
                                  self.homology_dimensions_,
                                  self.n_jobs)

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -1,8 +1,8 @@
 """Feature extraction from persistence diagrams."""
 # License: GNU AGPLv3
 
-import numbers
 import types
+from numbers import Real
 
 import numpy as np
 from joblib import Parallel, delayed, effective_n_jobs
@@ -10,11 +10,18 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import gen_even_slices
 from sklearn.utils.validation import check_is_fitted
 
-from ._metrics import betti_curves, landscapes, heats,\
+from ._metrics import betti_curves, landscapes, heats, \
     persistence_images, silhouettes
 from ._utils import _subdiagrams, _bin, _calculate_weights
 from ..utils._docs import adapt_fit_transform_docs
+from ..utils.intervals import Interval
 from ..utils.validation import validate_params, check_diagram
+
+
+def identity(x):
+    """The identity function.
+    """
+    return x
 
 
 @adapt_fit_transform_docs
@@ -168,7 +175,8 @@ class BettiCurve(BaseEstimator, TransformerMixin):
 
     """
 
-    _hyperparameters = {'n_bins': [int, (1, np.inf)]}
+    _hyperparameters = {
+        'n_bins': {'type': int, 'in': Interval(1, np.inf, closed='left')}}
 
     def __init__(self, n_bins=100, n_jobs=None):
         self.n_bins = n_bins
@@ -200,7 +208,8 @@ class BettiCurve(BaseEstimator, TransformerMixin):
 
         """
         X = check_diagram(X)
-        validate_params(self.get_params(), self._hyperparameters)
+        validate_params(
+            self.get_params(), self._hyperparameters, exclude=['n_jobs'])
 
         self.homology_dimensions_ = sorted(list(set(X[0, :, 2])))
         self._n_dimensions = len(self.homology_dimensions_)
@@ -299,8 +308,9 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin):
 
     """
 
-    _hyperparameters = {'n_layers': [int, (1, np.inf)],
-                        'n_bins': [int, (1, np.inf)]}
+    _hyperparameters = {
+        'n_bins': {'type': int, 'in': Interval(1, np.inf, closed='left')},
+        'n_layers': {'type': int, 'in': Interval(1, np.inf, closed='left')}}
 
     def __init__(self, n_layers=1, n_bins=100, n_jobs=None):
         self.n_layers = n_layers
@@ -333,7 +343,8 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin):
 
         """
         X = check_diagram(X)
-        validate_params(self.get_params(), self._hyperparameters)
+        validate_params(
+            self.get_params(), self._hyperparameters, exclude=['n_jobs'])
 
         self.homology_dimensions_ = sorted(list(set(X[0, :, 2])))
         self._n_dimensions = len(self.homology_dimensions_)
@@ -447,8 +458,9 @@ class HeatKernel(BaseEstimator, TransformerMixin):
 
     """
 
-    _hyperparameters = {'sigma': [numbers.Number, (1e-16, np.inf)],
-                        'n_bins': [int, (1, np.inf)]}
+    _hyperparameters = {
+        'n_bins': {'type': int, 'in': Interval(1, np.inf, closed='left')},
+        'sigma': {'type': Real, 'in': Interval(0, np.inf, closed='neither')}}
 
     def __init__(self, sigma=1.0, n_bins=100, n_jobs=None):
         self.sigma = sigma
@@ -481,7 +493,8 @@ class HeatKernel(BaseEstimator, TransformerMixin):
 
         """
         X = check_diagram(X)
-        validate_params(self.get_params(), self._hyperparameters)
+        validate_params(
+            self.get_params(), self._hyperparameters, exclude=['n_jobs'])
 
         self.homology_dimensions_ = sorted(list(set(X[0, :, 2])))
         self._n_dimensions = len(self.homology_dimensions_)
@@ -607,10 +620,10 @@ class PersistenceImage(BaseEstimator, TransformerMixin):
 
     """
 
-    _hyperparameters = {'sigma': [numbers.Number, (1e-16, np.inf)],
-                        'n_bins': [int, (1, np.inf)],
-                        'effective_weight_function_': [types.FunctionType,
-                                                       None]}
+    _hyperparameters = {
+        'n_bins': {'type': int, 'in': Interval(1, np.inf, closed='left')},
+        'sigma': {'type': Real, 'in': Interval(0, np.inf, closed='neither')},
+        'weight_function': {'type': (types.FunctionType, type(None))}}
 
     def __init__(self, sigma=1.0, n_bins=100, weight_function=None,
                  n_jobs=None):
@@ -646,15 +659,13 @@ class PersistenceImage(BaseEstimator, TransformerMixin):
         """
         X = check_diagram(X)
 
+        validate_params(
+            self.get_params(), self._hyperparameters, exclude=['n_jobs'])
+
         if self.weight_function is None:
-            self.effective_weight_function_ = lambda p: p
+            self.effective_weight_function_ = identity
         else:
             self.effective_weight_function_ = self.weight_function
-
-        validate_params({
-            **self.get_params(),
-            'effective_weight_function_': self.effective_weight_function_},
-                        self._hyperparameters)
 
         self.homology_dimensions_ = sorted(list(set(X[0, :, 2])))
         self._n_dimensions = len(self.homology_dimensions_)
@@ -725,7 +736,7 @@ class Silhouette(BaseEstimator, TransformerMixin):
 
      Parameters
     ----------
-    order: float, optional, default: ``1.``
+    power: float, optional, default: ``1.``
         The power to which persistence values are raised to define the
         `power-weighted silhouettes <https://giotto.ai/theory>`_.
 
@@ -772,11 +783,12 @@ class Silhouette(BaseEstimator, TransformerMixin):
 
     """
 
-    _hyperparameters = {'order': [float, (0., np.inf)],
-                        'n_bins': [int, (1., np.inf)]}
+    _hyperparameters = {
+        'n_bins': {'type': int, 'in': Interval(1, np.inf, closed='left')},
+        'power': {'type': Real, 'in': Interval(0, np.inf, closed='right')}}
 
-    def __init__(self, order=1., n_bins=100, n_jobs=None):
-        self.order = order
+    def __init__(self, power=1., n_bins=100, n_jobs=None):
+        self.power = power
         self.n_bins = n_bins
         self.n_jobs = n_jobs
 
@@ -806,7 +818,8 @@ class Silhouette(BaseEstimator, TransformerMixin):
 
         """
         X = check_diagram(X)
-        validate_params(self.get_params(), self._hyperparameters)
+        validate_params(
+            self.get_params(), self._hyperparameters, exclude=['n_jobs'])
 
         self.homology_dimensions_ = sorted(list(set(X[0, :, 2])))
         self._n_dimensions = len(self.homology_dimensions_)
@@ -845,7 +858,7 @@ class Silhouette(BaseEstimator, TransformerMixin):
 
         Xt = (Parallel(n_jobs=self.n_jobs)
               (delayed(silhouettes)(_subdiagrams(X, [dim], remove_dim=True)[s],
-                                    self._samplings[dim], order=self.order)
+                                    self._samplings[dim], power=self.power)
               for dim in self.homology_dimensions_
               for s in gen_even_slices(X.shape[0],
                                        effective_n_jobs(self.n_jobs))))

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -412,7 +412,7 @@ class HeatKernel(BaseEstimator, TransformerMixin):
 
     Parameters
     ----------
-    sigma : float, optional default ``1.0``
+    sigma : float, optional default ``1.``
         Standard deviation for Gaussian kernel.
 
     n_bins : int, optional, default: ``100``
@@ -462,7 +462,7 @@ class HeatKernel(BaseEstimator, TransformerMixin):
         'n_bins': {'type': int, 'in': Interval(1, np.inf, closed='left')},
         'sigma': {'type': Real, 'in': Interval(0, np.inf, closed='neither')}}
 
-    def __init__(self, sigma=1.0, n_bins=100, n_jobs=None):
+    def __init__(self, sigma=1., n_bins=100, n_jobs=None):
         self.sigma = sigma
         self.n_bins = n_bins
         self.n_jobs = n_jobs
@@ -561,7 +561,7 @@ class PersistenceImage(BaseEstimator, TransformerMixin):
 
     Parameters
     ----------
-    sigma : float, optional default ``1.0``
+    sigma : float, optional default ``1.``
         Standard deviation for Gaussian kernel.
 
     n_bins : int, optional, default: ``100``
@@ -625,7 +625,7 @@ class PersistenceImage(BaseEstimator, TransformerMixin):
         'sigma': {'type': Real, 'in': Interval(0, np.inf, closed='neither')},
         'weight_function': {'type': (types.FunctionType, type(None))}}
 
-    def __init__(self, sigma=1.0, n_bins=100, weight_function=None,
+    def __init__(self, sigma=1., n_bins=100, weight_function=None,
                  n_jobs=None):
         self.sigma = sigma
         self.n_bins = n_bins

--- a/gtda/diagrams/preprocessing.py
+++ b/gtda/diagrams/preprocessing.py
@@ -1,18 +1,18 @@
 """Persistence diagram preprocessing."""
 # License: GNU AGPLv3
 
-import numbers
-import types
+from numbers import Real
+from types import FunctionType
 
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
-from ._metrics import _parallel_amplitude
+from ._metrics import _AVAILABLE_AMPLITUDE_METRICS, _parallel_amplitude
 from ._utils import _sort, _filter, _bin, _calculate_weights
 from ..utils._docs import adapt_fit_transform_docs
-from ..utils.validation import (check_diagram, validate_params,
-                                validate_metric_params)
+from ..utils.intervals import Interval
+from ..utils.validation import check_diagram, validate_params
 
 
 @adapt_fit_transform_docs
@@ -54,7 +54,7 @@ class ForgetDimension(BaseEstimator, TransformerMixin):
         self : object
 
         """
-        X = check_diagram(X)
+        check_diagram(X)
 
         self._is_fitted = True
         return self
@@ -174,7 +174,11 @@ class Scaler(BaseEstimator, TransformerMixin):
 
     """
 
-    _hyperparameters = {'function': [types.FunctionType, None]}
+    _hyperparameters = {
+        'metric': {'type': str, 'in': _AVAILABLE_AMPLITUDE_METRICS.keys()},
+        'metric_params': {'type': (dict, type(None))},
+        'function': {'type': (FunctionType, type(None))}
+    }
 
     def __init__(self, metric='bottleneck', metric_params=None,
                  function=np.max, n_jobs=None):
@@ -204,15 +208,17 @@ class Scaler(BaseEstimator, TransformerMixin):
         self : object
 
         """
-        validate_params(self.get_params(), self._hyperparameters)
+        X = check_diagram(X)
+        validate_params(
+            self.get_params(), self._hyperparameters, exclude=['n_jobs'])
 
         if self.metric_params is None:
             self.effective_metric_params_ = {}
         else:
             self.effective_metric_params_ = self.metric_params.copy()
+        validate_params(self.effective_metric_params_,
+                        _AVAILABLE_AMPLITUDE_METRICS[self.metric])
 
-        validate_metric_params(self.metric, self.effective_metric_params_)
-        X = check_diagram(X)
         self.homology_dimensions_ = sorted(set(X[0, :, 2]))
 
         self.effective_metric_params_['samplings'], \
@@ -290,11 +296,11 @@ class Filtering(BaseEstimator, TransformerMixin):
 
     Parameters
     ----------
-    homology_dimensions : iterable or None, optional, default: ``None``
+    homology_dimensions : list, tuple, or None, optional, default: ``None``
         When set to ``None``, subdiagrams corresponding to all homology
         dimensions seen in :meth:`fit` will be filtered.
-        Otherwise, it contains the homology dimensions at which filtering
-        should occur.
+        Otherwise, it contains the homology dimensions (as non-negative
+        integers) at which filtering should occur.
 
     epsilon : float, optional, default: ``0.01``
         The cutoff value controlling the amount of filtering.
@@ -314,8 +320,12 @@ class Filtering(BaseEstimator, TransformerMixin):
 
     """
 
-    _hyperparameters = {'homology_dimensions_': [list, [int, (0, np.inf)]],
-                        'epsilon': [numbers.Number, (0., np.inf)]}
+    _hyperparameters = {
+        'homology_dimensions': {
+            'type': (list, tuple, type(None)),
+            'of': {'type': int, 'in': Interval(0, np.inf, closed='left')}},
+        'epsilon': {'type': Real, 'in': Interval(0, np.inf, closed='left')}
+    }
 
     def __init__(self, homology_dimensions=None, epsilon=0.01):
         self.homology_dimensions = homology_dimensions
@@ -345,19 +355,14 @@ class Filtering(BaseEstimator, TransformerMixin):
 
         """
         X = check_diagram(X)
+        validate_params(
+            self.get_params(), self._hyperparameters)
 
         if self.homology_dimensions is None:
             self.homology_dimensions_ = [int(dim) for dim in set(X[0, :, 2])]
         else:
             self.homology_dimensions_ = self.homology_dimensions
         self.homology_dimensions_ = sorted(self.homology_dimensions_)
-
-        validate_params({**self.get_params(),
-                         'homology_dimensions_': self.homology_dimensions_},
-                        self._hyperparameters)
-
-        self.homology_dimensions_ = \
-            [float(dim) for dim in self.homology_dimensions_]
 
         return self
 

--- a/gtda/diagrams/tests/test_distance.py
+++ b/gtda/diagrams/tests/test_distance.py
@@ -242,15 +242,15 @@ def test_not_fitted():
         da.transform(X_1)
 
 
-parameters = [('bottleneck', None),
-              ('wasserstein', {'p': 2, 'delta': 0.1}),
-              ('betti', {'p': 2.1, 'n_bins': 10}),
-              ('landscape', {'n_bins': 10}),
-              ('heat', {'n_bins': 10})  # See issue #63
-              ]
+parameters_distance = [
+    ('bottleneck', None),
+    ('wasserstein', {'p': 2, 'delta': 0.1}),
+    ('betti', {'p': 2.1, 'n_bins': 10}),
+    ('landscape', {'n_bins': 10}),
+    ('heat', {'n_bins': 10})]
 
 
-@pytest.mark.parametrize(('metric', 'metric_params'), parameters)
+@pytest.mark.parametrize(('metric', 'metric_params'), parameters_distance)
 @pytest.mark.parametrize('n_jobs', [1, 2, 4])
 @pytest.mark.parametrize('order', [2, None])
 def test_dd_transform(metric, metric_params, order, n_jobs):
@@ -275,7 +275,15 @@ def test_dd_transform(metric, metric_params, order, n_jobs):
     assert (X_res.shape[0], X_res.shape[1]) == (X_1.shape[0], X_2.shape[0])
 
 
-@pytest.mark.parametrize(('metric', 'metric_params'), parameters)
+parameters_amplitude = [
+    ('bottleneck', None),
+    ('wasserstein', {'p': 2}),
+    ('betti', {'p': 2.1, 'n_bins': 10}),
+    ('landscape', {'n_bins': 10}),
+    ('heat', {'n_bins': 10})]
+
+
+@pytest.mark.parametrize(('metric', 'metric_params'), parameters_amplitude)
 @pytest.mark.parametrize('n_jobs', [1, 2, 4])
 def test_da_transform(metric, metric_params, n_jobs):
     da = Amplitude(metric=metric, metric_params=metric_params,

--- a/gtda/diagrams/tests/test_features.py
+++ b/gtda/diagrams/tests/test_features.py
@@ -3,14 +3,13 @@
 
 import numpy as np
 import pytest
-from numpy.testing import assert_almost_equal
-from sklearn.exceptions import NotFittedError
-
 from hypothesis import given
 from hypothesis.extra.numpy import arrays, array_shapes
 from hypothesis.strategies import floats, integers
+from numpy.testing import assert_almost_equal
+from sklearn.exceptions import NotFittedError
 
-from gtda.diagrams import PersistenceEntropy, HeatKernel,\
+from gtda.diagrams import PersistenceEntropy, HeatKernel, \
     PersistenceImage, Silhouette
 
 diagram = np.array([[[0, 1, 0], [2, 3, 0], [4, 6, 1], [2, 6, 1]]])
@@ -70,7 +69,7 @@ def test_pi_positive(pts):
 
 
 def test_silhouette_transform():
-    sht = Silhouette(n_bins=31, order=1.)
+    sht = Silhouette(n_bins=31, power=1.)
     X_sht_res = np.array([0., 0.05, 0.1, 0.15, 0.2, 0.25, 0.2, 0.15, 0.1,
                           0.05, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0., 0.05,
                           0.1, 0.15, 0.2, 0.25, 0.2, 0.15, 0.1, 0.05, 0.])
@@ -80,7 +79,7 @@ def test_silhouette_transform():
 
 def test_silhouette_big_order():
     diagrams = np.array([[[0, 2, 0], [1, 4, 0]]])
-    sht_10 = Silhouette(n_bins=41, order=10.)
+    sht_10 = Silhouette(n_bins=41, power=10.)
     X_sht_res = np.array([0., 0.00170459, 0.00340919, 0.00511378, 0.00681837,
                           0.00852296, 0.01022756, 0.01193215, 0.01363674,
                           0.01534133, 0.01704593, 0.11363674, 0.21022756,

--- a/gtda/diagrams/tests/test_preprocessing.py
+++ b/gtda/diagrams/tests/test_preprocessing.py
@@ -1,4 +1,4 @@
-"""Testing for ForgetDimension and Scaler"""
+"""Testing for ForgetDimension and Scaler."""
 # License: GNU AGPLv3
 
 import numpy as np
@@ -229,7 +229,7 @@ def test_dst_transform(X):
     assert X_res.shape == X.shape
 
 
-parameters = [('wasserstein', {'p': 2, 'delta': 0.1}),
+parameters = [('wasserstein', {'p': 2}),
               ('betti', {'n_bins': 10}),
               ('bottleneck', None)]
 

--- a/gtda/graphs/transition.py
+++ b/gtda/graphs/transition.py
@@ -1,7 +1,7 @@
 """Construct transition graphs from dynamical systems."""
 # License: GNU AGPLv3
 
-import types
+from types import FunctionType
 import warnings
 
 import numpy as np
@@ -15,10 +15,10 @@ from ..utils._docs import adapt_fit_transform_docs
 from ..utils.validation import validate_params
 
 
-def _identity(X):
+def identity(x):
     """The identity function.
     """
-    return X
+    return x
 
 
 @adapt_fit_transform_docs
@@ -111,7 +111,10 @@ class TransitionGraph(BaseEstimator, TransformerMixin):
 
     """
 
-    _hyperparameters = {'_func': [types.FunctionType, None]}
+    _hyperparameters = {
+        'func': {'type': (FunctionType, type(None))},
+        'func_params': {'type': (dict, type(None))}
+    }
 
     def __init__(self, func=np.argsort, func_params=None, n_jobs=None):
         self.func = func
@@ -154,8 +157,11 @@ class TransitionGraph(BaseEstimator, TransformerMixin):
 
         """
         check_array(X, allow_nd=True)
+        validate_params(
+            self.get_params(), self._hyperparameters, exclude=['n_jobs'])
+
         if self.func is None:
-            self._func = _identity
+            self._func = identity
         else:
             self._func = self.func
 
@@ -163,9 +169,6 @@ class TransitionGraph(BaseEstimator, TransformerMixin):
             self.effective_func_params_ = {}
         else:
             self.effective_func_params_ = self.func_params.copy()
-
-        validate_params({**self.get_params(), '_func': self._func},
-                        self._hyperparameters)
 
         return self
 

--- a/gtda/homology/cubical.py
+++ b/gtda/homology/cubical.py
@@ -1,15 +1,17 @@
 """Persistent homology on grids."""
 # License: GNU AGPLv3
 
-import numpy as np
-import numbers
-from sklearn.base import BaseEstimator, TransformerMixin
-from joblib import Parallel, delayed
-from sklearn.utils.validation import check_array, check_is_fitted
-from ._utils import _pad_diagram
-from ..utils.validation import validate_params
+from numbers import Real
 
+import numpy as np
+from joblib import Parallel, delayed
+from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.utils.validation import check_array, check_is_fitted
+
+from ._utils import _pad_diagram
 from ..externals.python import CubicalComplex, PeriodicCubicalComplex
+from ..utils.intervals import Interval
+from ..utils.validation import validate_params
 
 
 class CubicalPersistence(BaseEstimator, TransformerMixin):
@@ -24,7 +26,7 @@ class CubicalPersistence(BaseEstimator, TransformerMixin):
 
     Parameters
     ----------
-    homology_dimensions : iterable, optional, default: ``(0, 1)``
+    homology_dimensions : list or tuple, optional, default: ``(0, 1)``
         Dimensions (non-negative integers) of the topological features to be
         detected.
 
@@ -33,13 +35,14 @@ class CubicalPersistence(BaseEstimator, TransformerMixin):
         :math:`\\mathbb{F}_p = \\{ 0, \\ldots, p - 1 \\}` where
         :math:`p` equals `coeff`.
 
-    periodic_dimensions : boolean ndarray of shape (n_dimensions, ), optional,
-        default: ``np.zeros((n_dimensions, ), dtype=np.bool)``
+    periodic_dimensions : boolean ndarray of shape (n_dimensions,) or None, \
+        optional, default: ``None``
         Periodicity of the boundaries along each of the axis, where
         ``n_dimensions`` is the dimension of the images of the collection. The
         boolean in the `d`th position expresses whether the boundaries along
-        the `d`th axis are periodic. By default, none of the boundaries are
-        periodic.
+        the `d`th axis are periodic. The default ``None`` is equivalent to
+        passing ``numpy.zeros((n_dimensions,), dtype=np.bool)``, i.e. none of
+        the boundaries are periodic.
 
     infinity_values : float or None, default : ``None``
         Which death value to assign to features which are still alive at
@@ -53,7 +56,7 @@ class CubicalPersistence(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    periodic_dimensions_ : boolean ndarray of shape (n_dimensions, )
+    periodic_dimensions_ : boolean ndarray of shape (n_dimensions,)
        Effective periodicity of the boundaries along each of the axis.
        Set in :meth:`fit`.
 
@@ -63,7 +66,7 @@ class CubicalPersistence(BaseEstimator, TransformerMixin):
 
     See also
     --------
-    VietorisRipsPersistence
+    VietorisRipsPersistence, SparseRipsPersistence, EuclideanCechPersistence
 
     Notes
     -----
@@ -81,10 +84,16 @@ class CubicalPersistence(BaseEstimator, TransformerMixin):
     <http://gudhi.gforge.inria.fr/doc/latest/group__cubical__complex.html>`_.
 
     """
-    _hyperparameters = {'_homology_dimensions': [list, [int, (0, np.inf)]],
-                        'coeff': [int, (2, np.inf)],
-                        'periodic_dimensions_': [np.ndarray, (np.bool_, None)],
-                        'infinity_values_': [numbers.Number, None]}
+
+    _hyperparameters = {
+        'homology_dimensions': {
+            'type': (list, tuple), 'of': {
+                'type': int, 'in': Interval(0, np.inf, closed='left')}},
+        'coeff': {'type': int, 'in': Interval(2, np.inf, closed='left')},
+        'periodic_dimensions': {
+            'type': (np.ndarray, type(None)),
+            'of': {'type': np.bool_}},
+        'infinity_values': {'type': (Real, type(None))}}
 
     def __init__(self, homology_dimensions=(0, 1), coeff=2,
                  periodic_dimensions=None, infinity_values=None, n_jobs=None):
@@ -134,6 +143,10 @@ class CubicalPersistence(BaseEstimator, TransformerMixin):
         self : object
 
         """
+        check_array(X, allow_nd=True)
+        validate_params(
+            self.get_params(), self._hyperparameters, exclude=['n_jobs'])
+
         self._filtration_kwargs = {}
         if self.periodic_dimensions is None or \
            np.sum(self.periodic_dimensions) == 0:
@@ -152,14 +165,6 @@ class CubicalPersistence(BaseEstimator, TransformerMixin):
             self.infinity_values_ = self.infinity_values
 
         self._homology_dimensions = sorted(self.homology_dimensions)
-
-        validate_params({**self.get_params(),
-                         'periodic_dimensions_': self.periodic_dimensions_,
-                         'infinity_values_': self.infinity_values_,
-                         '_homology_dimensions': self._homology_dimensions},
-                        self._hyperparameters)
-        check_array(X, allow_nd=True)
-
         self._max_homology_dimension = self._homology_dimensions[-1]
         return self
 

--- a/gtda/homology/cubical.py
+++ b/gtda/homology/cubical.py
@@ -151,7 +151,7 @@ class CubicalPersistence(BaseEstimator, TransformerMixin):
         if self.periodic_dimensions is None or \
            np.sum(self.periodic_dimensions) == 0:
             self._filtration = CubicalComplex
-            self.periodic_dimensions_ = np.zeros((len(X) - 1,), dtype=np.bool)
+            self.periodic_dimensions_ = np.zeros(len(X) - 1, dtype=np.bool)
         else:
             self._filtration = PeriodicCubicalComplex
             self.periodic_dimensions_ = np.array(self.periodic_dimensions,

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -1,17 +1,19 @@
 """Persistent homology on point clouds or finite metric spaces."""
 # License: GNU AGPLv3
 
-import numbers
+from numbers import Real
+from types import FunctionType
 
 import numpy as np
 from joblib import Parallel, delayed
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.utils.validation import check_array, check_is_fitted
 from sklearn.metrics.pairwise import pairwise_distances
+from sklearn.utils.validation import check_array, check_is_fitted
 
 from ._utils import _postprocess_diagrams
 from ..externals.python import ripser, SparseRipsComplex, CechComplex
 from ..utils._docs import adapt_fit_transform_docs
+from ..utils.intervals import Interval
 from ..utils.validation import validate_params
 
 
@@ -44,7 +46,7 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin):
         two arrays from the entry in `X` as input, and return a value
         indicating the distance between them.
 
-    homology_dimensions : iterable, optional, default: ``(0, 1)``
+    homology_dimensions : list or tuple, optional, default: ``(0, 1)``
         Dimensions (non-negative integers) of the topological features to be
         detected.
 
@@ -77,7 +79,8 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin):
 
     See also
     --------
-    SparseRipsPersistence, ConsistentRescaling
+    SparseRipsPersistence, EuclideanCechPersistence, CubicalPersistence,
+    ConsistentRescaling
 
     Notes
     -----
@@ -98,13 +101,18 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin):
 
     """
 
-    _hyperparameters = {'max_edge_length': [numbers.Number, None],
-                        'infinity_values_': [numbers.Number, None],
-                        '_homology_dimensions': [list, [int, (0, np.inf)]],
-                        'coeff': [int, (2, np.inf)]}
+    _hyperparameters = {
+        'metric': {'type': (str, FunctionType)},
+        'homology_dimensions': {
+            'type': (list, tuple), 'of': {
+                'type': int, 'in': Interval(0, np.inf, closed='left')}},
+        'coeff': {'type': int, 'in': Interval(2, np.inf, closed='left')},
+        'max_edge_length': {'type': Real},
+        'infinity_values': {'type': (Real, type(None))}
+    }
 
-    def __init__(self, metric='euclidean', max_edge_length=np.inf,
-                 homology_dimensions=(0, 1), coeff=2, infinity_values=None,
+    def __init__(self, metric='euclidean', homology_dimensions=(0, 1),
+                 coeff=2, max_edge_length=np.inf, infinity_values=None,
                  n_jobs=None):
         self.metric = metric
         self.homology_dimensions = homology_dimensions
@@ -154,19 +162,16 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin):
         self : object
 
         """
+        check_array(X, allow_nd=True, force_all_finite=False)
+        validate_params(
+            self.get_params(), self._hyperparameters, exclude=['n_jobs'])
+
         if self.infinity_values is None:
             self.infinity_values_ = self.max_edge_length
         else:
             self.infinity_values_ = self.infinity_values
 
         self._homology_dimensions = sorted(self.homology_dimensions)
-
-        validate_params({**self.get_params(),
-                         'infinity_values_': self.infinity_values_,
-                         '_homology_dimensions': self._homology_dimensions},
-                        self._hyperparameters)
-        check_array(X, allow_nd=True, force_all_finite=False)
-
         self._max_homology_dimension = self._homology_dimensions[-1]
         return self
 
@@ -246,7 +251,7 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin):
         two arrays from the entry in `X` as input, and return a value
         indicating the distance between them.
 
-    homology_dimensions : iterable, optional, default: ``(0, 1)``
+    homology_dimensions : list or tuple, optional, default: ``(0, 1)``
         Dimensions (non-negative integers) of the topological features to be
         detected.
 
@@ -284,7 +289,8 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin):
 
     See also
     --------
-    VietorisRipsPersistence, ConsistentRescaling
+    VietorisRipsPersistence, EuclideanCechPersistence, CubicalPersistence,
+    ConsistentRescaling
 
     Notes
     -----
@@ -303,14 +309,20 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin):
         cohomology.html>`_.
 
     """
-    _hyperparameters = {'epsilon': [numbers.Number, (0., 1.)],
-                        'max_edge_length': [numbers.Number, None],
-                        'infinity_values_': [numbers.Number, None],
-                        '_homology_dimensions': [list, [int, (0, np.inf)]],
-                        'coeff': [int, (2, np.inf)]}
 
-    def __init__(self, metric='euclidean', max_edge_length=np.inf,
-                 homology_dimensions=(0, 1), coeff=2, epsilon=0.1,
+    _hyperparameters = {
+        'metric': {'type': (str, FunctionType)},
+        'homology_dimensions': {
+            'type': (list, tuple), 'of': {
+                'type': int, 'in': Interval(0, np.inf, closed='left')}},
+        'coeff': {'type': int, 'in': Interval(2, np.inf, closed='left')},
+        'epsilon': {'type': Real, 'in': Interval(0, 1, closed='both')},
+        'max_edge_length': {'type': Real},
+        'infinity_values': {'type': (Real, type(None))}
+    }
+
+    def __init__(self, metric='euclidean', homology_dimensions=(0, 1),
+                 coeff=2, epsilon=0.1, max_edge_length=np.inf,
                  infinity_values=None, n_jobs=None):
         self.metric = metric
         self.homology_dimensions = homology_dimensions
@@ -370,19 +382,16 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin):
         self : object
 
         """
+        check_array(X, allow_nd=True, force_all_finite=False)
+        validate_params(
+            self.get_params(), self._hyperparameters, exclude=['n_jobs'])
+
         if self.infinity_values is None:
             self.infinity_values_ = self.max_edge_length
         else:
             self.infinity_values_ = self.infinity_values
 
         self._homology_dimensions = sorted(self.homology_dimensions)
-
-        validate_params({**self.get_params(),
-                         'infinity_values_': self.infinity_values_,
-                         '_homology_dimensions': self._homology_dimensions},
-                        self._hyperparameters)
-        check_array(X, allow_nd=True, force_all_finite=False)
-
         self._max_homology_dimension = self._homology_dimensions[-1]
         return self
 
@@ -447,7 +456,7 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin):
 
     Parameters
     ----------
-    homology_dimensions : iterable, optional, default: ``(0, 1)``
+    homology_dimensions : list or tuple, optional, default: ``(0, 1)``
         Dimensions (non-negative integers) of the topological features to be
         detected.
 
@@ -480,7 +489,8 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin):
 
     See also
     --------
-    VietorisRipsPersistence, SparseRipsPersistence, ConsistentRescaling
+    VietorisRipsPersistence, SparseRipsPersistence, CubicalPersistence,
+    ConsistentRescaling
 
     Notes
     -----
@@ -499,13 +509,21 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin):
         cohomology.html>`_.
 
     """
-    _hyperparameters = {'max_edge_length': [numbers.Number, None],
-                        'infinity_values_': [numbers.Number, None],
-                        '_homology_dimensions': [list, [int, (0, np.inf)]],
-                        'coeff': [int, (2, np.inf)]}
 
-    def __init__(self, max_edge_length=np.inf, homology_dimensions=(0, 1),
-                 coeff=2, infinity_values=None, n_jobs=None):
+    _hyperparameters = {
+        'homology_dimensions': {
+            'type': (list, tuple), 'of': {
+                'type': int, 'in': Interval(0, np.inf, closed='left')}},
+        'coeff': {'type': int, 'in': Interval(2, np.inf, closed='left')},
+        'max_edge_length': {
+            'type': Real, 'in': Interval(0, np.inf, closed='right')},
+        'infinity_values': {
+            'type': (Real, type(None)),
+            'in': Interval(0, np.inf, closed='neither')},
+    }
+
+    def __init__(self, homology_dimensions=(0, 1), coeff=2,
+                 max_edge_length=np.inf, infinity_values=None, n_jobs=None):
         self.homology_dimensions = homology_dimensions
         self.coeff = coeff
         self.max_edge_length = max_edge_length
@@ -555,19 +573,16 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin):
         self : object
 
         """
+        check_array(X, allow_nd=True)
+        validate_params(
+            self.get_params(), self._hyperparameters, exclude=['n_jobs'])
+
         if self.infinity_values is None:
             self.infinity_values_ = self.max_edge_length
         else:
             self.infinity_values_ = self.infinity_values
 
         self._homology_dimensions = sorted(self.homology_dimensions)
-
-        validate_params({**self.get_params(),
-                         'infinity_values_': self.infinity_values_,
-                         '_homology_dimensions': self._homology_dimensions},
-                        self._hyperparameters)
-        check_array(X, allow_nd=True)
-
         self._max_homology_dimension = self._homology_dimensions[-1]
         return self
 

--- a/gtda/images/filtrations.py
+++ b/gtda/images/filtrations.py
@@ -274,8 +274,8 @@ class RadialFiltration(BaseEstimator, TransformerMixin):
         return Xr
 
     def fit(self, X, y=None):
-        """Calculate :attr:`center_`, :attr:'effective_metric_params_',
-        :attr:`n_dimensions_`, :attr:'mesh_' and :attr:`max_value_` from a
+        """Calculate :attr:`center_`, :attr:`effective_metric_params_`,
+        :attr:`n_dimensions_`, :attr:`mesh_` and :attr:`max_value_` from a
         collection of binary images. Then, return the estimator.
 
         This method is here to implement the usual scikit-learn API and hence
@@ -534,7 +534,7 @@ class ErosionFiltration(BaseEstimator, TransformerMixin):
     ----------
     n_iterations : int or None, optional, default: ``None``
         Number of iterations in the erosion process. ``None`` means erosion
-       reaches all activated pixels.
+        reaches all activated pixels.
 
     n_jobs : int or None, optional, default: ``None``
         The number of jobs to use for the computation. ``None`` means 1 unless
@@ -576,7 +576,7 @@ class ErosionFiltration(BaseEstimator, TransformerMixin):
         return Xe
 
     def fit(self, X, y=None):
-        """Calculate :attr:`n_iterations_` and :attr:`max_value_`from a
+        """Calculate :attr:`n_iterations_` and :attr:`max_value_` from a
         collection of binary images. Then, return the estimator.
 
         This method is here to implement the usual scikit-learn API and hence

--- a/gtda/images/filtrations.py
+++ b/gtda/images/filtrations.py
@@ -305,7 +305,7 @@ class RadialFiltration(BaseEstimator, TransformerMixin):
             self.get_params(), self._hyperparameters, exclude=['n_jobs'])
 
         if self.center is None:
-            self.center_ = np.zeros((self.n_dimensions_,))
+            self.center_ = np.zeros(self.n_dimensions_)
         else:
             self.center_ = np.copy(self.center)
         self.center_ = self.center_.reshape((1, -1))

--- a/gtda/images/filtrations.py
+++ b/gtda/images/filtrations.py
@@ -3,6 +3,7 @@
 
 from numbers import Real
 from types import FunctionType
+from warnings import warn
 
 import numpy as np
 from joblib import Parallel, delayed, effective_n_jobs
@@ -109,10 +110,8 @@ class HeightFiltration(BaseEstimator, TransformerMixin):
         X = check_array(X, allow_nd=True)
         self.n_dimensions_ = X.ndim - 1
         if (self.n_dimensions_ < 2) or (self.n_dimensions_ > 3):
-            raise ValueError(
-                f"Input of `fit` must be a collection of 2D or 3D arrays "
-                f"representing images. Arrays of dimension "
-                f"{self.n_dimensions_} detected.")
+            warn(f"Input of `fit` contains arrays of dimension "
+                 f"{self.n_dimensions_}.")
         validate_params(
             self.get_params(), self._hyperparameters, exclude=['n_jobs'])
 
@@ -300,10 +299,8 @@ class RadialFiltration(BaseEstimator, TransformerMixin):
         X = check_array(X, allow_nd=True)
         self.n_dimensions_ = X.ndim - 1
         if (self.n_dimensions_ < 2) or (self.n_dimensions_ > 3):
-            raise ValueError(
-                f"Input of `fit` must be a collection of 2D or 3D arrays "
-                f"representing images. Arrays of dimension "
-                f"{self.n_dimensions_} detected.")
+            warn(f"Input of `fit` contains arrays of dimension "
+                 f"{self.n_dimensions_}.")
         validate_params(
             self.get_params(), self._hyperparameters, exclude=['n_jobs'])
 
@@ -462,10 +459,8 @@ class DilationFiltration(BaseEstimator, TransformerMixin):
         X = check_array(X, allow_nd=True)
         n_dimensions = X.ndim - 1
         if (n_dimensions < 2) or (n_dimensions > 3):
-            raise ValueError(
-                f"Input of `fit` must be a collection of 2D or 3D arrays "
-                f"representing images. Arrays of dimension "
-                f"{n_dimensions} detected.")
+            warn(f"Input of `fit` contains arrays of dimension "
+                 f"{self.n_dimensions_}.")
         validate_params(
             self.get_params(), self._hyperparameters, exclude=['n_jobs'])
 
@@ -605,10 +600,8 @@ class ErosionFiltration(BaseEstimator, TransformerMixin):
         X = check_array(X, allow_nd=True)
         n_dimensions = X.ndim - 1
         if (n_dimensions < 2) or (n_dimensions > 3):
-            raise ValueError(
-                f"Input of `fit` must be a collection of 2D or 3D arrays "
-                f"representing images. Arrays of dimension "
-                f"{n_dimensions} detected.")
+            warn(f"Input of `fit` contains arrays of dimension "
+                 f"{self.n_dimensions_}.")
         validate_params(
             self.get_params(), self._hyperparameters, exclude=['n_jobs'])
 
@@ -758,10 +751,8 @@ class SignedDistanceFiltration(BaseEstimator, TransformerMixin):
         X = check_array(X, allow_nd=True)
         n_dimensions = X.ndim - 1
         if (n_dimensions < 2) or (n_dimensions > 3):
-            raise ValueError(
-                f"Input of `fit` must be a collection of 2D or 3D arrays "
-                f"representing images. Arrays of dimension "
-                f"{n_dimensions} detected.")
+            warn(f"Input of `fit` contains arrays of dimension "
+                 f"{self.n_dimensions_}.")
         validate_params(
             self.get_params(), self._hyperparameters, exclude=['n_jobs'])
 

--- a/gtda/images/preprocessing.py
+++ b/gtda/images/preprocessing.py
@@ -372,7 +372,7 @@ class ImageToPointCloud(BaseEstimator, TransformerMixin):
         self.n_jobs = n_jobs
 
     def _embed(self, X):
-        Xpts = np.stack([self.mesh_ for _ in range(X.shape[0])]) * 1.0
+        Xpts = np.stack([self.mesh_ for _ in range(X.shape[0])]) * 1.
         Xpts[np.logical_not(X.reshape((X.shape[0], -1))), :] += np.inf
         return Xpts
 

--- a/gtda/images/preprocessing.py
+++ b/gtda/images/preprocessing.py
@@ -297,8 +297,6 @@ class Padder(BaseEstimator, TransformerMixin):
         else:
             self.paddings_ = self.paddings
 
-
-
         self._pad_width = ((0, 0),
                            *[(self.paddings_[axis], self.paddings_[axis])
                              for axis in range(n_dimensions)])

--- a/gtda/images/preprocessing.py
+++ b/gtda/images/preprocessing.py
@@ -358,8 +358,8 @@ class ImageToPointCloud(BaseEstimator, TransformerMixin):
     mesh_ : ndarray, shape (n_pixels_x * n_pixels_y [* n_pixels_z], \
         n_dimensions)
         Mesh image for which each pixel value is its coordinates in a
-        `n_dimensions` space, where `n_dimensions` is the dimension of the
-        images of the input collection. Set in meth:`fit`.
+        ``n_dimensions``-dimensional space, where ``n_dimensions`` is the
+        dimension of the images of the input collection. Set in meth:`fit`.
 
     See also
     --------
@@ -432,7 +432,7 @@ class ImageToPointCloud(BaseEstimator, TransformerMixin):
         Xt : ndarray, shape (n_samples, n_pixels_x * n_pixels_y [* n_pixels_z],
             n_dimensions)
             Transformed collection of images. Each entry along axis 0 is a
-            point cloud in a `n_dimensions` dimensional space.
+            point cloud in ``n_dimensions``-dimensional space.
 
         """
         check_is_fitted(self)

--- a/gtda/images/preprocessing.py
+++ b/gtda/images/preprocessing.py
@@ -2,6 +2,7 @@
 # License: GNU AGPLv3
 
 from numbers import Real
+from warnings import warn
 
 import numpy as np
 from joblib import Parallel, delayed, effective_n_jobs
@@ -91,10 +92,8 @@ class Binarizer(BaseEstimator, TransformerMixin):
         X = check_array(X, allow_nd=True)
         self.n_dimensions_ = X.ndim - 1
         if (self.n_dimensions_ < 2) or (self.n_dimensions_ > 3):
-            raise ValueError(
-                f"Input of `fit` must be a collection of 2D or 3D arrays "
-                f"representing images. Arrays of dimension "
-                f"{self.n_dimensions_} detected.")
+            warn(f"Input of `fit` contains arrays of dimension "
+                 f"{self.n_dimensions_}.")
         validate_params(
             self.get_params(), self._hyperparameters, exclude=['n_jobs'])
 
@@ -281,10 +280,8 @@ class Padder(BaseEstimator, TransformerMixin):
         check_array(X, allow_nd=True)
         n_dimensions = X.ndim - 1
         if n_dimensions < 2 or n_dimensions > 3:
-            raise ValueError(
-                f"Input of `fit` must be a collection of 2D or 3D arrays "
-                f"representing images. Arrays of dimension "
-                f"{n_dimensions} detected.")
+            warn(f"Input of `fit` contains arrays of dimension "
+                 f"{self.n_dimensions_}.")
         validate_params(
             self.get_params(), self._hyperparameters, exclude=['n_jobs'])
 
@@ -293,7 +290,7 @@ class Padder(BaseEstimator, TransformerMixin):
         elif len(self.paddings) != n_dimensions:
             raise ValueError(
                 f"`paddings` has length {self.paddings} while the input "
-                f"data requires it to have length equal to {n_dimensions}")
+                f"data requires it to have length equal to {n_dimensions}.")
         else:
             self.paddings_ = self.paddings
 
@@ -402,10 +399,8 @@ class ImageToPointCloud(BaseEstimator, TransformerMixin):
         X = check_array(X, allow_nd=True)
         n_dimensions = X.ndim - 1
         if n_dimensions < 2 or n_dimensions > 3:
-            raise ValueError(
-                f"Input of `fit` must be a collection of 2D or 3D arrays "
-                f"representing images. Arrays of dimension "
-                f"{n_dimensions} detected.")
+            warn(f"Input of `fit` contains arrays of dimension "
+                 f"{self.n_dimensions_}.")
 
         axis_order = [2, 1, 3]
         mesh_range_list = [np.arange(0, X.shape[i])

--- a/gtda/images/tests/test_filtrations.py
+++ b/gtda/images/tests/test_filtrations.py
@@ -68,8 +68,9 @@ images_3D_height = np.array(
 
 @pytest.mark.parametrize("direction, images, expected",
                          [(None, images_2D, images_2D_height),
-                          ([1, 1], images_2D, images_2D_height),
-                          ([1, 0, 1], images_3D, images_3D_height)])
+                          (np.asarray([1, 1]), images_2D, images_2D_height),
+                          (np.asarray([1, 0, 1]), images_3D,
+                           images_3D_height)])
 def test_height_transform(direction, images, expected):
     height = HeightFiltration(direction=direction)
 
@@ -119,8 +120,9 @@ images_3D_radial = np.array(
 
 @pytest.mark.parametrize("center, images, expected",
                          [(None, images_2D, images_2D_radial),
-                          ([0, 0], images_2D, images_2D_radial),
-                          ([1, 0, 1], images_3D, images_3D_radial)])
+                          (np.asarray([0, 0]), images_2D, images_2D_radial),
+                          (np.asarray([1, 0, 1]), images_3D,
+                           images_3D_radial)])
 def test_radial_transform(center, images, expected):
     radial = RadialFiltration(center=center)
 

--- a/gtda/mapper/__init__.py
+++ b/gtda/mapper/__init__.py
@@ -5,10 +5,10 @@ from .cluster import FirstHistogramGap, FirstSimpleGap
 from .cover import CubicalCover, OneDimensionalCover
 from .filter import Eccentricity, Entropy, Projection
 from .pipeline import make_mapper_pipeline
-from .visualization import (
-    plot_static_mapper_graph, plot_interactive_mapper_graph)
 from .utils.decorators import method_to_transform
 from .utils.pipeline import transformer_from_callable_on_rows
+from .visualization import plot_static_mapper_graph, \
+    plot_interactive_mapper_graph
 
 __all__ = [
     'Projection',

--- a/gtda/mapper/cluster.py
+++ b/gtda/mapper/cluster.py
@@ -450,7 +450,7 @@ class FirstSimpleGap(ClusterMixin, BaseEstimator, Agglomerative):
 
         min_gap_size = self.relative_gap_size * self.distances_[-1]
         self.n_clusters_ = _num_clusters_simple(
-            self.distances_, min_gap_size, self.max_fraction)
+            self.distances_, min_gap_size, _max_fraction)
 
         # Cut the tree to find labels
         # TODO: Verify whether Daniel Mullner's implementation of this step
@@ -606,7 +606,7 @@ class FirstHistogramGap(ClusterMixin, BaseEstimator, Agglomerative):
 
         self.n_clusters_ = _num_clusters_histogram(
             self.distances_, self.freq_threshold, self.n_bins_start,
-            self.max_fraction)
+            _max_fraction)
 
         # Cut the tree to find labels
         # TODO: Verify whether Daniel Mullner's implementation of this step

--- a/gtda/mapper/cluster.py
+++ b/gtda/mapper/cluster.py
@@ -2,6 +2,7 @@
 # License: GNU AGPLv3
 
 from inspect import signature
+from numbers import Real
 
 import numpy as np
 from joblib import Parallel, delayed
@@ -15,6 +16,7 @@ except ImportError:
 from sklearn.utils import check_array
 from sklearn.utils.validation import check_memory
 
+from ..utils.intervals import Interval
 from ..utils.validation import validate_params
 from .utils._cluster import _num_clusters_histogram, _num_clusters_simple
 
@@ -396,8 +398,14 @@ class FirstSimpleGap(ClusterMixin, BaseEstimator, Agglomerative):
 
     """
 
-    _hyperparameters = {'relative_gap_size': [float, (0, 1)],
-                        'max_fraction': [float, (0, 1)]}
+    _hyperparameters = {
+        'relative_gap_size': {
+            'type': Real, 'in': Interval(0, 1, closed='right')},
+        'max_fraction': {
+            'type': (Real, type(None)), 'in': Interval(0, 1, closed='right')},
+        'affinity': {'type': str},
+        'linkage': {'type': str}
+    }
 
     def __init__(self, relative_gap_size=0.3, max_fraction=None,
                  affinity='euclidean', memory=None, linkage='single'):
@@ -427,11 +435,11 @@ class FirstSimpleGap(ClusterMixin, BaseEstimator, Agglomerative):
         self
 
         """
-        _max_fraction = 1. if self.max_fraction is None else self.max_fraction
-        validate_params({'relative_gap_size': self.relative_gap_size,
-                         'max_fraction': _max_fraction},
-                        self._hyperparameters)
         X = check_array(X)
+        validate_params(
+            self.get_params(), self._hyperparameters, exclude=['memory'])
+
+        _max_fraction = 1. if self.max_fraction is None else self.max_fraction
 
         if X.shape[0] == 1:
             self.labels_ = np.array([0])
@@ -543,9 +551,16 @@ class FirstHistogramGap(ClusterMixin, BaseEstimator, Agglomerative):
 
     """
 
-    _hyperparameters = {'freq_threshold': [int, (0, np.inf)],
-                        'max_fraction': [float, (0, 1)],
-                        'n_bins_start': [int, (1, np.inf)]}
+    _hyperparameters = {
+        'freq_threshold': {
+            'type': int, 'in': Interval(0, np.inf, closed='left')},
+        'max_fraction': {
+            'type': (Real, type(None)), 'in': Interval(0, 1, closed='right')},
+        'n_bins_start': {
+            'type': int, 'in': Interval(1, np.inf, closed='left')},
+        'affinity': {'type': str},
+        'linkage': {'type': str}
+    }
 
     def __init__(self, freq_threshold=0, max_fraction=None, n_bins_start=5,
                  affinity='euclidean', memory=None, linkage='single'):
@@ -576,12 +591,12 @@ class FirstHistogramGap(ClusterMixin, BaseEstimator, Agglomerative):
         self
 
         """
-        _max_fraction = 1. if self.max_fraction is None else self.max_fraction
-        validate_params({'freq_threshold': self.freq_threshold,
-                         'max_fraction': _max_fraction,
-                         'n_bins_start': self.n_bins_start},
-                        self._hyperparameters)
         X = check_array(X)
+        validate_params(
+            self.get_params(), self._hyperparameters, exclude=['memory'])
+
+        _max_fraction = 1. if self.max_fraction is None else self.max_fraction
+
         if X.shape[0] == 1:
             self.labels_ = np.array([0])
             self.n_clusters_ = 1

--- a/gtda/mapper/tests/test_cover.py
+++ b/gtda/mapper/tests/test_cover.py
@@ -225,33 +225,3 @@ def test_cubical_fit_A_transform_consistent_with_OneD(filter, kind,
     x_one_d = one_d.fit(filter).transform(filter)
     x_cubical = cubical.fit(filter).transform(filter)
     assert_almost_equal(x_one_d, x_cubical)
-
-# @given(
-#     filter_values=arrays(dtype=np.float,
-#                          elements=floats(allow_nan=False,
-#                                          allow_infinity=False,
-#                                          min_value=-1e10,
-#                                          max_value=1e10),
-#                          shape=array_shapes(min_dims=1, max_dims=1,
-#                                             min_side=2),
-#                          unique=True),
-#     n_intervals=integers(min_value=4, max_value=50),
-#     overlap_frac=floats(allow_nan=False,
-#                         allow_infinity=False,
-#                         min_value=0.01,
-#                         max_value=1.)
-# )
-# def test_overlap_fraction(filter_values, n_intervals, overlap_frac):
-#     cover = OneDimensionalCover(kind='uniform',
-#                                 n_intervals=n_intervals,
-#                                 overlap_frac=overlap_frac)
-#     cover.fit(filter_values)
-
-#     lower_limits = cover.left_limits_[1:-1]
-#     upper_limits = cover.right_limits_[1:-1]
-#     lengths = (upper_limits[:-1] - lower_limits[:-1])
-
-#     overlap_array = (upper_limits[:-1] - lower_limits[1:]) / lengths
-#     expected_overlap_array = np.array([overlap_frac] * (n_intervals - 3))
-
-#     assert_allclose(overlap_array, expected_overlap_array, rtol=1e-5)

--- a/gtda/mapper/utils/_logging.py
+++ b/gtda/mapper/utils/_logging.py
@@ -25,7 +25,7 @@ class OutputWidgetHandler(logging.Handler):
             'output_type': 'stream',
             'text': formatted_record+'\n'
         }
-        self.out.outputs = (new_output, ) + self.out.outputs
+        self.out.outputs = (new_output,) + self.out.outputs
 
     def show_logs(self):
         """Show the logs"""

--- a/gtda/mapper/utils/visualization.py
+++ b/gtda/mapper/utils/visualization.py
@@ -17,7 +17,7 @@ def _get_node_size(node_elements):
 
 def _get_node_text(graph):
     return [
-        f"Node ID:{node_id}<br>Node size:{len(node_elements)}"
+        f"Node ID: {node_id}<br>Node size: {len(node_elements)}"
         for node_id, node_elements in zip(
             graph["node_metadata"]["node_id"],
             graph["node_metadata"]["node_elements"])

--- a/gtda/pipeline.py
+++ b/gtda/pipeline.py
@@ -291,13 +291,13 @@ class Pipeline(pipeline.Pipeline):
 
         Parameters
         ----------
-        y : array-like, shape = (n_samples, )
+        y : array-like, shape = (n_samples,)
             Data to resample. Must fulfill input requirements of first step
             of the pipeline.
 
         Returns
         -------
-        yr : array-like, shape = (n_samples_new, )
+        yr : array-like, shape = (n_samples_new,)
         """
         # _final_estimator is None or has transform, otherwise attribute error
         if self._final_estimator != 'passthrough':
@@ -327,7 +327,7 @@ class Pipeline(pipeline.Pipeline):
         Returns
         -------
         Xt : array-like, shape = (n_samples_new, n_transformed_features)
-        yr : array-like, shape = (n_samples_new, )
+        yr : array-like, shape = (n_samples_new,)
         """
         # _final_estimator is None or has transform, otherwise attribute error
         final_estimator = self._final_estimator

--- a/gtda/point_clouds/rescaling.py
+++ b/gtda/point_clouds/rescaling.py
@@ -2,7 +2,9 @@
 # License: GNU AGPLv3
 
 import itertools
-import numbers
+from numbers import Real
+from types import FunctionType
+
 import numpy as np
 from joblib import Parallel, delayed
 from sklearn.base import BaseEstimator, TransformerMixin
@@ -10,6 +12,7 @@ from sklearn.metrics import pairwise_distances
 from sklearn.utils.validation import check_array, check_is_fitted
 
 from ..utils._docs import adapt_fit_transform_docs
+from ..utils.intervals import Interval
 from ..utils.validation import validate_params
 
 
@@ -85,7 +88,13 @@ class ConsistentRescaling(BaseEstimator, TransformerMixin):
            <http://dx.doi.org/10.3934/fods.2019001>`_.
 
     """
-    _hyperparameters = {'neighbor_rank': [int, (1, np.inf)]}
+
+    _hyperparameters = {
+        'metric': {'type': (str, FunctionType)},
+        'metric_params': {'type': (dict, type(None))},
+        'neighbor_rank': {
+            'type': int, 'in': Interval(1, np.inf, closed='left')}
+    }
 
     def __init__(self, metric='euclidean', metric_params=None, neighbor_rank=1,
                  n_jobs=None):
@@ -136,13 +145,14 @@ class ConsistentRescaling(BaseEstimator, TransformerMixin):
         self : object
 
         """
+        check_array(X, allow_nd=True)
+        validate_params(
+            self.get_params(), self._hyperparameters, exclude=['n_jobs'])
+
         if self.metric_params is None:
             self.effective_metric_params_ = {}
         else:
             self.effective_metric_params_ = self.metric_params.copy()
-
-        validate_params(self.get_params(), self._hyperparameters)
-        check_array(X, allow_nd=True)
 
         return self
 
@@ -172,11 +182,11 @@ class ConsistentRescaling(BaseEstimator, TransformerMixin):
 
         """
         check_is_fitted(self)
-        X = check_array(X, allow_nd=True, copy=True)
+        Xt = check_array(X, allow_nd=True, copy=True)
 
         Xt = Parallel(n_jobs=self.n_jobs)(
-            delayed(self._consistent_rescaling)(X[i])
-            for i in range(X.shape[0]))
+            delayed(self._consistent_rescaling)(Xt[i])
+            for i in range(Xt.shape[0]))
         Xt = np.array(Xt)
         return Xt
 
@@ -244,7 +254,13 @@ class ConsecutiveRescaling(BaseEstimator, TransformerMixin):
     VietorisRipsPersistence
 
     """
-    _hyperparameters = {'factor': [numbers.Number, (0., np.inf)]}
+
+    _hyperparameters = {
+        'metric': {'type': (str, FunctionType)},
+        'metric_params': {'type': (dict, type(None))},
+        'factor': {
+            'type': Real, 'in': Interval(0, np.inf, closed='both')}
+    }
 
     def __init__(self, metric='euclidean', metric_params=None, factor=0.,
                  n_jobs=None):
@@ -286,13 +302,14 @@ class ConsecutiveRescaling(BaseEstimator, TransformerMixin):
         self : object
 
         """
+        check_array(X, allow_nd=True)
+        validate_params(
+            self.get_params(), self._hyperparameters, exclude=['n_jobs'])
+
         if self.metric_params is None:
             self.effective_metric_params_ = {}
         else:
             self.effective_metric_params_ = self.metric_params.copy()
-
-        validate_params(self.get_params(), self._hyperparameters)
-        check_array(X, allow_nd=True)
 
         return self
 
@@ -322,10 +339,10 @@ class ConsecutiveRescaling(BaseEstimator, TransformerMixin):
 
         """
         check_is_fitted(self)
-        X = check_array(X, allow_nd=True, copy=True)
+        Xt = check_array(X, allow_nd=True, copy=True)
 
         Xt = Parallel(n_jobs=self.n_jobs)(
-            delayed(self._consecutive_rescaling)(X[i])
-            for i in range(X.shape[0]))
+            delayed(self._consecutive_rescaling)(Xt[i])
+            for i in range(Xt.shape[0]))
         Xt = np.array(Xt)
         return Xt

--- a/gtda/time_series/embedding.py
+++ b/gtda/time_series/embedding.py
@@ -10,6 +10,7 @@ from sklearn.utils.validation import check_is_fitted, check_array, column_or_1d
 
 from ..base import TransformerResamplerMixin
 from ..utils._docs import adapt_fit_transform_docs
+from ..utils.intervals import Interval
 from ..utils.validation import validate_params
 
 
@@ -71,8 +72,10 @@ class SlidingWindow(BaseEstimator, TransformerResamplerMixin):
 
     """
 
-    _hyperparameters = {'width': [int, (1, np.inf)],
-                        'stride': [int, (1, np.inf)]}
+    _hyperparameters = {
+        'width': {'type': int, 'in': Interval(1, np.inf, closed='left')},
+        'stride': {'type': int, 'in': Interval(1, np.inf, closed='left')}
+    }
 
     def __init__(self, width=10, stride=1):
         self.width = width
@@ -107,8 +110,8 @@ class SlidingWindow(BaseEstimator, TransformerResamplerMixin):
         self
 
         """
-        validate_params(self.get_params(), self._hyperparameters)
         check_array(X, ensure_2d=False, allow_nd=True)
+        validate_params(self.get_params(), self._hyperparameters)
 
         self._is_fitted = True
         return self
@@ -297,10 +300,12 @@ class TakensEmbedding(BaseEstimator, TransformerResamplerMixin):
 
     """
 
-    _hyperparameters = {'parameters_type': [str, ['fixed', 'search']],
-                        'time_delay': [int, (1, np.inf)],
-                        'dimension': [int, (1, np.inf)],
-                        'stride': [int, (1, np.inf)]}
+    _hyperparameters = {
+        'parameters_type': {'type': str, 'in': ['fixed', 'search']},
+        'time_delay': {'type': int, 'in': Interval(1, np.inf, closed='left')},
+        'dimension': {'type': int, 'in': Interval(1, np.inf, closed='left')},
+        'stride': {'type': int, 'in': Interval(1, np.inf, closed='left')}
+    }
 
     def __init__(self, parameters_type='search', time_delay=1, dimension=5,
                  stride=1, n_jobs=None):
@@ -389,8 +394,10 @@ class TakensEmbedding(BaseEstimator, TransformerResamplerMixin):
         self : object
 
         """
-        validate_params(self.get_params(), self._hyperparameters)
         X = check_array(X, ensure_2d=False)
+        validate_params(
+            self.get_params(), self._hyperparameters, exclude=['n_jobs'])
+
         if X.ndim == 1:
             X = X[:, None]
 

--- a/gtda/time_series/embedding.py
+++ b/gtda/time_series/embedding.py
@@ -349,7 +349,7 @@ class TakensEmbedding(BaseEstimator, TransformerResamplerMixin):
         distance = distances[:, 1]
         X_first_nbhrs = X[indices[:, 1]]
 
-        epsilon = 2.0 * np.std(X)
+        epsilon = 2. * np.std(X)
         tolerance = 10
 
         neg_dim_delay = - dimension * time_delay

--- a/gtda/time_series/multivariate.py
+++ b/gtda/time_series/multivariate.py
@@ -45,7 +45,8 @@ class PearsonDissimilarity(BaseEstimator, TransformerMixin):
 
     """
 
-    _hyperparameters = {'absolute_value': [bool, (0, 1)]}
+    _hyperparameters = {
+        'absolute_value': {'type': bool}}
 
     def __init__(self, absolute_value=False, n_jobs=None):
         self.absolute_value = absolute_value
@@ -72,8 +73,9 @@ class PearsonDissimilarity(BaseEstimator, TransformerMixin):
         self : object
 
         """
-        validate_params(self.get_params(), self._hyperparameters)
         check_array(X, allow_nd=True)
+        validate_params(
+            self.get_params(), self._hyperparameters, exclude=['n_jobs'])
 
         self._is_fitted = True
         return self

--- a/gtda/time_series/preprocessing.py
+++ b/gtda/time_series/preprocessing.py
@@ -8,6 +8,7 @@ from sklearn.utils.validation import check_is_fitted
 
 from ..base import TransformerResamplerMixin
 from ..utils._docs import adapt_fit_transform_docs
+from ..utils.intervals import Interval
 from ..utils.validation import validate_params
 
 
@@ -37,7 +38,8 @@ class Resampler(BaseEstimator, TransformerResamplerMixin):
 
     """
 
-    _hyperparameters = {'period': [int, (1, np.inf)]}
+    _hyperparameters = {
+        'period': {'type': int, 'in': Interval(1, np.inf, closed='left')}}
 
     def __init__(self, period=2):
         self.period = period
@@ -61,8 +63,8 @@ class Resampler(BaseEstimator, TransformerResamplerMixin):
         self : object
 
         """
-        validate_params(self.get_params(), self._hyperparameters)
         check_array(X, ensure_2d=False, allow_nd=True)
+        validate_params(self.get_params(), self._hyperparameters)
 
         self._is_fitted = True
         return self
@@ -156,7 +158,8 @@ class Stationarizer(BaseEstimator, TransformerResamplerMixin):
 
     """
 
-    _hyperparameters = {'operation': [str, ['return', 'log-return']]}
+    _hyperparameters = {
+        'operation': {'type': str, 'in': ['return', 'log-return']}}
 
     def __init__(self, operation='return'):
         self.operation = operation
@@ -180,8 +183,8 @@ class Stationarizer(BaseEstimator, TransformerResamplerMixin):
         self : object
 
         """
-        validate_params(self.get_params(), self._hyperparameters)
         check_array(X, ensure_2d=False, allow_nd=True)
+        validate_params(self.get_params(), self._hyperparameters)
 
         self._is_fitted = True
         return self

--- a/gtda/time_series/target.py
+++ b/gtda/time_series/target.py
@@ -1,8 +1,8 @@
 """Time series labelling."""
 # License: GNU AGPLv3
 
-import numbers
-import types
+from numbers import Real
+from types import FunctionType
 
 import numpy as np
 from sklearn.base import BaseEstimator
@@ -11,6 +11,7 @@ from sklearn.utils.validation import check_is_fitted, column_or_1d
 from .embedding import SlidingWindow
 from ..base import TransformerResamplerMixin
 from ..utils._docs import adapt_fit_transform_docs
+from ..utils.intervals import Interval
 from ..utils.validation import validate_params
 
 
@@ -31,11 +32,11 @@ class Labeller(BaseEstimator, TransformerResamplerMixin):
     func : callable, optional, default: ``numpy.std``
         Function to be applied to each window.
 
-    func_params : dict, optional, default: ``{}``
+    func_params : dict or None, optional, default: ``None``
         Additional keyword arguments for `func`.
 
-    percentiles : list of ordered floats between 0 and 1 or None, optional, \
-                  default: ``None``
+    percentiles : list of real numbers between 0 and 100 inclusive, or \
+        None, optional, default: ``None``
         If ``None``, creates a target for a regression task. Otherwise,
         creates a target for an n-class classification task where
         ``n = len(percentiles) + 1``.
@@ -74,12 +75,18 @@ class Labeller(BaseEstimator, TransformerResamplerMixin):
     """
 
     _hyperparameters = {
-        'func': [types.FunctionType, None],
-        '_percentiles': [list, [numbers.Number, (0., 100.)]],
-        'n_steps_future': [int, [1, np.inf]]}
+        'width': {'type': int, 'in': Interval(1, np.inf, closed='left')},
+        'func': {'type': FunctionType},
+        'func_params': {'type': (dict, type(None))},
+        'percentiles': {
+            'type': (list, type(None)),
+            'of': {'type': Real, 'in': Interval(0, 100, closed='both')}},
+        'n_steps_future': {
+            'type': int, 'in': Interval(1, np.inf, closed='left')}
+    }
 
     def __init__(self, width=10, func=np.std,
-                 func_params={}, percentiles=None, n_steps_future=1):
+                 func_params=None, percentiles=None, n_steps_future=1):
         self.width = width
         self.func = func
         self.func_params = func_params
@@ -103,25 +110,24 @@ class Labeller(BaseEstimator, TransformerResamplerMixin):
         self : object
 
         """
-        if self.percentiles is None:
-            _percentiles = [0.]
-        else:
-            _percentiles = self.percentiles
-
-        validate_params({**self.get_params(), '_percentiles': _percentiles},
-                        self._hyperparameters)
         X = column_or_1d(X)
+        validate_params(self.get_params(), self._hyperparameters)
 
         self._sliding_window = SlidingWindow(width=self.width, stride=1).fit(X)
-
         _X = self._sliding_window.transform(X)
-        _X = self.func(_X, axis=1, **self.func_params).reshape(-1, 1)
+        if self.func_params is None:
+            self._effective_func_params = {}
+        else:
+            self._effective_func_params = self.func_params
+        _X = self.func(
+            _X, axis=1, **self._effective_func_params).reshape(-1, 1)
 
-        if self.percentiles is not None:
+        if self.percentiles is None:
+            self.thresholds_ = None
+        else:
             self.thresholds_ = [np.percentile(np.abs(_X.flatten()), percentile)
                                 for percentile in self.percentiles]
-        else:
-            self.thresholds_ = None
+
         return self
 
     def transform(self, X, y=None):
@@ -143,9 +149,9 @@ class Labeller(BaseEstimator, TransformerResamplerMixin):
 
         """
         check_is_fitted(self)
-        X = column_or_1d(X)
+        Xt = column_or_1d(X)
 
-        Xt = X[:-self.n_steps_future]
+        Xt = Xt[:-self.n_steps_future]
 
         if self.n_steps_future < self.width:
             Xt = Xt[self.width - self.n_steps_future:]
@@ -173,7 +179,8 @@ class Labeller(BaseEstimator, TransformerResamplerMixin):
         y = column_or_1d(y)
 
         yr = self._sliding_window.transform(y)
-        yr = self.func(yr, axis=1, **self.func_params).reshape(-1, 1)
+        yr = self.func(
+            yr, axis=1, **self._effective_func_params).reshape(-1, 1)
 
         if self.thresholds_ is not None:
             yr = np.abs(yr)

--- a/gtda/utils/__init__.py
+++ b/gtda/utils/__init__.py
@@ -2,12 +2,11 @@
 validation functions."""
 
 from .validation import check_diagram, check_graph
-from .validation import validate_metric_params, validate_params
+from .validation import validate_params
 
 
 __all__ = [
     'check_diagram',
     'check_graph',
-    'validate_metric_params',
     'validate_params'
 ]

--- a/gtda/utils/intervals.py
+++ b/gtda/utils/intervals.py
@@ -1,0 +1,192 @@
+"""Base class for real intervals."""
+# License: GNU AGPLv3
+
+from numbers import Real
+
+
+def _interval_like(other):
+    return (hasattr(other, 'left')
+            and hasattr(other, 'right')
+            and hasattr(other, 'closed'))
+
+
+class Interval:
+    """Immutable object implementing an interval.
+
+    Parameters
+    ----------
+    left : real scalar, required
+        Left bound for the interval.
+
+    right : real scalar, required
+        Right bound for the interval.
+
+    closed : ``'right'`` | ``'left'`` | ``'both'`` | ``'neither'``, required
+        Whether the interval is closed on the left-side, right-side, both or
+        neither.
+
+    """
+    _VALID_CLOSED = frozenset(['left', 'right', 'both', 'neither'])
+
+    def __init__(self, left, right, *, closed):
+        self._validate_endpoint(left)
+        self._validate_endpoint(right)
+        if closed not in self._VALID_CLOSED:
+            raise ValueError(
+                f"Invalid option for `closed`: {closed}. Argument must be "
+                f"one of {list(self._VALID_CLOSED)}.")
+        if not left <= right:
+            raise ValueError("Left side of interval must be <= right side")
+
+        self.left = left
+        self.right = right
+        self.closed = closed
+
+    @staticmethod
+    def _validate_endpoint(endpoint):
+        if not isinstance(endpoint, Real):
+            raise ValueError(
+                "Only real (finite or infinite) endpoints are allowed when "
+                "constructing an Interval.")
+
+    @property
+    def closed_left(self):
+        """Check if the interval is closed on the left side.
+
+        """
+        return self.closed in ('left', 'both')
+
+    @property
+    def closed_right(self):
+        """Check if the interval is closed on the right side.
+
+        """
+        return self.closed in ('right', 'both')
+
+    @property
+    def open_left(self):
+        """Check if the interval is open on the left side.
+
+        """
+        return not self.closed_left
+
+    @property
+    def open_right(self):
+        """Check if the interval is closed on the left side.
+
+        """
+        return not self.closed_right
+
+    @property
+    def mid(self):
+        """Return the midpoint of the interval. Take care when the left or
+        right sides are infinite.
+
+        """
+        return 0.5 * (self.left + self.right)
+
+    @property
+    def length(self):
+        """Return the length of the interval. Take care when the left or
+        right sides are infinite.
+
+        """
+        return self.right - self.left
+
+    @property
+    def is_empty(self):
+        """Indicates if an interval is empty, meaning it contains no points.
+
+        """
+        return (self.right == self.left) & (self.closed != 'both')
+
+    def __hash__(self):
+        return hash((self.left, self.right, self.closed))
+
+    def __contains__(self, key):
+        if _interval_like(key):
+            raise TypeError("__contains__ not defined for two intervals")
+        return ((self.left < key if self.open_left else self.left <= key) &
+                (key < self.right if self.open_right else key <= self.right))
+
+    def __reduce__(self):
+        args = (self.left, self.right, self.closed)
+        return type(self), args
+
+    def __repr__(self):
+        left, right = self.left, self.right
+        name = type(self).__name__
+        repr_str = f"{name}({repr(left)}, {repr(right)}, " \
+                   f"closed={repr(self.closed)})"
+        return repr_str
+
+    def __str__(self):
+        left, right = self.left, self.right
+        start_symbol = '[' if self.closed_left else '('
+        end_symbol = ']' if self.closed_right else ')'
+        return f'{start_symbol}{left}, {right}{end_symbol}'
+
+    def __add__(self, y):
+        if isinstance(y, Real):
+            return Interval(self.left + y, self.right + y, closed=self.closed)
+        elif isinstance(y, Interval) and isinstance(self, Real):
+            return Interval(y.left + self, y.right + self, closed=y.closed)
+        return NotImplemented
+
+    def __sub__(self, y):
+        if isinstance(y, Real):
+            return Interval(self.left - y, self.right - y, closed=self.closed)
+        return NotImplemented
+
+    def __mul__(self, y):
+        if isinstance(y, Real):
+            return Interval(self.left * y, self.right * y, closed=self.closed)
+        elif isinstance(y, Interval) and isinstance(self, Real):
+            return Interval(y.left * self, y.right * self, closed=y.closed)
+        return NotImplemented
+
+    def __div__(self, y):
+        if isinstance(y, Real):
+            return Interval(self.left / y, self.right / y, closed=self.closed)
+        return NotImplemented
+
+    def __truediv__(self, y):
+        if isinstance(y, Real):
+            return Interval(self.left / y, self.right / y, closed=self.closed)
+        return NotImplemented
+
+    def __floordiv__(self, y):
+        if isinstance(y, Real):
+            return Interval(
+                self.left // y, self.right // y, closed=self.closed)
+        return NotImplemented
+
+    def intersects(self, other):
+        """Check whether two :cls:`Interval` objects intersect. Two
+        intervals intersect if they share a common point, including closed
+        endpoints. Intervals that only have an open endpoint in common do not
+        intersect.
+
+        Parameters
+        ----------
+        other : Interval object
+            Interval to check against for an overlap.
+
+        Returns
+        -------
+        bool
+            ``True`` if the two intervals overlap.
+
+        """
+        if not isinstance(other, Interval):
+            raise TypeError("`other` must be an Interval, "
+                            f"got {type(other).__name__}")
+
+        # equality is okay if both endpoints are closed (overlap at a point)
+        op1 = le if (self.closed_left and other.closed_right) else lt
+        op2 = le if (other.closed_left and self.closed_right) else lt
+
+        # overlaps is equivalent negation of two interval being disjoint:
+        # disjoint = (A.left > B.right) or (B.left > A.right)
+        # (simplifying the negation allows this to be done in fewer operations)
+        return op1(self.left, other.right) and op2(other.left, self.right)

--- a/gtda/utils/intervals.py
+++ b/gtda/utils/intervals.py
@@ -2,6 +2,7 @@
 # License: GNU AGPLv3
 
 from numbers import Real
+from operator import le, lt
 
 
 def _interval_like(other):

--- a/gtda/utils/tests/test_validation.py
+++ b/gtda/utils/tests/test_validation.py
@@ -9,6 +9,9 @@ from gtda.utils.validation import check_diagram, validate_params
 
 # Testing for validate_params
 def test_validate_params():
+    """These tests should fail because either the type of parameters[
+    parameter_name] is incorrect, or because parameter not in references[
+    parameter_name]['in']."""
     references = {'par1': {'type': int, 'in': [0, 1]}}
     parameters = {'par1': 0.5}
 
@@ -26,6 +29,9 @@ def test_validate_params():
 
 # Testing for validate_params when one of the parameters is of list type
 def test_validate_params_list():
+    """Test the behaviour of validate_params on parameters which are of list
+    type. Each entry in the list should satisfy the constraints described by
+    references[parameter_name]['of']."""
     references = {
         'par1': {'type': list, 'of': {'type': float, 'in': [1., 2.]}}
     }

--- a/gtda/utils/tests/test_validation.py
+++ b/gtda/utils/tests/test_validation.py
@@ -1,16 +1,15 @@
-"""Tests for validation functions"""
+"""Tests for validation functions."""
 # License: GNU AGPLv3
 
 import numpy as np
 import pytest
 
-from gtda.utils.validation import (check_diagram, validate_metric_params,
-                                   validate_params)
+from gtda.utils.validation import check_diagram, validate_params
 
 
 # Testing for validate_params
 def test_validate_params():
-    references = {'par1': [int, [0, 1]]}
+    references = {'par1': {'type': int, 'in': [0, 1]}}
     parameters = {'par1': 0.5}
 
     with pytest.raises(TypeError):
@@ -25,9 +24,11 @@ def test_validate_params():
         validate_params(parameters, references)
 
 
-# Testing for validate_params
+# Testing for validate_params when one of the parameters is of list type
 def test_validate_params_list():
-    references = {'par1': [list, [float, [1., 2.]]]}
+    references = {
+        'par1': {'type': list, 'of': {'type': float, 'in': [1., 2.]}}
+    }
     parameters = {'par1': [1.]}
 
     validate_params(parameters, references)
@@ -47,80 +48,3 @@ def test_inputs_arrayStruc_V():
 
     with pytest.raises(ValueError):
         check_diagram(X)
-
-
-# Testing validate_metric_params
-# Test for the wrong metric value
-def test_metric_V():
-    with pytest.raises(ValueError, match="No metric called"):
-        validate_metric_params('blah', metric_params={
-            'n_bins': 200, 'delta': 0.01})
-
-
-# Test for the wrong n_values type
-def test_n_values_T():
-    with pytest.raises(TypeError, match=" in params_metric is of type "):
-        validate_metric_params('landscape',
-                               metric_params={'n_bins': 'a',
-                                              'delta': 0.01})
-
-
-# Test for the wrong n_values value
-def test_n_values_V():
-    with pytest.raises(ValueError, match=" in param_metric should be between"):
-        validate_metric_params('landscape',
-                               metric_params={'n_bins': -2,
-                                              'delta': 0.01})
-
-
-# Test for the wrong delta value
-def test_delta_V():
-    with pytest.raises(ValueError, match=" in param_metric should be between"):
-        validate_metric_params('bottleneck',
-                               metric_params={'n_bins': 200,
-                                              'delta': -1})
-
-
-# Test for the wrong delta value
-def test_delta_T():
-    with pytest.raises(TypeError, match=" in params_metric is of type"):
-        validate_metric_params('bottleneck',
-                               metric_params={'n_bins': 200,
-                                              'delta': 'a'})
-
-
-# Test for the wrong order value
-def test_order_V():
-    with pytest.raises(ValueError, match=" in param_metric should be between"):
-        validate_metric_params('heat',
-                               metric_params={'n_bins': 200,
-                                              'p': -1})
-
-
-# Test for the wrong order type
-def test_order_T():
-    with pytest.raises(TypeError, match=" in params_metric is of type"):
-        validate_metric_params('heat',
-                               metric_params={'n_bins': 200,
-                                              'p': 'a'})
-
-
-# Test for the wrong sigma value
-def test_sigma_V():
-    with pytest.raises(ValueError, match=" in param_metric should be between"):
-        validate_metric_params('heat',
-                               metric_params={'n_bins': 200,
-                                              'sigma': -1})
-
-
-# Test for the wrong sigma type
-def test_sigma_T():
-    with pytest.raises(TypeError, match=" in params_metric is of type"):
-        validate_metric_params('heat', metric_params={'n_bins': 200,
-                                                      'sigma': 'a'})
-
-
-# Undefined metric_params
-def test_validate():
-    with pytest.raises(ValueError):
-        validate_metric_params('heat', metric_params={'blah': 200})

--- a/gtda/utils/validation.py
+++ b/gtda/utils/validation.py
@@ -115,27 +115,30 @@ def validate_params(parameters, references, exclude=None):
         are checked against `references`.
 
     references : dict, required
-        Dictionary in which the keys are parameter names (as strings). The
-        value ``reference`` corresponding to a key ``name`` is a dictionary
-        responsible for checking the value ``parameter`` in `parameters`
-        corresponding to ``name``, and containing any of the following keys:
+        Dictionary in which the keys are parameter names (as strings). Let
+        ``name`` and ``parameter`` denote a key-value pair in `parameters`.
+        Since ``name`` should also be a key in `references`, let ``reference``
+        be the corresponding value there. Then, ``reference`` must be a
+        dictionary containing any of the following keys:
 
         - ``'type'``, mapping to a class or tuple of classes. ``parameter``
           is checked to be an instance of this class or tuple of classes.
 
-        - ``'in'``, mapping to a dictionary ``ref_in``, when the value of
-          ``'type'`` is not one of ``list``, ``tuple``, ``numpy.ndarray`` or
-          ``dict``. The following check is performed: ``parameter in ref_in``.
+        - ``'in'``, mapping to a dictionary, when the value of ``'type'`` is
+          not one of ``list``, ``tuple``, ``numpy.ndarray`` or ``dict``.
+          Letting ``ref_in`` denote this dictionary, the following check is
+          performed: ``parameter in ref_in``.
 
-        - ``'of'``, mapping to a dictionary ``ref_of``, when the value of
-          ``'type'`` is one of ``list``, ``tuple``, ``numpy.ndarray`` or
-          ``dict``. When the value of ``'type'`` is ``dict`` – meaning that
-          ``parameter`` should be a dictionary – ``ref_of`` should have a
-          similar structure as `references` and :func:`validate_params`
-          is called recursively on ``(parameter, ref_of)``. Otherwise,
-          ``ref_of`` should have a similar structure as ``reference`` and
-          each entry in ``parameter`` is checked to satisfy the constraints
-          in ``ref_of``.
+        - ``'of'``, mapping to a dictionary], when the value of ``'type'``
+          is one of ``list``, ``tuple``, ``numpy.ndarray`` or ``dict``.
+          Let``ref_of`` denote this dictionary. Then:
+          a) If ``reference['type'] == dict`` – meaning that ``parameter``
+             should be a dictionary – ``ref_of`` should have a similar
+             structure as `references`, and :func:`validate_params` is called
+             recursively on ``(parameter, ref_of)``.
+          b) Otherwise, ``ref_of`` should have a similar structure as
+             ``reference`` and each entry in ``parameter`` is checked to
+             satisfy the constraints in ``ref_of``.
 
         - ``'other'``, which should map to a callable defining custom checks on
           ``parameter``.

--- a/gtda/utils/validation.py
+++ b/gtda/utils/validation.py
@@ -126,12 +126,12 @@ def validate_params(parameters, references, exclude=None):
 
         - ``'in'``, mapping to a dictionary, when the value of ``'type'`` is
           not one of ``list``, ``tuple``, ``numpy.ndarray`` or ``dict``.
-          Letting ``ref_in`` denote this dictionary, the following check is
+          Letting ``ref_in`` denote that dictionary, the following check is
           performed: ``parameter in ref_in``.
 
         - ``'of'``, mapping to a dictionary, when the value of ``'type'``
           is one of ``list``, ``tuple``, ``numpy.ndarray`` or ``dict``.
-          Let ``ref_of`` denote this dictionary. Then:
+          Let ``ref_of`` denote that dictionary. Then:
 
           a) If ``reference['type'] == dict`` – meaning that ``parameter``
              should be a dictionary – ``ref_of`` should have a similar

--- a/gtda/utils/validation.py
+++ b/gtda/utils/validation.py
@@ -123,7 +123,7 @@ def validate_params(parameters, references, exclude=None):
         - ``'type'``, mapping to a class or tuple of classes. ``parameter``
           is checked to be an instance of this class or tuple of classes.
 
-        - ``'in'``, mapping to a dictionary ``ref_of``, when the value of
+        - ``'in'``, mapping to a dictionary ``ref_in``, when the value of
           ``'type'`` is not one of ``list``, ``tuple``, ``numpy.ndarray`` or
           ``dict``. The following check is performed: ``parameter in ref_in``.
 

--- a/gtda/utils/validation.py
+++ b/gtda/utils/validation.py
@@ -129,9 +129,10 @@ def validate_params(parameters, references, exclude=None):
           Letting ``ref_in`` denote this dictionary, the following check is
           performed: ``parameter in ref_in``.
 
-        - ``'of'``, mapping to a dictionary], when the value of ``'type'``
+        - ``'of'``, mapping to a dictionary, when the value of ``'type'``
           is one of ``list``, ``tuple``, ``numpy.ndarray`` or ``dict``.
-          Let``ref_of`` denote this dictionary. Then:
+          Let ``ref_of`` denote this dictionary. Then:
+
           a) If ``reference['type'] == dict`` – meaning that ``parameter``
              should be a dictionary – ``ref_of`` should have a similar
              structure as `references`, and :func:`validate_params` is called

--- a/gtda/utils/validation.py
+++ b/gtda/utils/validation.py
@@ -1,32 +1,7 @@
 """Utilities for input validation."""
 # License: GNU AGPLv3
 
-import numbers
 import numpy as np
-import types
-
-available_metrics = {
-    'bottleneck': [('delta', numbers.Number, (0., 1.))],
-    'wasserstein': [('p', int, (1, np.inf)),
-                    ('delta', numbers.Number, (1e-16, 1.))],
-    'betti': [('p', numbers.Number, (1, np.inf)),
-              ('n_bins', int, (1, np.inf))],
-    'landscape': [('p', numbers.Number, (1, np.inf)),
-                  ('n_bins', int, (1, np.inf)),
-                  ('n_layers', int, (1, np.inf))],
-    'heat': [('p', numbers.Number, (1, np.inf)),
-             ('n_bins', int, (1, np.inf)),
-             ('sigma', numbers.Number, (0., np.inf))],
-    'persistence_image': [('p', numbers.Number, (1, np.inf)),
-                          ('n_bins', int, (1, np.inf)),
-                          ('sigma', numbers.Number, (0., np.inf)),
-                          ('weight_function', types.FunctionType,
-                           None)],
-    'silhouette': [('order', numbers.Number, (0, np.inf)),
-                   ('n_bins', int, (1, np.inf))]}
-
-available_metric_params = {metric: [p[0] for p in param_lst]
-                           for metric, param_lst in available_metrics.items()}
 
 
 def check_diagram(X, copy=False):
@@ -76,8 +51,61 @@ def check_graph(X):
     return X
 
 
-# Check the type and range of numerical parameters
-def validate_params(parameters, references):
+def _validate_params_single(parameter, reference, name):
+    if reference is None:
+        return
+
+    ref_type = reference.get('type', None)
+
+    # Check that parameter has the correct type
+    if (ref_type is not None) and (not isinstance(parameter, ref_type)):
+        raise TypeError(
+            f"Parameter `{name}` is of type {type(parameter)} while "
+            f"it should be of type {ref_type}.")
+
+    # If the reference type parameter is not list or tuple, the checks are
+    # performed on the parameter object directly. Note: ref_type can be
+    elif ref_type not in [list, tuple, np.ndarray, dict]:
+        ref_in = reference.get('in', None)
+        ref_other = reference.get('other', None)
+        if parameter is not None:
+            if (ref_in is not None) and (parameter not in ref_in):
+                raise ValueError(
+                    f"Parameter `{name}` is {parameter}, which is not in "
+                    f"{ref_in}.")
+        # Perform any other checks via the callable ref_others
+        if ref_other is not None:
+            return ref_other(parameter)
+
+    # Explicitly return a boolean flag to indicate that checks must be
+    # performed recursively at deeper layers
+    else:
+        return ref_type
+
+
+def _validate_params(parameters, references, rec_name=None):
+    for name, parameter in parameters.items():
+        if name == 'n_jobs':
+            continue
+        if name not in references.keys():
+            name_extras = "" if rec_name is None else f" in `{rec_name}`"
+            raise KeyError(
+                f"`{name}`{name_extras} is not an available parameter. "
+                f"Available parameters are in {list(references.keys())}.")
+
+        reference = references[name]
+        ref_type = _validate_params_single(parameter, reference, name)
+        if ref_type:
+            ref_of = reference.get('of', None)
+            if ref_type == dict:
+                _validate_params(parameter, ref_of, rec_name=name)
+            else:  # List or tuple type
+                for i, parameter_elem in enumerate(parameter):
+                    _validate_params_single(
+                        parameter_elem, ref_of, f"{name}[{i}]")
+
+
+def validate_params(parameters, references, exclude=None):
     """Function to automate the validation of hyperparameters.
 
     Parameters
@@ -89,8 +117,8 @@ def validate_params(parameters, references):
     references : dict, required
         Dictionary in which the keys are hyperparameter names and the
         corresponding values are lists. The first element of that list is a
-        type. If that type is not an iterable, the second element can be one
-        of:
+        type. If that type is not one of ``list``, ``tuple`` or
+        ``numpy.ndarray``, the second element can be one of:
 
         - ``None``, when only the type should be checked.
         - A tuple of two numbers, when the type is numerical. In this case,
@@ -100,10 +128,11 @@ def validate_params(parameters, references):
         - A list containing all possible allowed values for the
           corresponding hyperparameter.
 
-        If that type is an iterable, the second element is a list that provides
-        information to validate each element of that iterable. The first
-        element of that list is the type of the elements of the iterable and
-        the second element of that list can be one of:
+        If that type is one of ``list``,``tuple`` or ``numpy.ndarray``,
+        the second element is a list that provides information to validate
+        each element of that iterable. The first element of that list is the
+        type of the elements of the iterable and the second element of that
+        list can be one of:
 
         - ``None``, when only the type of the iterable elements should be
           checked.
@@ -115,104 +144,7 @@ def validate_params(parameters, references):
           corresponding iterable element.
 
     """
-    for key in references.keys():
-        # Check type
-        if not isinstance(parameters[key], references[key][0]):
-            raise TypeError(
-                f"Parameter {key} is of type {type(parameters[key])} while it "
-                f"should be of type {references[key][0]}.")
-
-        # If the key is a list, tuple, or numpy array, check element by element
-        if references[key][0] == list or references[key][0] == tuple or \
-           references[key][0] == np.ndarray:
-            for parameter in parameters[key]:
-                # If an element has to be an int, it can be passed as a float
-                # that has no decimals, else we check the type of the element
-                if references[key][1][0] == int:
-                    if not isinstance(parameter, numbers.Number):
-                        raise TypeError(
-                            f"Parameter {key} is a {type(parameters[key])} of "
-                            f"{references[key][1][0]} but contains an "
-                            f"element of type {type(parameter)}.")
-                    if not float(parameter).is_integer():
-                        raise TypeError(
-                            f"Parameter {key} is a {type(parameters[key])} of "
-                            f"int but contains an element of type "
-                            f"{type(parameter)} that is not an integer.")
-                else:
-                    # Otherwise just check for the type
-                    if not isinstance(parameter, references[key][1][0]):
-                        raise TypeError(
-                            f"Parameter {key} is a {type(parameters[key])} of "
-                            f"{references[key][1][0]}  but contains an "
-                            f"element of type {type(parameter)}.")
-
-                # If there is no parameter range to check, continue
-                if references[key][1][1] is None:
-                    continue
-                # Check element range indicated by a tuple of 2 values
-                if isinstance(references[key][1][1], tuple):
-                    if (parameter < references[key][1][1][0] or
-                            parameter > references[key][1][1][1]):
-                        raise ValueError(
-                            f"Parameter {key} is a {type(parameters[key])} "
-                            f"containing {parameter} which should be in the "
-                            f"range [{references[key][1][1][0]}, "
-                            f"{references[key][1][1][1]}].")
-                # Check if element is in a list
-                elif isinstance(references[key][1][1], list):
-                    if parameter not in references[key][1][1]:
-                        raise ValueError(
-                            f"Parameter {key} is a {type(parameters[key])} "
-                            f"containing {parameter}, while it should only "
-                            f"contain one of the following: "
-                            f"{references[key][1][1]}.")
-        else:
-            # If only the type should be checked, continue
-            if references[key][1] is None:
-                continue
-
-            # Check parameter range indicated by a tuple of 2 values
-            if isinstance(references[key][1], tuple):
-                if (parameters[key] < references[key][1][0] or
-                        parameters[key] > references[key][1][1]):
-                    raise ValueError(
-                        f"Parameter {key} is {parameters[key]}, while it  "
-                        f"should be in the range [{references[key][1][0]}, "
-                        f"{references[key][1][1]}].")
-            # Check if parameter is in a list
-            elif isinstance(references[key][1], list):
-                if parameters[key] not in references[key][1]:
-                    raise ValueError(
-                        f"Parameter {key} is {parameters[key]}, while it "
-                        f"should be one of the following: "
-                        f"{references[key][1]}.")
-
-
-def validate_metric_params(metric, metric_params):
-    if metric not in available_metrics.keys():
-        raise ValueError(
-            f"No metric called {metric}. Available metrics are "
-            f"{list(available_metrics.keys())}.")
-
-    for (param, param_type, param_values) in available_metrics[metric]:
-        if param in metric_params.keys():
-            input_param = metric_params[param]
-            if not isinstance(input_param, param_type):
-                raise TypeError(
-                    f"{param} in params_metric is of type {type(input_param)} "
-                    f" but must be an {param_type}.")
-            if param_values is not None:
-                if input_param < param_values[0] or \
-                   input_param > param_values[1]:
-                    raise ValueError(
-                        f"{param} in param_metric should be between "
-                        f"{param_values[0]} and {param_values[1]} but has "
-                        f"been set to {input_param}.")
-
-    for param in metric_params.keys():
-        if param not in available_metric_params[metric]:
-            raise ValueError(
-                f"{param} in metric_param is not an available parameter. "
-                f"Available metric_params are: "
-                f"{available_metric_params[metric]}.")
+    exclude_ = [] if exclude is None else exclude
+    parameters_ = {key: value for key, value in parameters.items()
+                   if key not in exclude_}
+    return _validate_params(parameters_, references)

--- a/gtda/utils/validation.py
+++ b/gtda/utils/validation.py
@@ -123,10 +123,9 @@ def validate_params(parameters, references, exclude=None):
         - ``'type'``, mapping to a class or tuple of classes. ``parameter``
           is checked to be an instance of this class or tuple of classes.
 
-        - ``'in'``, when the value of ``'type'`` is not one of ``list``,
-          ``tuple``, ``numpy.ndarray`` or ``dict``. If the corresponding value
-          is ``ref_in`` the following check is performed on ``parameter``:
-          ``parameter in ref_in``.
+        - ``'in'``, mapping to a dictionary ``ref_of``, when the value of
+          ``'type'`` is not one of ``list``, ``tuple``, ``numpy.ndarray`` or
+          ``dict``. The following check is performed: ``parameter in ref_in``.
 
         - ``'of'``, mapping to a dictionary ``ref_of``, when the value of
           ``'type'`` is one of ``list``, ``tuple``, ``numpy.ndarray`` or

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ addopts =
     --ignore gtda/externals/hera/
     --ignore gtda/externals/pybind11/
     --ignore gtda/externals/ripser/
-    --ignore gtda/tests/test_common.py
 
     -ra
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This is a thorough refactoring of our approach to hyperparameter validation in `utils/validation.py`:

- `utils/intervals.py` is created to host a new class `Interval` – heavily inspired by but modified from the implementation [in pandas](https://github.com/pandas-dev/pandas/blob/2128b2af3b4d293385f1ab00daff811b3aee894a/pandas/_libs/interval.pyx). This class can handle intervals which are open/closed on either side and contain plus or minus `np.inf` as interval bounds. Example of usage: `x in Interval(0, 1, closed='both')`, returning `True` when `0 <= x <= 1`.
- The behaviour and expected inputs in`validate_params` are changed to communicate intent more clearly and, among other things, exploit the new `Interval` class.
- `validate_metric_params` is removed and it is handled in classes as a special case of `validate_params`, by using the `_AVAILABLE_METRICS` and the newly introduced `_AVAILABLE_AMPLITUDE_METRICS` dictionaries placed in `diagrams/_metrics.py`.
- All classes and tests have been updated to adapt to the new `validate_params`.

Other miscellaneous and issues were solved as they were discovered, namely:
- The parameter `order` in `Silhouette` is renamed to `power`
- A previously unseen bug in `silhouette_distances` and `silhouette_amplitudes` is fixed where the power in the power-weighting was also used as the p in the functional L^p norm
- Minor code style improvements and linting fixes are performed
- Docstrings have been improved in a few places.