### PR TITLE
Fix mapper docstring issues following #406

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ jobs:
 
   - script: |
       set -e
-      pip install pandas openml
+      pip install pandas openml matplotlib
       pip install "papermill==1.2.1"
       cd examples
       for n in *.ipynb

--- a/gtda/mapper/pipeline.py
+++ b/gtda/mapper/pipeline.py
@@ -342,7 +342,7 @@ def make_mapper_pipeline(scaler=None,
 
     .. [3] "Caching transformers: avoid repeated computation", in
             `scikit-learn documentation \
-            <https://scikit-learn.org/stable/modules/compose.html>_`.
+            <https://scikit-learn.org/stable/modules/compose.html>`_.
 
     """
 

--- a/gtda/mapper/pipeline.py
+++ b/gtda/mapper/pipeline.py
@@ -220,7 +220,7 @@ def make_mapper_pipeline(scaler=None,
         is advantageous when the fitting of early steps is time consuming and
         only later steps in the pipeline are modified (e.g. using
         :meth:`set_params`) before refitting on the same data. To be used
-        used exactly as for :func:`sklearn.pipeline.make_pipeline`. By default,
+        exactly as for :func:`sklearn.pipeline.make_pipeline`. By default, no
         no caching is performed. If a string is given, it is the path to the
         caching directory. See [3]_.
 
@@ -260,7 +260,7 @@ def make_mapper_pipeline(scaler=None,
     >>> # Find which points belong to first node of graph
     >>> node_id = mapper_graph['node_metadata']['node_id']
     >>> node_elements = mapper_graph['node_metadata']['node_elements']
-    >>> print(f"Node Id: {node_id[0]}, Node elements: {node_elements[0]}, "
+    >>> print(f"Node ID: {node_id[0]}, Node elements: {node_elements[0]}, "
     ...       f"Data points: {X[node_elements[0]]}")
     Node Id: 0,
     Node elements: [8768],
@@ -341,7 +341,7 @@ def make_mapper_pipeline(scaler=None,
            <https://joblib.readthedocs.io/en/latest/parallel.html>`_.
 
     .. [3] "Caching transformers: avoid repeated computation", in
-            `scikit-learn documentation
+            `scikit-learn documentation \
             <https://scikit-learn.org/stable/modules/compose.html>_`.
 
     """

--- a/gtda/mapper/visualization.py
+++ b/gtda/mapper/visualization.py
@@ -121,8 +121,8 @@ def plot_static_mapper_graph(
 
     See also
     --------
-    `~gtda.mapper.plot_interactive_mapper_graph`,
-    `~gtda.mapper.make_mapper_pipeline`
+    :func:`~gtda.mapper.visualization.plot_interactive_mapper_graph`,
+    :func:`~gtda.mapper.pipeline.make_mapper_pipeline`
 
     References
     ----------
@@ -349,8 +349,8 @@ def plot_interactive_mapper_graph(
 
     See also
     --------
-    `~gtda.mapper.plot_static_mapper_graph`,
-    `~gtda.mapper.make_mapper_pipeline`
+    :func:`~gtda.mapper.visualization.plot_static_mapper_graph`,
+    :func:`~gtda.mapper.pipeline.make_mapper_pipeline`
 
     References
     ----------

--- a/gtda/mapper/visualization.py
+++ b/gtda/mapper/visualization.py
@@ -91,7 +91,8 @@ def plot_static_mapper_graph(
         Sets the scale factor used to determine the rendered size of the
         nodes. Increase for larger nodes. Implements a formula in the
         `Plotly documentation \
-        <plotly.com/python/bubble-charts/#scaling-the-size-of-bubble-charts>`_.
+        <https://plotly.com/python/bubble-charts/#scaling-the-size-of-bubble\
+        -charts>`_.
 
     plotly_params : dict or None, optional, default: ``None``
         Custom parameters to configure the plotly figure. Allowed keys are
@@ -120,8 +121,8 @@ def plot_static_mapper_graph(
 
     See also
     --------
-    :func:`~gtda.mapper.plot_interactive_mapper_graph`,
-    :func:`~gtda.mapper.make_mapper_pipeline`
+    `~gtda.mapper.plot_interactive_mapper_graph`,
+    `~gtda.mapper.make_mapper_pipeline`
 
     References
     ----------
@@ -348,8 +349,8 @@ def plot_interactive_mapper_graph(
 
     See also
     --------
-    :func:`~gtda.mapper.plot_static_mapper_graph`,
-    :func:`~gtda.mapper.make_mapper_pipeline`
+    `~gtda.mapper.plot_static_mapper_graph`,
+    `~gtda.mapper.make_mapper_pipeline`
 
     References
     ----------


### PR DESCRIPTION
#406 introduced some issues with the docstrings of `make_mapper_pipeline`, `plot_static_mapper_graph` and `plot_interactive_mapper_graph`. This PR attempts to fix them.