### PR TITLE
Fix issues with docstring of `gtda.mapper.method_to_transform`

### DIFF
--- a/gtda/mapper/utils/decorators.py
+++ b/gtda/mapper/utils/decorators.py
@@ -8,9 +8,12 @@ def method_to_transform(cls, method_name):
     """Wrap a class to add a :meth:`transform` method as an alias to an
     existing method.
 
-    An example of use is for classes possessing a :meth:`score` method such
-    as kernel density estimators and anomaly/novelty detection estimators,
-    to allow for these estimators are to be used as steps in a pipeline.
+    An example of use is for classes possessing a :meth:`score` method such as
+    kernel density estimators and anomaly/novelty detection estimators, to
+    allow for these estimators are to be used as steps in a pipeline.
+
+    Note that 1D array outputs are reshaped into 2D column vectors before
+    being returned by the new :meth:`transform`.
 
     Parameters
     ----------
@@ -20,20 +23,19 @@ def method_to_transform(cls, method_name):
 
     method_name : str
         Name of the method in `cls` to which :meth:`transform` will be
-        an alias. The fist argument of this method becomes the `X`
-        input for :meth:`transform`.
+        an alias. The fist argument of this method (after ``self``) becomes
+        the ``X`` input for :meth:`transform`.
 
     Returns
     -------
     wrapped_cls : object
-        New class inheriting from :class:`sklearn.base.TransformerMixin`,
-        so that a :meth:`fit_transform` is also available. Its name is the
-        name of `cls` prepended with ``'Extended'``.
+        New class inheriting from :class:`sklearn.base.TransformerMixin`, so
+        that both :meth:`transform` and :meth:`fit_transform` are available.
+        Its name is the name of `cls` prepended with ``'Extended'``.
 
     Examples
     --------
     >>> import numpy as np
-    >>> from numpy.testing import assert_almost_equal
     >>> from sklearn.neighbors import KernelDensity
     >>> from gtda.mapper import method_to_transform
     >>> X = np.random.random((100, 2))
@@ -41,8 +43,12 @@ def method_to_transform(cls, method_name):
     >>> kde_extended = method_to_transform(
     ...     KernelDensity, 'score_samples')()
     >>> Xt = kde.fit(X).score_samples(X)
+    >>> print(Xt.shape)
+    (100,)
     >>> Xt_extended = kde_extended.fit_transform(X)
-    >>> assert_almost_equal(Xt, Xt_extended)
+    >>> print(Xt_extended.shape)
+    (100, 1)
+    >>> np.array_equal(Xt, Xt_extended.flatten())
     True
 
     """


### PR DESCRIPTION
**Types of changes**
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
The current docstring example for the `method_to_transform` decorator in `gtda.mapper` became incorrect following changes that reshape the output of the new `transform` method to ensure it is at least 2D. This PR documents this reshaping in the docstring and fixes the example.

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] ~~I have added tests to cover my changes.~~
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.
