### PR TITLE
Introduce `nightly_release` variable in azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ jobs:
       set -e
       sed -i "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
       sed -i "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
-    condition: nightly_release
+    condition: variables['nightly_release']
     displayName: 'Change name to giotto-tda-nightly'
 
   - task: Bash@3
@@ -103,7 +103,7 @@ jobs:
       set -e
       pip install twine
       twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*manylinux2010*.whl
-    condition: nightly_release
+    condition: variables['nightly_release']
     displayName: 'Upload nightly wheels to PyPI'
 
 
@@ -132,7 +132,7 @@ jobs:
       rm setup.py.bak
       sed -i.bak "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
       rm gtda/_version.py.bak
-    condition: nightly_release
+    condition: variables['nightly_release']
     displayName: 'Change name to giotto-tda-nightly'
 
   - task: Cache@2
@@ -219,7 +219,7 @@ jobs:
   - bash: |
       set -e
       twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*
-    condition: nightly_release
+    condition: variables['nightly_release']
     displayName: 'Upload nightly wheels to PyPI'
 
 
@@ -247,7 +247,7 @@ jobs:
       set -e
       sed -i "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
       sed -i "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
-    condition: nightly_release
+    condition: variables['nightly_release']
     displayName: 'Change name to giotto-tda-nightly'
 
   # Set BOOST_ROOT_PIPELINE to the version used in the pipeline
@@ -310,5 +310,5 @@ jobs:
       set -e
       pip install twine
       twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*
-    condition: nightly_release
+    condition: variables['nightly_release']
     displayName: 'Upload nightly wheels to PyPI'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,8 +1,7 @@
 # These jobs are triggered automatically and they test code, examples, and wheels.
 # Additional checks can be manually triggered
 variables:
-- name: nightly_release
-  value: and(eq(variables['nightly_check'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['Build.Reason'], 'PullRequest'))
+- nightly_release: and(eq(variables['nightly_check'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['Build.Reason'], 'PullRequest'))
 
 trigger:
 - master

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,9 @@
 # These jobs are triggered automatically and they test code, examples, and wheels.
 # Additional checks can be manually triggered
+variables:
+- name: nightly_release
+  value: and(eq(variables['nightly_check'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+
 trigger:
 - master
 
@@ -46,7 +50,7 @@ jobs:
       set -e
       sed -i "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
       sed -i "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
-    condition: eq(variables['nightly_check'], 'true')
+    condition: nightly_release
     displayName: 'Change name to giotto-tda-nightly'
 
   - task: Bash@3
@@ -99,7 +103,7 @@ jobs:
       set -e
       pip install twine
       twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*manylinux2010*.whl
-    condition: eq(variables['nightly_check'], 'true')
+    condition: nightly_release
     displayName: 'Upload nightly wheels to PyPI'
 
 
@@ -128,7 +132,7 @@ jobs:
       rm setup.py.bak
       sed -i.bak "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
       rm gtda/_version.py.bak
-    condition: eq(variables['nightly_check'], 'true')
+    condition: nightly_release
     displayName: 'Change name to giotto-tda-nightly'
 
   - task: Cache@2
@@ -215,7 +219,7 @@ jobs:
   - bash: |
       set -e
       twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*
-    condition: eq(variables['nightly_check'], 'true')
+    condition: nightly_release
     displayName: 'Upload nightly wheels to PyPI'
 
 
@@ -243,7 +247,7 @@ jobs:
       set -e
       sed -i "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
       sed -i "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
-    condition: eq(variables['nightly_check'], 'true')
+    condition: nightly_release
     displayName: 'Change name to giotto-tda-nightly'
 
   # Set BOOST_ROOT_PIPELINE to the version used in the pipeline
@@ -306,5 +310,5 @@ jobs:
       set -e
       pip install twine
       twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*
-    condition: eq(variables['nightly_check'], 'true')
+    condition: nightly_release
     displayName: 'Upload nightly wheels to PyPI'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@
 # Additional checks can be manually triggered
 variables:
 - name: nightly_release
-  value: and(eq(variables['nightly_check'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  value: and(eq(variables['nightly_check'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['Build.Reason'], 'PullRequest'))
 
 trigger:
 - master

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,7 @@ jobs:
       set -e
       sed -i "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
       sed -i "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
-    condition: variables['nightly_release']
+    condition: eq('True', variables['nightly_release'])
     displayName: 'Change name to giotto-tda-nightly'
 
   - task: Bash@3
@@ -102,7 +102,7 @@ jobs:
       set -e
       pip install twine
       twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*manylinux2010*.whl
-    condition: variables['nightly_release']
+    condition: eq('True', variables['nightly_release'])
     displayName: 'Upload nightly wheels to PyPI'
 
 
@@ -131,7 +131,7 @@ jobs:
       rm setup.py.bak
       sed -i.bak "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
       rm gtda/_version.py.bak
-    condition: variables['nightly_release']
+    condition: eq('True', variables['nightly_release'])
     displayName: 'Change name to giotto-tda-nightly'
 
   - task: Cache@2
@@ -218,7 +218,7 @@ jobs:
   - bash: |
       set -e
       twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*
-    condition: variables['nightly_release']
+    condition: eq('True', variables['nightly_release'])
     displayName: 'Upload nightly wheels to PyPI'
 
 
@@ -246,7 +246,7 @@ jobs:
       set -e
       sed -i "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
       sed -i "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
-    condition: variables['nightly_release']
+    condition: eq('True', variables['nightly_release'])
     displayName: 'Change name to giotto-tda-nightly'
 
   # Set BOOST_ROOT_PIPELINE to the version used in the pipeline
@@ -309,5 +309,5 @@ jobs:
       set -e
       pip install twine
       twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*
-    condition: variables['nightly_release']
+    condition: eq('True', variables['nightly_release'])
     displayName: 'Upload nightly wheels to PyPI'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@
 # Additional checks can be manually triggered
 variables:
 - name: nightly_release
-  value: and(eq(variables['nightly_check'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['Build.Reason'], 'PullRequest'))
+  value: and(eq(variables['nightly_check'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['Build.Reason'], 'PullRequest'))
 
 trigger:
 - master

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 # These jobs are triggered automatically and they test code, examples, and wheels.
 # Additional checks can be manually triggered
 variables:
-- nightly_release: and(eq(variables['nightly_check'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['Build.Reason'], 'PullRequest'))
+  nightly_release: and(eq(variables['nightly_check'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['Build.Reason'], 'PullRequest'))
 
 trigger:
 - master


### PR DESCRIPTION
**Types of changes**
- [ ] ~~Bug fix (non-breaking change which fixes an issue)~~
- [ ] ~~New feature (non-breaking change which adds functionality)~~
- [ ] ~~Breaking change (fix or feature that would cause existing functionality to change)~~
- [x] CI change

**Description**
Introduces a `nightly_release` variable in `azure-pipelines.yml` which checks whether the CI run is meant to release a nightly version on PyPI. The variable is defined as
```
and(eq(variables['nightly_check'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['Build.Reason'], 'PullRequest'))
```
so that in particular one may not accidentally publish on PyPI from a feature branch via a PR. 

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] ~~I have added tests to cover my changes.~~
- [ ] All new and existing tests passed. I used `pytest` to check this on Python tests.
