### PR TITLE
Transpose the output of PairwiseDistance to match scikit-learn convention

### DIFF
--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -259,17 +259,17 @@ def _parallel_pairwise(X1, X2, metric, metric_params,
         X2 = X1
 
     distance_matrices = Parallel(n_jobs=n_jobs)(
-        delayed(metric_func)(_subdiagrams(X1, [dim], remove_dim=True),
-                             _subdiagrams(X2[s], [dim], remove_dim=True),
+        delayed(metric_func)(_subdiagrams(X2[s], [dim], remove_dim=True),
+                             _subdiagrams(X1, [dim], remove_dim=True),
                              sampling=samplings[dim],
                              step_size=step_sizes[dim],
                              **effective_metric_params)
         for dim in homology_dimensions
         for s in gen_even_slices(X2.shape[0], effective_n_jobs(n_jobs)))
 
-    distance_matrices = np.concatenate(distance_matrices, axis=1)
+    distance_matrices = np.concatenate(distance_matrices, axis=0)
     distance_matrices = np.stack(
-        [distance_matrices[:, i * X2.shape[0]:(i + 1) * X2.shape[0]]
+        [distance_matrices[i * X2.shape[0]:(i + 1) * X2.shape[0], :]
          for i in range(len(homology_dimensions))],
         axis=2)
     return distance_matrices

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -255,13 +255,10 @@ def _parallel_pairwise(X1, X2, metric, metric_params,
     samplings = effective_metric_params.pop("samplings", none_dict)
     step_sizes = effective_metric_params.pop("step_sizes", none_dict)
 
-    if X2 is None:
-        X2 = X1
-
     n_columns = len(X2)
     distance_matrices = Parallel(n_jobs=n_jobs)(
-        delayed(metric_func)(_subdiagrams(X2[s], [dim], remove_dim=True),
-                             _subdiagrams(X1, [dim], remove_dim=True),
+        delayed(metric_func)(_subdiagrams(X1, [dim], remove_dim=True),
+                             _subdiagrams(X2[s], [dim], remove_dim=True),
                              sampling=samplings[dim],
                              step_size=step_sizes[dim],
                              **effective_metric_params)

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -265,7 +265,7 @@ def _parallel_pairwise(X1, X2, metric, metric_params,
         for dim in homology_dimensions
         for s in gen_even_slices(n_columns, effective_n_jobs(n_jobs)))
 
-    distance_matrices = np.concatenate(distance_matrices, axis=0)
+    distance_matrices = np.concatenate(distance_matrices, axis=1)
     distance_matrices = np.stack(
         [distance_matrices[:, i * n_columns:(i + 1) * n_columns]
          for i in range(len(homology_dimensions))],

--- a/gtda/diagrams/distance.py
+++ b/gtda/diagrams/distance.py
@@ -197,9 +197,9 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        Xt : ndarray of shape (n_samples_fit, n_samples, \
+        Xt : ndarray of shape (n_samples, n_samples_fit \
             n_homology_dimensions) if `order` is ``None``, else \
-            (n_samples_fit, n_samples)
+            (n_samples, n_samples_fit)
             Distance matrix or collection of distance matrices between
             diagrams in `X` and diagrams seen in :meth:`fit`. In the
             second case, index i along axis 2 corresponds to the i-th
@@ -221,4 +221,4 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
         if self.order is not None:
             Xt = np.linalg.norm(Xt, axis=2, ord=self.order)
 
-        return Xt
+        return np.swapaxes(Xt, 1, 0)

--- a/gtda/diagrams/distance.py
+++ b/gtda/diagrams/distance.py
@@ -214,11 +214,11 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
         else:
             X2 = X
 
-        Xt = _parallel_pairwise(self._X, X2, self.metric,
+        Xt = _parallel_pairwise(X2, self._X, self.metric,
                                 self.effective_metric_params_,
                                 self.homology_dimensions_,
                                 self.n_jobs)
         if self.order is not None:
             Xt = np.linalg.norm(Xt, axis=2, ord=self.order)
 
-        return np.swapaxes(Xt, 1, 0)
+        return Xt

--- a/gtda/diagrams/distance.py
+++ b/gtda/diagrams/distance.py
@@ -210,11 +210,11 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
         X = check_diagrams(X, copy=True)
 
         if np.array_equal(X, self._X):
-            X2 = None
+            X1 = None
         else:
-            X2 = X
+            X1 = X
 
-        Xt = _parallel_pairwise(X2, self._X, self.metric,
+        Xt = _parallel_pairwise(X1, self._X, self.metric,
                                 self.effective_metric_params_,
                                 self.homology_dimensions_,
                                 self.n_jobs)

--- a/gtda/diagrams/distance.py
+++ b/gtda/diagrams/distance.py
@@ -197,7 +197,7 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
 
         Returns
         -------
-        Xt : ndarray of shape (n_samples, n_samples_fit \
+        Xt : ndarray of shape (n_samples, n_samples_fit, \
             n_homology_dimensions) if `order` is ``None``, else \
             (n_samples, n_samples_fit)
             Distance matrix or collection of distance matrices between
@@ -209,12 +209,7 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
         check_is_fitted(self)
         X = check_diagrams(X, copy=True)
 
-        if np.array_equal(X, self._X):
-            X1 = None
-        else:
-            X1 = X
-
-        Xt = _parallel_pairwise(self._X, X1, self.metric,
+        Xt = _parallel_pairwise(X, self._X, self.metric,
                                 self.effective_metric_params_,
                                 self.homology_dimensions_,
                                 self.n_jobs)

--- a/gtda/diagrams/distance.py
+++ b/gtda/diagrams/distance.py
@@ -214,7 +214,7 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
         else:
             X1 = X
 
-        Xt = _parallel_pairwise(X1, self._X, self.metric,
+        Xt = _parallel_pairwise(self._X, X1, self.metric,
                                 self.effective_metric_params_,
                                 self.homology_dimensions_,
                                 self.n_jobs)

--- a/gtda/diagrams/tests/test_distance.py
+++ b/gtda/diagrams/tests/test_distance.py
@@ -264,7 +264,7 @@ def test_dd_transform(metric, metric_params, order, n_jobs):
     dd = PairwiseDistance(metric=metric, metric_params=metric_params,
                           order=order, n_jobs=n_jobs)
     X_res = dd.fit(X_1).transform(X_2)
-    assert (X_res.shape[0], X_res.shape[1]) == (X_1.shape[0], X_2.shape[0])
+    assert (X_res.shape[0], X_res.shape[1]) == (X_2.shape[0], X_1.shape[0])
 
     if order is None:
         assert X_res.shape[2] == len(np.unique(X_2[:, :, 2]))
@@ -272,7 +272,7 @@ def test_dd_transform(metric, metric_params, order, n_jobs):
     # X_fit != X_transform, default metric_params
     dd = PairwiseDistance(metric=metric, order=order, n_jobs=n_jobs)
     X_res = dd.fit(X_1).transform(X_2)
-    assert (X_res.shape[0], X_res.shape[1]) == (X_1.shape[0], X_2.shape[0])
+    assert (X_res.shape[0], X_res.shape[1]) == (X_2.shape[0], X_1.shape[0])
 
 
 parameters_amplitude = [

--- a/gtda/diagrams/tests/test_distance.py
+++ b/gtda/diagrams/tests/test_distance.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_almost_equal
 
 from gtda.diagrams import PairwiseDistance, Amplitude
 
-X_1 = np.array([
+X1 = np.array([
     [[0., 0.36905774, 0],
      [0., 0.37293977, 0],
      [0., 0.38995215, 0],
@@ -118,7 +118,7 @@ X_1 = np.array([
      [0., 0., 2],
      [0., 0., 2]]])
 
-X_2 = np.array([
+X2 = np.array([
     [[0., 0.36905774, 0],
      [0., 0.37293977, 0],
      [0., 0.38995215, 0],
@@ -236,10 +236,10 @@ def test_not_fitted():
     da = Amplitude()
 
     with pytest.raises(NotFittedError):
-        dd.transform(X_1)
+        dd.transform(X1)
 
     with pytest.raises(NotFittedError):
-        da.transform(X_1)
+        da.transform(X1)
 
 
 parameters_distance = [
@@ -257,22 +257,22 @@ def test_dd_transform(metric, metric_params, order, n_jobs):
     # X_fit == X_transform
     dd = PairwiseDistance(metric=metric, metric_params=metric_params,
                           order=order, n_jobs=n_jobs)
-    X_res = dd.fit_transform(X_1)
-    assert (X_res.shape[0], X_res.shape[1]) == (X_1.shape[0], X_1.shape[0])
+    X_res = dd.fit_transform(X1)
+    assert (X_res.shape[0], X_res.shape[1]) == (X1.shape[0], X1.shape[0])
 
     # X_fit != X_transform
     dd = PairwiseDistance(metric=metric, metric_params=metric_params,
                           order=order, n_jobs=n_jobs)
-    X_res = dd.fit(X_1).transform(X_2)
-    assert (X_res.shape[0], X_res.shape[1]) == (X_2.shape[0], X_1.shape[0])
+    X_res = dd.fit(X1).transform(X2)
+    assert (X_res.shape[0], X_res.shape[1]) == (X2.shape[0], X1.shape[0])
 
     if order is None:
-        assert X_res.shape[2] == len(np.unique(X_2[:, :, 2]))
+        assert X_res.shape[2] == len(np.unique(X2[:, :, 2]))
 
     # X_fit != X_transform, default metric_params
     dd = PairwiseDistance(metric=metric, order=order, n_jobs=n_jobs)
-    X_res = dd.fit(X_1).transform(X_2)
-    assert (X_res.shape[0], X_res.shape[1]) == (X_2.shape[0], X_1.shape[0])
+    X_res = dd.fit(X1).transform(X2)
+    assert (X_res.shape[0], X_res.shape[1]) == (X2.shape[0], X1.shape[0])
 
 
 parameters_amplitude = [
@@ -288,14 +288,14 @@ parameters_amplitude = [
 def test_da_transform(metric, metric_params, n_jobs):
     da = Amplitude(metric=metric, metric_params=metric_params,
                    n_jobs=n_jobs)
-    X_res = da.fit_transform(X_1)
-    assert X_res.shape == (X_1.shape[0], 1)
+    X_res = da.fit_transform(X1)
+    assert X_res.shape == (X1.shape[0], 1)
 
     # X_fit != X_transform
     da = Amplitude(metric=metric, metric_params=metric_params,
                    n_jobs=n_jobs)
-    X_res = da.fit(X_1).transform(X_2)
-    assert X_res.shape == (X_2.shape[0], 1)
+    X_res = da.fit(X1).transform(X2)
+    assert X_res.shape == (X2.shape[0], 1)
 
 
 @pytest.mark.parametrize(('metric', 'metric_params', 'order'),


### PR DESCRIPTION
**Reference issues/PRs**
None

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
Currently, the shape of a `pairwise_distance.transform(X)` is `(X_fit.shape[0], X.shape[0])`, where `pairwise_distance = PairwiseDistance().fit(X_fit)`.

The above convention is the opposite [the one](https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KNeighborsClassifier.html#sklearn.neighbors.KNeighborsClassifier.predict) in `sklearn.neighbors.kNearestNeighbors`. Hence, I propose to transpose the output of `PairwiseDistance().transform` to match that of `sklearn`.

**Screenshots (if appropriate)**

**Any other comments?**

**Checklist**
<!--
Go over all the following points, and put an `x` in all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [X] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [X] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. I used `pytest` to check this on Python tests.

<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
