### PR TITLE
Add pip install matplotlib to notebook tests in manylinux job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ jobs:
 
   - script: |
       set -e
-      pip install pandas openml
+      pip install pandas openml matplotlib
       pip install "papermill==1.2.1"
       cd examples
       for n in *.ipynb


### PR DESCRIPTION
#406 broke the manylinux notebook tests as it removed `matplotlib` from the library requirements. This PR adds a pip install matplotlib step in the CI to fix this.