### PR TITLE
Allow more general input to ripser when metric='precomputed', improve/refactor check_point_clouds and add tests

### DIFF
--- a/gtda/externals/python/ripser_interface.py
+++ b/gtda/externals/python/ripser_interface.py
@@ -163,7 +163,8 @@ def ripser(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
         )
     if n_perm and n_perm < 0:
         raise Exception(
-            "Should be a strictly positive number of points in the greedy permutation"
+            "Should be a strictly positive number of points in the greedy "
+            "permutation"
         )
 
     idx_perm = np.arange(X.shape[0])
@@ -175,7 +176,10 @@ def ripser(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
         r_cover = lambdas[-1]
         dm = dperm2all[:, idx_perm]
     else:
-        dm = pairwise_distances(X, metric=metric)
+        if metric == 'precomputed':
+            dm = X
+        else:
+            dm = pairwise_distances(X, metric=metric)
         dperm2all = dm
 
     n_points = dm.shape[0]

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -134,7 +134,7 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
                        metric=self.metric)['dgms']
 
         if 0 in self._homology_dimensions:
-            Xdgms[0] = Xdgms[0][:-1, :]  # Remove final death at np.inf
+            Xdgms[0] = Xdgms[0][:-1, :]  # Remove one infinite bar
 
         # Add dimension as the third elements of each (b, d) tuple
         Xdgms = {dim: np.hstack([Xdgms[dim],
@@ -386,7 +386,7 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
                  for dim in self.homology_dimensions}
 
         if 0 in self._homology_dimensions:
-            Xdgms[0] = Xdgms[0][1:, :]  # Remove final death at np.inf
+            Xdgms[0] = Xdgms[0][1:, :]  # Remove one infinite bar
 
         # Add dimension as the third elements of each (b, d) tuple
         Xdgms = {dim: np.hstack([Xdgms[dim],
@@ -608,7 +608,7 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
                  for dim in self.homology_dimensions}
 
         if 0 in self._homology_dimensions:
-            Xdgms[0] = Xdgms[0][1:, :]  # Remove final death at np.inf
+            Xdgms[0] = Xdgms[0][1:, :]  # Remove one infinite bar
 
         # Add dimension as the third elements of each (b, d) tuple
         Xdgms = {dim: np.hstack([Xdgms[dim],

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -40,18 +40,18 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
     ----------
     metric : string or callable, optional, default: ``'euclidean'``
         If set to ``'precomputed'``, input data is to be interpreted as a
-        collection of distance matrices. Otherwise, input data is to be
-        interpreted as a collection of point clouds (i.e. feature arrays),
-        and `metric` determines a rule with which to calculate distances
-        between pairs of instances (i.e. rows) in these arrays.
-        If `metric` is a string, it must be one of the options allowed by
-        :func:`scipy.spatial.distance.pdist` for its metric parameter, or a
-        metric listed in :obj:`sklearn.pairwise.PAIRWISE_DISTANCE_FUNCTIONS`,
-        including "euclidean", "manhattan", or "cosine".
-        If `metric` is a callable function, it is called on each pair of
-        instances and the resulting value recorded. The callable should take
-        two arrays from the entry in `X` as input, and return a value
-        indicating the distance between them.
+        collection of distance matrices or of adjacency matrices of weighted
+        undirected graphs. Otherwise, input data is to be interpreted as a
+        collection of point clouds (i.e. feature arrays), and `metric`
+        determines a rule with which to calculate distances between pairs of
+        points (i.e. row vectors). If `metric` is a string, it must be one
+        of the options allowed by :func:`scipy.spatial.distance.pdist` for
+        its metric parameter, or a metric listed in
+        :obj:`sklearn.pairwise.PAIRWISE_DISTANCE_FUNCTIONS`, including
+        ``'euclidean'``, ``'manhattan'`` or ``'cosine'``. If `metric` is a
+        callable, it should take pairs of vectors (1D arrays) as input and, for
+        each two vectors in a pair, it should return a scalar indicating the
+        distance/dissimilarity between them.
 
     homology_dimensions : list or tuple, optional, default: ``(0, 1)``
         Dimensions (non-negative integers) of the topological features to be
@@ -152,14 +152,15 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         Parameters
         ----------
         X : ndarray or list
-            Input data representing a collection of point clouds or of distance
-            matrices. Can be either a 3D ndarray whose zeroth dimension has
-            size ``n_samples``, or a list containing ``n_samples`` 2D ndarrays.
-            If ``metric == 'precomputed'``, elements of `X` must be square
-            arrays representing distance matrices; otherwise, their rows are
-            interpreted as vectors in Euclidean space and, when `X` is a list,
-            warnings are issued when the number of columns (dimension of the
-            Euclidean space) differs among samples.
+            Input data representing a collection of point clouds if `metric`
+            was not set to ``'precomputed'``, and of distance matrices or
+            adjacency matrices of weighted undirected graphs otherwise. Can be
+            either a 3D ndarray whose zeroth dimension has size ``n_samples``,
+            or a list containing ``n_samples`` 2D ndarrays. If `metric` was
+            set to ``'precomputed'``, each entry of `X` must be a square
+            array and should be compatible with a filtration, i.e. the value
+            at index (i, j) should be no smaller than the values at diagonal
+            indices (i, i) and (j, j).
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -199,14 +200,15 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         Parameters
         ----------
         X : ndarray or list
-            Input data representing a collection of point clouds or of distance
-            matrices. Can be either a 3D ndarray whose zeroth dimension has
-            size ``n_samples``, or a list containing ``n_samples`` 2D ndarrays.
-            If ``metric == 'precomputed'``, elements of `X` must be square
-            arrays representing distance matrices; otherwise, their rows are
-            interpreted as vectors in Euclidean space and, when `X` is a list,
-            warnings are issued when the number of columns (dimension of the
-            Euclidean space) differs among samples.
+            Input data representing a collection of point clouds if `metric`
+            was not set to ``'precomputed'``, and of distance matrices or
+            adjacency matrices of weighted undirected graphs otherwise. Can be
+            either a 3D ndarray whose zeroth dimension has size ``n_samples``,
+            or a list containing ``n_samples`` 2D ndarrays. If `metric` was
+            set to ``'precomputed'``, each entry of `X` must be a square
+            array and should be compatible with a filtration, i.e. the value
+            at index (i, j) should be no smaller than the values at diagonal
+            indices (i, i) and (j, j).
 
         y : None
             There is no need for a target in a transformer, yet the pipeline

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -129,8 +129,7 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         self.n_jobs = n_jobs
 
     def _ripser_diagram(self, X):
-        Xdgms = ripser(X[X[:, 0] != np.inf],
-                       maxdim=self._max_homology_dimension,
+        Xdgms = ripser(X, maxdim=self._max_homology_dimension,
                        thresh=self.max_edge_length, coeff=self.coeff,
                        metric=self.metric)['dgms']
 

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -173,7 +173,7 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         validate_params(
             self.get_params(), self._hyperparameters, exclude=['n_jobs'])
         self._is_precomputed = self.metric == 'precomputed'
-        check_point_clouds(X, distance_matrix=self._is_precomputed)
+        check_point_clouds(X, distance_matrices=self._is_precomputed)
 
         if self.infinity_values is None:
             self.infinity_values_ = self.max_edge_length
@@ -223,7 +223,7 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         """
         check_is_fitted(self)
-        X = check_point_clouds(X, distance_matrix=self._is_precomputed)
+        X = check_point_clouds(X, distance_matrices=self._is_precomputed)
 
         Xt = Parallel(n_jobs=self.n_jobs)(
             delayed(self._ripser_diagram)(x) for x in X)
@@ -423,7 +423,7 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         validate_params(
             self.get_params(), self._hyperparameters, exclude=['n_jobs'])
         self._is_precomputed = self.metric == 'precomputed'
-        check_point_clouds(X, distance_matrix=self._is_precomputed)
+        check_point_clouds(X, distance_matrices=self._is_precomputed)
 
         if self.infinity_values is None:
             self.infinity_values_ = self.max_edge_length
@@ -473,7 +473,7 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         """
         check_is_fitted(self)
-        X = check_point_clouds(X, distance_matrix=self._is_precomputed)
+        X = check_point_clouds(X, distance_matrices=self._is_precomputed)
 
         Xt = Parallel(n_jobs=self.n_jobs)(
             delayed(self._gudhi_diagram)(x) for x in X)

--- a/gtda/utils/tests/test_validation.py
+++ b/gtda/utils/tests/test_validation.py
@@ -3,8 +3,10 @@
 
 import numpy as np
 import pytest
+from sklearn.exceptions import DataDimensionalityWarning
 
-from gtda.utils.validation import check_diagrams, validate_params
+from gtda.utils.validation import check_diagrams, validate_params, \
+    check_point_clouds
 
 
 # Testing for validate_params
@@ -54,3 +56,206 @@ def test_inputs_arrayStruc_V():
 
     with pytest.raises(ValueError):
         check_diagrams(X)
+
+
+# Testing check_point_clouds
+# Create several kinds of inputs
+class CreateInputs:
+    def __init__(
+            self, n_samples, n_1, n_2, n_samples_extra, n_1_extra, n_2_extra
+    ):
+        N = n_samples * n_1 * n_2
+        n_1_rectang = n_1 + 1
+        n_2_rectang = n_2 - 1
+        N_rectang = n_samples * n_1_rectang * n_2_rectang
+
+        self.X = np.arange(N, dtype=float).reshape(n_samples, n_1, n_2)
+        self.X_rectang = np.arange(N_rectang, dtype=float). \
+            reshape(n_samples, n_1_rectang, n_2_rectang)
+
+        self.X_list = []
+        self.X_list_rectang = []
+        for i in range(n_samples):
+            self.X_list.append(self.X[i].copy())
+            self.X_list_rectang.append(self.X_rectang[i].copy())
+
+        # List example where not all 2D arrays have the same no. of rows
+        self.X_list_rectang_diff_rows = \
+            self.X_list_rectang[:-1] + [self.X_list_rectang[-1][:-1, :]]
+
+        # List example where not all 2D arrays have the same no. of columns
+        self.X_list_rectang_diff_cols = \
+            self.X_list_rectang[:-1] + [self.X_list_rectang[-1][:, :-1]]
+
+        N_extra = n_samples_extra * n_1_extra * n_2_extra
+        X_extra = np.arange(N_extra, dtype=float). \
+            reshape(n_samples_extra, n_1_extra, n_2_extra)
+        X_list_extra = []
+        for i in range(n_samples_extra):
+            X_list_extra.append(X_extra[i].copy())
+        self.X_list_tot = self.X_list + X_list_extra
+
+    def insert_inf(self):
+        # Replace first entries with np.inf
+        self.X[0, 0, 0] = np.inf
+        self.X_rectang[0, 0, 0] = np.inf
+        self.X_list[0][0, 0] = np.inf
+        self.X_list_rectang[0][0, 0] = np.inf
+        return self
+
+    def insert_nan(self):
+        # Replace first entries with np.nan
+        self.X[0, 0, 0] = np.nan
+        self.X_rectang[0, 0, 0] = np.nan
+        self.X_list[0][0, 0] = np.nan
+        self.X_list_rectang[0][0, 0] = np.nan
+        return self
+
+
+n_samples = 2
+n_1 = 5
+n_2 = 5
+n_samples_extra = 1
+n_1_extra = 6
+n_2_extra = 6
+
+
+def test_check_point_clouds_regular_finite():
+    """Cases in which the input is finite and no warnings or errors should be
+    thrown by check_point_clouds."""
+
+    ex = CreateInputs(
+        n_samples, n_1, n_2, n_samples_extra, n_1_extra, n_2_extra)
+    check_point_clouds(ex.X_rectang)
+    check_point_clouds(ex.X_list_rectang)
+    check_point_clouds(ex.X_list_rectang_diff_rows)
+    check_point_clouds(ex.X, distance_matrices=True)
+    check_point_clouds(ex.X_list, distance_matrices=True)
+    check_point_clouds(ex.X_list_tot, distance_matrices=True)
+
+
+def test_check_point_clouds_value_err_finite():
+    """Cases in which the input is finite but we throw a ValueError."""
+
+    ex = CreateInputs(
+        n_samples, n_1, n_2, n_samples_extra, n_1_extra, n_2_extra)
+
+    # Check that we error on 1d array input
+    with pytest.raises(ValueError):
+        check_point_clouds(np.asarray(ex.X_list_tot))
+
+    # Check that we error on 2d array input
+    with pytest.raises(ValueError):
+        check_point_clouds(ex.X[0])
+
+    # Check that we throw errors when arrays are not square and
+    # distance_matrices is True.
+    # 1) Array input
+    with pytest.raises(ValueError):
+        check_point_clouds(ex.X_rectang, distance_matrices=True)
+    # 2) List input
+    with pytest.raises(ValueError):
+        check_point_clouds(ex.X_list_rectang, distance_matrices=True)
+
+
+def test_check_point_clouds_warn_finite():
+    """Cases in which the input is finite but we throw warnings."""
+
+    ex = CreateInputs(
+        n_samples, n_1, n_2, n_samples_extra, n_1_extra, n_2_extra)
+
+    # Check that we throw warnings when arrays are square and distance_matrices
+    # is False
+    # 1) Array input
+    with pytest.warns(DataDimensionalityWarning):
+        check_point_clouds(ex.X)
+    # 2) List input
+    with pytest.warns(DataDimensionalityWarning):
+        check_point_clouds(ex.X_list)
+
+    # Check that we throw warnings on list input when arrays have different
+    # number of columns
+    with pytest.warns(DataDimensionalityWarning):
+        check_point_clouds(ex.X_list_rectang_diff_cols)
+
+
+def test_check_point_clouds_regular_inf():
+    """Cases in which part of the input is infinite and no warnings or errors
+    should be thrown by check_point_clouds."""
+
+    ex = CreateInputs(
+        n_samples, n_1, n_2, n_samples_extra, n_1_extra, n_2_extra).\
+        insert_inf()
+
+    check_point_clouds(ex.X, distance_matrices=True)
+    check_point_clouds(ex.X_list, distance_matrices=True)
+    check_point_clouds(ex.X_rectang, force_all_finite=False)
+    check_point_clouds(ex.X_list_rectang, force_all_finite=False)
+
+
+def test_check_point_clouds_value_err_inf():
+    """Cases in which part of the input is infinite and we throw a
+    ValueError."""
+
+    ex = CreateInputs(
+        n_samples, n_1, n_2, n_samples_extra, n_1_extra, n_2_extra).\
+        insert_inf()
+
+    # Check that, by default, np.inf is only accepted when distance_matrices
+    # is True.
+    # 1) Array input
+    with pytest.raises(ValueError):
+        check_point_clouds(ex.X_rectang)
+    # 2) List input
+    with pytest.raises(ValueError):
+        check_point_clouds(ex.X_list_rectang)
+
+    # Check that we error if we explicitly set force_all_finite to True
+    # 1) Array input
+    with pytest.raises(ValueError):
+        check_point_clouds(ex.X, distance_matrices=True, force_all_finite=True)
+    # 2) List input
+    with pytest.raises(ValueError):
+        check_point_clouds(
+            ex.X_list, distance_matrices=True, force_all_finite=True)
+
+
+def test_check_point_clouds_regular_nan():
+    """Cases in which part of the input is NaN and no warnings or errors
+    should be thrown by check_point_clouds."""
+
+    ex = CreateInputs(
+        n_samples, n_1, n_2, n_samples_extra, n_1_extra, n_2_extra).\
+        insert_nan()
+
+    check_point_clouds(ex.X, distance_matrices=True,
+                       force_all_finite='allow-nan')
+    check_point_clouds(
+        ex.X_list, distance_matrices=True, force_all_finite='allow-nan')
+    check_point_clouds(ex.X_rectang, force_all_finite='allow-nan')
+    check_point_clouds(ex.X_list_rectang, force_all_finite='allow-nan')
+
+
+@pytest.mark.parametrize("force_all_finite", [True, False])
+def test_check_point_clouds_value_err_nan(force_all_finite):
+    """Cases in which part of the input is nan and we throw a
+    ValueError."""
+
+    ex = CreateInputs(
+        n_samples, n_1, n_2, n_samples_extra, n_1_extra, n_2_extra).\
+        insert_nan()
+
+    # Check that we error when force_all_finite is True or False
+    # 1) Array input
+    with pytest.raises(ValueError):
+        check_point_clouds(
+            ex.X, distance_matrices=True, force_all_finite=force_all_finite)
+    with pytest.raises(ValueError):
+        check_point_clouds(ex.X_rectang, force_all_finite=force_all_finite)
+    # 2) List input
+    with pytest.raises(ValueError):
+        check_point_clouds(ex.X_list, distance_matrices=True,
+                           force_all_finite=force_all_finite)
+    with pytest.raises(ValueError):
+        check_point_clouds(
+            ex.X_list_rectang, force_all_finite=force_all_finite)

--- a/gtda/utils/validation.py
+++ b/gtda/utils/validation.py
@@ -6,7 +6,9 @@ from operator import and_
 from warnings import warn
 
 import numpy as np
+
 from sklearn.utils.validation import check_array
+from sklearn.exceptions import DataDimensionalityWarning
 
 
 def check_diagrams(X, copy=False):
@@ -186,9 +188,23 @@ def validate_params(parameters, references, exclude=None):
     return _validate_params(parameters_, references)
 
 
-def check_point_clouds(X, distance_matrix=False, **kwargs):
-    """Input validation on an array or list representing a collection of point
-    clouds or distance matrices.
+def _check_array_mod(X, **kwargs):
+    """Modified version of :func:`~sklearn.utils.validation.check_array. When
+    keyword parameter `force_all_finite` is set to False, NaNs are not
+    accepted but infinity is."""
+    if not kwargs['force_all_finite']:
+        Xnew = check_array(X, **kwargs)
+        if np.isnan(Xnew).any():
+            raise ValueError(
+                "Input contains NaN. Only finite values and infinity are "
+                "allowed when parameter `force_all_finite` is False.")
+        return Xnew
+    return check_array(X, **kwargs)
+
+
+def check_point_clouds(X, distance_matrices=False, **kwargs):
+    """Input validation on arrays or lists representing collections of point
+    clouds or of distance/adjacency matrices.
 
     The input is checked to be either a single 3D array using a single call
     to :func:`~sklearn.utils.validation.check_array`, or a list of 2D arrays by
@@ -204,14 +220,22 @@ def check_point_clouds(X, distance_matrix=False, **kwargs):
     X : object
         Input object to check / convert.
 
-    distance_matrix : bool, optional, default: ``False``
+    distance_matrices : bool, optional, default: ``False``
         Whether the input represents a collection of distance matrices or of
         concrete point clouds in Euclidean space. In the first case, entries
         are allowed to be infinite unless otherwise specified in `kwargs`.
 
     kwargs
         Keyword arguments accepted by
-        :func:`~gtda.utils.validation.check_list_of_arrays`.
+        :func:`~sklearn.utils.validation.check_array`, with the following
+        caveats: 1) `ensure_2d` and `allow_nd` are ignored; 2) if not passed
+        explicitly, `force_all_finite` is set to be the boolean negation of
+        `distance_matrices`; 3) when `force_all_finite` is set to ``False``,
+        NaN inputs are not allowed; 4) `accept_sparse` and
+        `accept_large_sparse` are only meaningful in the case of lists of 2D
+        arrays, in which case they are passed to individual instances of
+        :func:`~sklearn.utils.validation.check_array` validating each entry
+        in the list.
 
     Returns
     -------
@@ -219,30 +243,67 @@ def check_point_clouds(X, distance_matrix=False, **kwargs):
         The converted and validated object.
 
     """
-    kwargs_ = {'force_all_finite': not distance_matrix}
+    kwargs_ = {'force_all_finite': not distance_matrices}
     kwargs_.update(kwargs)
-    if hasattr(X, 'shape'):
+    kwargs_.pop('allow_nd', None)
+    kwargs_.pop('ensure_2d', None)
+    if hasattr(X, 'shape') and hasattr(X, 'ndim'):
         if X.ndim != 3:
-            raise ValueError("ndarray input must be 3D.")
-        return check_array(X, allow_nd=True, **kwargs_)
+            if X.ndim == 2:
+                extra_2D = \
+                    "\nReshape your input X using X.reshape(1, *X.shape) or " \
+                    "X[None, :, :] if X is a single point cloud/distance " \
+                    "matrix/adjacency matrix of a weighted graph."
+            else:
+                extra_2D = ""
+            raise ValueError(
+                f"Input must be a single 3D array or a list of 2D arrays. "
+                f"Array of dimension {X.ndim} passed." + extra_2D)
+        if (X.shape[1] != X.shape[2]) and distance_matrices:
+            raise ValueError(
+                f"Input array X must have X.shape[1] == X.shape[2]: "
+                f"{X.shape[1]} != {X.shape[2]} passed.")
+        elif (X.shape[1] == X.shape[2]) and not distance_matrices:
+            warn(
+                "Input array X has X.shape[1] == X.shape[2]. This is "
+                "consistent with a collection of distance/adjacency "
+                "matrices, but the input is being treated as a collection "
+                "of vectors in Euclidean space.",
+                DataDimensionalityWarning, stacklevel=2)
+        Xnew = _check_array_mod(X, **kwargs_, allow_nd=True)
     else:
-        if not distance_matrix:
-            reference = X[0].shape[1]  # Embedding dimension of first sample
-            if not reduce(
-                    and_, (x.shape[1] == reference for x in X[1:]), True):
-                warn("Not all point clouds have the same embedding dimension.")
+        has_check_failed = False
+        messages = []
+        Xnew = []
+        for i, x in enumerate(X):
+            try:
+                xnew = _check_array_mod(x, **kwargs_, ensure_2d=True)
+                if distance_matrices:
+                    if not x.shape[0] == x.shape[1]:
+                        raise ValueError(
+                            f"All arrays must be square: {x.shape[0]} rows "
+                            f"and {x.shape[1]} columns found in this array.")
+                Xnew.append(xnew)
+            except ValueError as e:
+                has_check_failed = True
+                messages.append(f"Entry {i}:\n{e}")
+        if has_check_failed:
+            raise ValueError(
+                "The following errors were raised by the inputs:\n\n" +
+                "\n\n".join(messages))
 
-    has_check_failed = False
-    messages = []
-    Xnew = []
-    for i, x in enumerate(X):
-        try:
-            Xnew.append(check_array(x, **kwargs_))
-            messages = ['']
-        except ValueError as e:
-            has_check_failed = True
-            messages.append(str(e))
-    if has_check_failed:
-        raise ValueError("The following errors were raised by the inputs: \n"
-                         "\n".join(messages))
+        if not distance_matrices:
+            if reduce(and_, (x.shape[0] == x.shape[1] for x in X), True):
+                warn(
+                    "All arrays are square. This is consistent with a "
+                    "collection of distance/adjacency matrices, but the input "
+                    "is being treated as a collection of vectors in Euclidean "
+                    "space.", DataDimensionalityWarning, stacklevel=2)
+
+            ref_dim = X[0].shape[1]  # Embedding dimension of first sample
+            if not reduce(and_, (x.shape[1] == ref_dim for x in X[1:]), True):
+                warn(
+                    "Not all point clouds have the same embedding dimension.",
+                    DataDimensionalityWarning, stacklevel=2)
+
     return Xnew


### PR DESCRIPTION
**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
The initial thrust for this PR was the need to lift unnecessary input restrictions in `gtda.externals.ripser` when `metric='precomputed'`. Namely, `pairwise_distances(X, metric='precomputed')` will perform input validation and reject any`X` containing negative entries. But the theory of Vietoris-Rips filtrations and the C++ implementation of `ripser` handle these cases perfectly well.

However, simply removing the call to `pairwise_distances` in the case `metric='precomputed'` would have removed useful checks for input shape (square). The point of view was adopted that since `gtda.externals.ripser` is not exposed to the user via documentation, and is only meant to be called by `VietorisRipsPersistence` instances, these checks should in fact be moved to the input validation steps in that class, i.e. to the calls to `check_point_clouds`.

Hence, `check_point_clouds` was refactored as follows:
- The parameter `distance_matrix` was renamed `distance_matrices` (plural, agreeing with `check_point_clouds`).
- When `distance_matrices` is set to `True`, the shapes of entries are checked to be square.
- Warnings have been added to guide the user to correctly setting the `distance_matrices` parameter.
- The default behaviour of sklearn's `check_array` has been modified so that `force_all_finite=False` does *not* mean accepting NaN input (only infinite input is accepted). Note that `ripser` handles infinities quite correctly when distance/adjacency matrices are passed.
- The docstrings have been improved.

Finally, comprehensive tests for `check_point_clouds` were created.

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.
