### PR TITLE
Feat/custom resampler

### DIFF
--- a/gtda/time_series/embedding.py
+++ b/gtda/time_series/embedding.py
@@ -1,5 +1,6 @@
 """Time series embedding."""
 # License: GNU AGPLv3
+from typing import Callable
 
 import numpy as np
 from joblib import Parallel, delayed
@@ -32,6 +33,9 @@ class SlidingWindow(BaseEstimator, TransformerResamplerMixin):
 
     stride : int, optional, default: ``1``
         Stride between consecutive windows.
+
+    target_resampler: callable, optional, default: ``None``
+        Function that defines the target from a collection of targets.
 
     Examples
     --------
@@ -75,12 +79,18 @@ class SlidingWindow(BaseEstimator, TransformerResamplerMixin):
 
     _hyperparameters = {
         'width': {'type': int, 'in': Interval(1, np.inf, closed='left')},
-        'stride': {'type': int, 'in': Interval(1, np.inf, closed='left')}
+        'stride': {'type': int, 'in': Interval(1, np.inf, closed='left')},
+        'target_resampler': {'type': Callable}
     }
 
-    def __init__(self, width=10, stride=1):
+    def __init__(self, width=10, stride=1, target_resampler=None):
         self.width = width
         self.stride = stride
+
+        if target_resampler is None:
+            self.target_resampler = lambda x: x[-1]
+        else:
+            self.target_resampler = target_resampler
 
     def _slice_windows(self, X):
         n_samples = X.shape[0]
@@ -145,9 +155,11 @@ class SlidingWindow(BaseEstimator, TransformerResamplerMixin):
         return Xt
 
     def resample(self, y, X=None):
-        """Resample `y` so that, for any i > 0, the minus i-th entry of the
-        resampled vector corresponds in time to the last entry of the minus
-        i-th window produced by :meth:`transform`.
+        """Resample `y` so that, for any i > 0, the i-th entry is the target
+        for the i-th window, obtained by applying `self.target_resampler` to
+        sliding window embedding of `y`. The default behavior is that the minus
+        i-th entry of the resampled vector corresponds in time to the last
+        entry of the minus i-th window produced by :meth:`transform`.
 
         Parameters
         ----------
@@ -168,8 +180,10 @@ class SlidingWindow(BaseEstimator, TransformerResamplerMixin):
         check_is_fitted(self, '_is_fitted')
         yr = column_or_1d(y)
 
-        yr = np.flip(yr)
-        yr = np.flip(yr[:-self.width:self.stride])
+        #yr = np.flip(yr)
+        #yr = np.flip(yr[:-self.width:self.stride])
+        yr = self.transform(y[:, None])[:, :, 0]
+        yr = np.apply_along_axis(self.target_resampler, 1, yr)
         return yr
 
     @staticmethod

--- a/gtda/time_series/embedding.py
+++ b/gtda/time_series/embedding.py
@@ -180,9 +180,7 @@ class SlidingWindow(BaseEstimator, TransformerResamplerMixin):
         check_is_fitted(self, '_is_fitted')
         yr = column_or_1d(y)
 
-        #yr = np.flip(yr)
-        #yr = np.flip(yr[:-self.width:self.stride])
-        yr = self.transform(y[:, None])[:, :, 0]
+        yr = self.transform(yr[:, None])[:, :, 0]
         yr = np.apply_along_axis(self.target_resampler, 1, yr)
         return yr
 

--- a/gtda/time_series/tests/test_embedding.py
+++ b/gtda/time_series/tests/test_embedding.py
@@ -111,7 +111,6 @@ def test_window_resample_any():
                             target_resampler=lambda x: sum(x))
     windows.fit(y_binary)
     y_resampled = windows.resample(y_binary)
-    print(y_resampled)
     assert_almost_equal(y_resampled, y_expected)
 
 

--- a/gtda/time_series/tests/test_embedding.py
+++ b/gtda/time_series/tests/test_embedding.py
@@ -34,6 +34,9 @@ signal_embedded_search = np.array([[2., 2.47942554],
                                    [2.41211849, 1.92484888]])
 
 y = np.arange(signal.shape[0])
+y_binary = np.array([0, 1, 0, 1, 1, 1, 0, 0, 0])
+
+y_expected = np.array([1, 2, 2, 0])
 
 signal_embedded_fixed = \
     np.array([[2., 2.47942554, 2.84147098, 2.99749499, 2.90929743],
@@ -101,6 +104,15 @@ def test_window_resample():
     windows.fit(y)
     y_resampled = windows.resample(y)
     assert_almost_equal(y_resampled, y[np.arange(3, 20, 2)])
+
+
+def test_window_resample_any():
+    windows = SlidingWindow(width=2, stride=2,
+                            target_resampler=lambda x: sum(x))
+    windows.fit(y_binary)
+    y_resampled = windows.resample(y_binary)
+    print(y_resampled)
+    assert_almost_equal(y_resampled, y_expected)
 
 
 def test_window_plot():


### PR DESCRIPTION
**Reference issues/PRs**
None

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
Currently, the minus i-th entry in `SlidingWindow().resample(y)` is the last element from the minus i-th full window.
This PR offers a generalization, where `SlidingWindow.target_resampler` is applied to `SlidingWindow().transform(y)[i]` to obtain `SlidingWindow().resample(y)[i]`.
The default `SlidingWindow.target_resampler=lambda x: x[-1]` makes the default behavior unchanged.

**Screenshots (if appropriate)**

**Any other comments?**
I am not sure if this is the right place to introduce that. Maybe another transformer, which inherits from Sliding window would be better?

**Checklist**
<!--
Go over all the following points, and put an `x` in all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [X] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [X] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed. I used `pytest` to check this on Python tests.

