### PR TITLE
Merge twine hotfixes post 0.2.0

### DIFF
--- a/CODE_AUTHORS
+++ b/CODE_AUTHORS
@@ -11,3 +11,4 @@ Alessio Ghiraldello, amg28@protonmail.com
 Adélie Garin, adelie.garin@epfl.ch
 Anibal Medina-Mardones, anibal.medinamardones@epfl.ch
 Wojciech Reise, reisewojciech@gmail.com
+Roman Yurchak, roman.yurchak@symerio.com

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,9 @@ and the `Institute of Reconfigurable & Embedded Digital Systems (REDS) <https://
 
 License
 =======
+
 .. _L2F team: business@l2f.ch
+
 ``giotto-tda`` is distributed under the AGPLv3 `license <https://github.com/giotto-ai/giotto-tda/blob/master/LICENSE>`_.
 If you need a different distribution license, please contact the `L2F team`_.
 
@@ -96,7 +98,7 @@ the same environment.
 Developer installation
 ----------------------
 
-Please consult the `relevant page <https://giotto-ai.github.io/gtda-docs/latest/installation.html#developer-installation>`_
+Please consult the `dedicated page <https://giotto-ai.github.io/gtda-docs/latest/installation.html#developer-installation>`_
 for detailed instructions on how to build ``giotto-tda`` from sources across different platforms.
 
 .. _contributing-section:
@@ -106,14 +108,14 @@ Contributing
 
 We welcome new contributors of all experience levels. The Giotto
 community goals are to be helpful, welcoming, and effective. To learn more about
-making a contribution to ``giotto-tda``, please consult the `relevant page
+making a contribution to ``giotto-tda``, please consult `the relevant page
 <https://giotto-ai.github.io/gtda-docs/latest/contributing/index.html>`_.
 
 Testing
 -------
 
 After installation, you can launch the test suite from outside the
-source directory::
+source directory   ::
 
     pytest gtda
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -200,6 +200,12 @@ jobs:
       contents: 'dist/*'
       targetFolder: '$(Build.ArtifactStagingDirectory)'
 
+  - script: |
+      set -e
+      pip install twine
+      twine check dist/*
+    displayName: 'Check distribution with twine'
+
   - task: PublishBuildArtifacts@1
     displayName: 'Create download link'
     inputs:
@@ -208,7 +214,6 @@ jobs:
 
   - bash: |
       set -e
-      pip install twine
       twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*
     condition: eq(variables['nightly_check'], 'true')
     displayName: 'Upload nightly wheels to PyPI'

--- a/doc/release.rst
+++ b/doc/release.rst
@@ -140,7 +140,7 @@ Thanks to our Contributors
 
 This release contains contributions from many people:
 
-Umberto Lupo, Guillaume Tauzin, Wojciech Reise, Julian Burella Pérez, Lewis Tunstall, Anibal Medina-Mardones, and Adélie Garin.
+Umberto Lupo, Guillaume Tauzin, Wojciech Reise, Julian Burella Pérez, Roman Yurchak, Lewis Tunstall, Anibal Medina-Mardones, and Adélie Garin.
 
 We are also grateful to all who filed issues or helped resolve them, asked and answered questions, and were part of
 inspiring discussions.


### PR DESCRIPTION
The build distribution files at the v0.2.0 tag could not be uploaded to PyPI due to small formatting issues in `README.rst` flagged by `twine`. This PR fixes the issue, introducing no further changes.