### PR TITLE
[WIP] Add option to modify the mapper pipeline

### DIFF
--- a/gtda/mapper/tests/test_visualization.py
+++ b/gtda/mapper/tests/test_visualization.py
@@ -93,3 +93,27 @@ class TestInteractivePlot(TestCaseNoTemplate):
                           for l in g['node_metadata']['node_elements']]
 
         assert sum(node_sizes_vis) == sum(node_size_real)
+
+    def test_is_cloned(self):
+        """Verify that the pipeline is changed on interaction, if and only if
+        `in_place` is True."""
+
+        def inner(is_change_in_place):
+            expected = 'manhattan' if is_change_in_place else 'euclidean'
+
+            pipe = make_mapper_pipeline(clusterer=FirstSimpleGap(
+                affinity='euclidean'))
+            warnings.simplefilter("ignore")
+            fig = plot_interactive_mapper_graph(pipe, X,
+                                                in_place=is_change_in_place)
+            # Get widget and change the cover type
+            w_text = self._get_widget_by_trait(fig, 'description', 'affinity')
+            d = w_text.get_state()
+            d.update({'value': 'manhattan'})
+            w_text.set_state(d)
+
+            assert pipe.get_mapper_params()['clusterer__affinity'] == expected
+
+        for do_change in [False, True]:
+            with self.subTest(do_change=do_change):
+                inner(do_change)

--- a/gtda/mapper/visualization.py
+++ b/gtda/mapper/visualization.py
@@ -234,7 +234,8 @@ def plot_interactive_mapper_graph(pipeline, data, layout='kamada_kawai',
         Keyword arguments to configure the Plotly Figure.
 
     in_place : bool, optional, default: ``False``
-        Specify whether to modify the pipeline or not.
+        Specify whether the `pipeline` is modified on change of
+        parameters through the interface.
 
     Returns
     -------

--- a/gtda/mapper/visualization.py
+++ b/gtda/mapper/visualization.py
@@ -176,7 +176,8 @@ def plot_interactive_mapper_graph(pipeline, data, layout='kamada_kawai',
                                   layout_dim=2, color_variable=None,
                                   node_color_statistic=None,
                                   color_by_columns_dropdown=False,
-                                  plotly_kwargs=None):
+                                  plotly_kwargs=None,
+                                  in_place=False):
     """Plotting function for interactive Mapper graphs.
 
     Provides functionality to interactively update parameters from the cover
@@ -232,6 +233,9 @@ def plot_interactive_mapper_graph(pipeline, data, layout='kamada_kawai',
     plotly_kwargs : dict, optional, default: ``None``
         Keyword arguments to configure the Plotly Figure.
 
+    in_place : bool, optional, default: ``False``
+        Specify whether to modify the pipeline or not.
+
     Returns
     -------
     box : :class:`ipywidgets.VBox` object
@@ -248,7 +252,10 @@ def plot_interactive_mapper_graph(pipeline, data, layout='kamada_kawai',
     """
 
     # clone pipeline to avoid side effects from in-place parameter changes
-    pipe = clone(pipeline)
+    if not(in_place):
+        pipe = clone(pipeline)
+    else:
+        pipe = pipeline
 
     if node_color_statistic is not None:
         _node_color_statistic = node_color_statistic


### PR DESCRIPTION
**Reference issues/PRs**
None

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
When playing with `MapperPipeline`, I realized that the flow could be improved by reducing the gap between the exploration phase (changing mapper) and the subsequent analysis. The new feature allows us to modify the mapper pipeline, using `plot_interactive_mapper_graph`.

*Currently:* we cannot access the underlying `igraph.Graph`. Hence, even if we are satisfied with the parameters and look of the graph, we need to initialize another pipeline with the desired parameters.

*After the change:* the default behavior `in_place=False` is the same as previously. However, setting `in_place=True` affects the `pipe`, which can be later used.

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. I used `pytest` to check this on Python tests.

