### PR TITLE
Refactor GraphGeodesicDistance

### DIFF
--- a/gtda/graphs/geodesic_distance.py
+++ b/gtda/graphs/geodesic_distance.py
@@ -171,7 +171,7 @@ class GraphGeodesicDistance(BaseEstimator, TransformerMixin, PlotterMixin):
         X = check_graph(X)
 
         Xt = Parallel(n_jobs=self.n_jobs)(
-            delayed(self._geodesic_distance)(x, i) for i, x in enumerate(X))
+            delayed(self._geodesic_distance)(x, i=i) for i, x in enumerate(X))
 
         x0_shape = Xt[0].shape
         if reduce(and_, (x.shape == x0_shape for x in X), True):

--- a/gtda/graphs/kneighbors.py
+++ b/gtda/graphs/kneighbors.py
@@ -89,6 +89,10 @@ class KNeighborsGraph(BaseEstimator, TransformerMixin):
      [1. 0. 0. 1.]
      [1. 1. 1. 0.]]
 
+    See also
+    --------
+    TransitionGraph, GraphGeodesicDistance
+
     """
 
     def __init__(self, n_neighbors=4, metric='euclidean',

--- a/gtda/graphs/tests/test_geodesic_distance.py
+++ b/gtda/graphs/tests/test_geodesic_distance.py
@@ -55,18 +55,24 @@ X_ggd.append((X_ggd_int, X_ggd_int_res))
 x_ggd_float = X_ggd_bool[0].astype(np.float)
 X_ggd.append(([x_ggd_float], X_ggd_int_res))
 
-X_ggd.append(([masked_array(x_ggd_float, mask=x_ggd_float == np.inf)], X_ggd_int_res))
+X_ggd.append(
+    ([masked_array(x_ggd_float, mask=x_ggd_float == np.inf)], X_ggd_int_res)
+)
 
 X_ggd_csr_int = [csr_matrix(X_ggd_int[0])]
 X_ggd.append((X_ggd_csr_int, X_ggd_bool_res))
 
-X_ggd_csr_int_with_zeros = [csr_matrix(([1, 1, 0, 0], ([0, 1, 0, 2], [1, 0, 2, 0])))]
+X_ggd_csr_int_with_zeros = [
+    csr_matrix(([1, 1, 0, 0], ([0, 1, 0, 2], [1, 0, 2, 0])))
+]
 X_ggd_csr_int_with_zeros_res = np.array([[[0., 1., 0.],
                                           [1., 0., 1.],
                                           [0., 1., 0.]]])
 X_ggd.append((X_ggd_csr_int_with_zeros, X_ggd_csr_int_with_zeros_res))
 
-X_ggd_csr_bool_with_False = [csr_matrix(([True, True, False, False], ([0, 1, 0, 2], [1, 0, 2, 0])))]
+X_ggd_csr_bool_with_False = [
+    csr_matrix(([True, True, False, False], ([0, 1, 0, 2], [1, 0, 2, 0])))
+]
 X_ggd.append((X_ggd_csr_bool_with_False, X_ggd_csr_int_with_zeros_res))
 
 

--- a/gtda/graphs/tests/test_geodesic_distance.py
+++ b/gtda/graphs/tests/test_geodesic_distance.py
@@ -43,9 +43,9 @@ X_ggd.append((X_ggd_float_list, X_ggd_float_res))
 X_ggd_bool = [np.array([[False, True, False],
                        [True, False, False],
                        [False, False, False]])]
-X_ggd_bool_res = np.array([[[0.,  1., np.inf],
-                            [1.,  0., np.inf],
-                            [np.inf, np.inf,  0.]]])
+X_ggd_bool_res = np.array([[[0., 1., np.inf],
+                            [1., 0., np.inf],
+                            [np.inf, np.inf, 0.]]])
 X_ggd.append((X_ggd_bool, X_ggd_bool_res))
 
 X_ggd_int = [X_ggd_bool[0].astype(int)]

--- a/gtda/graphs/tests/test_geodesic_distance.py
+++ b/gtda/graphs/tests/test_geodesic_distance.py
@@ -37,19 +37,7 @@ def test_ggd_fit_transform_plot():
 
 
 def test_ggd_transform():
-    X_ggd_res = np.array([
-        [[0., 1., 3., 7., np.inf],
-         [1., 0., 4., 8., np.inf],
-         [3., 4., 0., 4., np.inf],
-         [7., 8., 4., 0., np.inf],
-         [np.inf, np.inf, np.inf, np.inf, 0.]],
-
-        [[0., 1., 2., 6., np.inf],
-         [1., 0., 1., 5., np.inf],
-         [2., 1., 0., 4., np.inf],
-         [6., 5., 4., 0., np.inf],
-         [np.inf, np.inf, np.inf, np.inf, 0.]]
-    ])
+    X_ggd_res = np.zeros(X_ggd.shape)
     ggd = GraphGeodesicDistance()
 
     assert_almost_equal(ggd.fit_transform(X_ggd), X_ggd_res)

--- a/gtda/graphs/tests/test_geodesic_distance.py
+++ b/gtda/graphs/tests/test_geodesic_distance.py
@@ -3,26 +3,71 @@
 import numpy as np
 import plotly.io as pio
 import pytest
+from numpy.ma import masked_array
 from numpy.testing import assert_almost_equal
+from scipy.sparse import csr_matrix
 from sklearn.exceptions import NotFittedError
 
 from gtda.graphs import GraphGeodesicDistance
 
-pio.renderers.default = 'plotly_mimetype'
+pio.renderers.default = "plotly_mimetype"
 
-X_ggd = np.array([
-    np.array(
-        [[0, 1, 3, 0, 0],
-         [1, 0, 5, 0, 0],
-         [3, 5, 0, 4, 0],
-         [0, 0, 4, 0, 0],
-         [0, 0, 0, 0, 0]]),
-    np.array(
-        [[0, 1, 3, 0, 0],
-         [1, 0, 1, 0, 0],
-         [3, 1, 0, 4, 0],
-         [0, 0, 4, 0, 0],
-         [0, 0, 0, 0, 0]])])
+
+X_ggd = []
+
+X_ggd_float = np.array([
+    np.array([[0., 1., 3., 0., 0.],
+              [1., 0., 5., 0., 0.],
+              [3., 5., 0., 4., 0.],
+              [0., 0., 4., 0., 0.],
+              [0., 0., 0., 0., 0.]]),
+    np.array([[0., 1., 3., 0., np.inf],
+              [1., 0., 1., 0., np.inf],
+              [3., 1., 0., 4., np.inf],
+              [0., 0., 4., 0., np.inf],
+              [np.inf, np.inf, np.inf, np.inf, 0.]])
+])
+X_ggd_float_res = np.array([
+    np.zeros(X_ggd_float[0].shape, dtype=np.float),
+    np.array([[0., 0., 1., 0., np.inf],
+              [0., 0., 1., 0., np.inf],
+              [1., 1., 0., 1., np.inf],
+              [0., 0., 1., 0., np.inf],
+              [np.inf, np.inf, np.inf, np.inf, 0.]])
+])
+X_ggd.append((X_ggd_float, X_ggd_float_res))
+
+X_ggd_float_list = list(X_ggd_float)
+X_ggd.append((X_ggd_float_list, X_ggd_float_res))
+
+X_ggd_bool = [np.array([[False, True, False],
+                       [True, False, False],
+                       [False, False, False]])]
+X_ggd_bool_res = np.array([[[0.,  1., np.inf],
+                            [1.,  0., np.inf],
+                            [np.inf, np.inf,  0.]]])
+X_ggd.append((X_ggd_bool, X_ggd_bool_res))
+
+X_ggd_int = [X_ggd_bool[0].astype(int)]
+X_ggd_int_res = np.zeros((1, *X_ggd_int[0].shape), dtype=np.float)
+X_ggd.append((X_ggd_int, X_ggd_int_res))
+
+x_ggd_float = X_ggd_bool[0].astype(np.float)
+X_ggd.append(([x_ggd_float], X_ggd_int_res))
+
+X_ggd.append(([masked_array(x_ggd_float, mask=x_ggd_float == np.inf)], X_ggd_int_res))
+
+X_ggd_csr_int = [csr_matrix(X_ggd_int[0])]
+X_ggd.append((X_ggd_csr_int, X_ggd_bool_res))
+
+X_ggd_csr_int_with_zeros = [csr_matrix(([1, 1, 0, 0], ([0, 1, 0, 2], [1, 0, 2, 0])))]
+X_ggd_csr_int_with_zeros_res = np.array([[[0., 1., 0.],
+                                          [1., 0., 1.],
+                                          [0., 1., 0.]]])
+X_ggd.append((X_ggd_csr_int_with_zeros, X_ggd_csr_int_with_zeros_res))
+
+X_ggd_csr_bool_with_False = [csr_matrix(([True, True, False, False], ([0, 1, 0, 2], [1, 0, 2, 0])))]
+X_ggd.append((X_ggd_csr_bool_with_False, X_ggd_csr_int_with_zeros_res))
 
 
 def test_ggd_not_fitted():
@@ -33,19 +78,21 @@ def test_ggd_not_fitted():
 
 
 def test_ggd_fit_transform_plot():
-    GraphGeodesicDistance().fit_transform_plot(X_ggd, sample=0)
+    X = X_ggd[0][0]
+    GraphGeodesicDistance().fit_transform_plot(X, sample=0)
 
 
-def test_ggd_transform():
-    X_ggd_res = np.zeros(X_ggd.shape)
-    ggd = GraphGeodesicDistance()
+@pytest.mark.parametrize("X, X_res", X_ggd)
+@pytest.mark.parametrize("method", ["auto", "FW", "D", "J", "BF"])
+def test_ggd_transform(X, X_res, method):
+    ggd = GraphGeodesicDistance(directed=False, method=method)
 
-    assert_almost_equal(ggd.fit_transform(X_ggd), X_ggd_res)
+    assert_almost_equal(ggd.fit_transform(X), X_res)
 
 
 def test_parallel_ggd_transform():
+    X = X_ggd[0][0]
     ggd = GraphGeodesicDistance(n_jobs=1)
     ggd_parallel = GraphGeodesicDistance(n_jobs=2)
 
-    assert_almost_equal(ggd.fit_transform(X_ggd), ggd_parallel.fit_transform(
-        X_ggd))
+    assert_almost_equal(ggd.fit_transform(X), ggd_parallel.fit_transform(X))

--- a/gtda/graphs/transition.py
+++ b/gtda/graphs/transition.py
@@ -82,7 +82,8 @@ class TransitionGraph(BaseEstimator, TransformerMixin):
 
     See also
     --------
-    GraphGeodesicDistance, gtda.time_series.TakensEmbedding
+    KNeighborsGraph, GraphGeodesicDistance,
+    :class:`~gtda.time_series.TakensEmbedding`
 
     Notes
     -----


### PR DESCRIPTION
**Types of changes**
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
There are a couple of major problems with the current implementation of `GraphGeodesicDistance`:
1. The return type of `transform` is always ndarray, even when different distance matrix shapes imply that the ndarray is 1D. But in this case, output fed to the homology transformers will fail due to the current implementation of `check_point_cloud`, see https://github.com/giotto-ai/giotto-tda/blob/188b6755b7f567a49d0a15cb63492de29a81ab45/gtda/utils/validation.py#L260
2. The handling of zero entries, infinity entries and non-stored entries in the sparse case was quite opaque and some non-generic shortcuts were taken in the code to address most, but not all, cases.

This PR fixes both problems and introduces additional changes. In particular:
- The return type of `transform` is only ndarray if it can be turned into a 3D ndarray, else it is list.
- Scipy's [`shortest_path`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csgraph.shortest_path.html) replaces scikit-learn's [`graph_shortest_path`](https://scikit-learn.org/stable/modules/generated/sklearn.utils.graph_shortest_path.graph_shortest_path.html). This is because it supports a wider range of algorithms, it supports masked arrays, it is better maintained, and it has "better" behaviour in the sparse case (see below). I have created a gist to exhibit the difference in behaviour and the new behaviour of `GraphGeodesicDistance`: https://gist.github.com/ulupo/83cc82ce83379ebda8fdfe846d0c06a5.
- A particular convention is clearly established:
  - if the input arrays are dense, then absent edges must be indicated by ``numpy.inf``;
  - zero edges in int or float arrays do not denote absent edges, but edges of length 0;
  - on the other hand, ``False`` edges in Boolean arrays do denote absent edges;
  - in the sparse case, non-stored values are interpreted as absent edges.
- The additional parameters `directed`, `unweighted` and `method` are made available, with the obvious meanings.

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.