### PR TITLE
Update parameter q to be of type double and not int

### DIFF
--- a/gtda/externals/bindings/wasserstein_bindings.cpp
+++ b/gtda/externals/bindings/wasserstein_bindings.cpp
@@ -11,7 +11,7 @@
 
 double wasserstein_distance(const std::vector<std::pair<double, double>>& dgm1,
                             const std::vector<std::pair<double, double>>& dgm2,
-                            int q, double delta, double internal_p,
+                            double q, double delta, double internal_p,
                             double initial_eps, double eps_factor) {
   hera::AuctionParams<double> params;
   params.wasserstein_power = q;
@@ -31,7 +31,7 @@ PYBIND11_MODULE(gtda_wasserstein, m) {
   m.doc() = "wasserstein dionysus implementation";
   using namespace pybind11::literals;
   m.def("wasserstein_distance", &wasserstein_distance, "dgm1"_a, "dgm2"_a,
-        py::arg("q") = 2, py::arg("delta") = .01,
+        py::arg("q") = 2.0, py::arg("delta") = .01,
         py::arg("internal_p") = hera::get_infinity<double>(),
         py::arg("initial_eps") = 0., py::arg("eps_factor") = 0.,
         "compute Wasserstein distance between two persistence diagrams");

--- a/gtda/utils/validation.py
+++ b/gtda/utils/validation.py
@@ -7,7 +7,7 @@ import types
 
 available_metrics = {
     'bottleneck': [('delta', numbers.Number, (0., 1.))],
-    'wasserstein': [('p', int, (1, np.inf)),
+    'wasserstein': [('p', numbers.Number, (1, np.inf)),
                     ('delta', numbers.Number, (1e-16, 1.))],
     'betti': [('p', numbers.Number, (1, np.inf)),
               ('n_bins', int, (1, np.inf))],


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/giotto-ai/giotto-tda/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#350 

#### What does this implement/fix? Explain your changes.

Update parameter `q` in wasserstein bindings to be of type `double`-
In `gtda` this parameter is called `p`, corresponding `check_parameter` was updated.

#### Any other comments?

Is there any reason to keep `p` and  `q` naming instead of using only one ?
<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
