### PR TITLE
Fix issue 403 (color_variable is scaled in plot_static_mapper by default)

### DIFF
--- a/gtda/mapper/utils/visualization.py
+++ b/gtda/mapper/utils/visualization.py
@@ -109,7 +109,8 @@ def _infer_color_variable_kind(color_variable, data):
 
 def _get_node_colors(data, is_data_dataframe, node_elements,
                      is_node_colors_ndarray, node_color_statistic,
-                     color_variable, color_variable_kind):
+                     color_variable, color_variable_kind,
+                     normalize_node_colors=False):
     """Calculate node colors"""
     if is_node_colors_ndarray:
         node_colors = node_color_statistic
@@ -142,16 +143,18 @@ def _get_node_colors(data, is_data_dataframe, node_elements,
         warn('NaN values detected in the array of Mapper node colors!'
              'These values will be ignored in the color scale', RuntimeWarning)
 
-    # Normalise node colours in range [0,1] for colorscale mapping
-    node_colors = (node_colors - np.nanmin(node_colors)) / \
-        (np.nanmax(node_colors) - np.nanmin(node_colors))
+    # Optionally normalize node colours in range [0,1] for colorscale mapping
+    if normalize_node_colors:
+        node_colors = ((node_colors - np.nanmin(node_colors)) /
+                       (np.nanmax(node_colors) - np.nanmin(node_colors)))
 
     return node_colors
 
 
 def _calculate_graph_data(
         pipeline, data, layout, layout_dim,
-        color_variable, node_color_statistic, plotly_kwargs):
+        color_variable, node_color_statistic, plotly_kwargs,
+        normalize_node_colors=False):
     graph = pipeline.fit_transform(data)
     node_elements = graph['node_metadata']['node_elements']
 
@@ -175,7 +178,8 @@ def _calculate_graph_data(
     node_colors = _get_node_colors(
         data, is_data_dataframe, node_elements,
         is_node_colors_ndarray, node_color_statistic,
-        color_variable, color_variable_kind)
+        color_variable, color_variable_kind,
+        normalize_node_colors=normalize_node_colors)
 
     plot_options = {
         'edge_trace_mode': 'lines',

--- a/gtda/mapper/visualization.py
+++ b/gtda/mapper/visualization.py
@@ -18,7 +18,7 @@ def plot_static_mapper_graph(
         pipeline, data, layout='kamada_kawai', layout_dim=2,
         color_variable=None, node_color_statistic=None,
         color_by_columns_dropdown=False, plotly_kwargs=None,
-        clone_pipeline=True):
+        clone_pipeline=True, normalize_node_colors=False):
     """Plotting function for static Mapper graphs.
 
     Nodes are colored according to :attr:`color_variable`. By default, the
@@ -109,7 +109,8 @@ def plot_static_mapper_graph(
     node_trace, edge_trace, node_elements, _node_colors, plot_options = \
         _calculate_graph_data(
             pipe, data, layout, layout_dim,
-            color_variable, _node_color_statistic, plotly_kwargs)
+            color_variable, _node_color_statistic, plotly_kwargs,
+            normalize_node_colors=normalize_node_colors)
 
     # Define layout options that are common to 2D and 3D figures
     layout_options_common = go.Layout(
@@ -317,7 +318,8 @@ def plot_interactive_mapper_graph(pipeline, data, layout='kamada_kawai',
                 (node_trace, edge_trace, node_elements, node_colors,
                  plot_options) = _calculate_graph_data(
                     pipe, data, layout, layout_dim,
-                    color_variable, _node_color_statistic, plotly_kwargs
+                    color_variable, _node_color_statistic, plotly_kwargs,
+                    normalize_node_colors=False
                 )
                 update_figure(fig, edge_trace, node_trace, layout_dim)
 


### PR DESCRIPTION
**Reference issues/PRs**
Fixes #403 via one possible resolution. 

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
Issue #403 notes that when a `color_variable` is selected for use in `plot_static_mapper`, the existing behavior is to scale the node color mapping so that it takes values in [0,1]. While this is a reasonable default behavior in principle, it is somewhat at odds with the fact that the default behavior for displaying other data columns in the drop down list is to display the node color mappings without normalizing. 

The proposed fix here is to add a paramater `normalize_node_colors` to `plot_static_mapper` and the various functions called from plot_static_mapper that are involved in the node coloring process (e.g. in `_get_node_colors`), and then to default this parameter to `False` at every stage. I did not yet add any new tests for this change in behavior, because the nature of tests will depend on the nature of the implemented fix, so I thought I'd get some feedback on this proposal first.

**Any other comments?**

**Checklist**

- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.

