### PR TITLE
Modify check_point_clouds to allow for sparse input

### DIFF
--- a/CODE_AUTHORS.rst
+++ b/CODE_AUTHORS.rst
@@ -3,7 +3,7 @@ The following is the list of code authors of the ``giotto-tda`` python package.
 Where component authors are known, add them here.
 
 | Guillaume Tauzin, guillaume.tauzin@epfl.ch
-| Umberto Lupo, u.lupo@l2f.ch
+| Umberto Lupo, umberto.lupo@gmail.com
 | Lewis Tunstall, l.tunstall@l2f.ch
 | Matteo Caorsi, m.caorsi@l2f.ch
 | Philippe Nguyen, p.nguyen@l2f.ch

--- a/GOVERNANCE.rst
+++ b/GOVERNANCE.rst
@@ -13,7 +13,7 @@ Authors:
 Giotto-tda Project Team:
 ------------------------
 
-- Umberto Lupo u.lupo@l2f.ch (Maintainer)
+- Umberto Lupo umberto.lupo@gmail.com (Maintainer)
 - Lewis Tunstall l.tunstall@l2f.ch (Maintainer)
 - Matteo Caorsi m.caorsi@l2f.ch (Project Leader)
 

--- a/gtda/homology/cubical.py
+++ b/gtda/homology/cubical.py
@@ -85,7 +85,8 @@ class CubicalPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
     References
     ----------
     [1] P. Dlotko, "Cubical complex", 2015; `GUDHI User and Reference Manual \
-    <http://gudhi.gforge.inria.fr/doc/latest/group__cubical__complex.html>`_.
+        <http://gudhi.gforge.inria.fr/doc/latest/group__cubical__complex.\
+        html>`_.
 
     """
 

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -880,7 +880,7 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         self : object
 
         """
-        check_point_clouds(X, allow_sparse=True, distance_matrices=True)
+        check_point_clouds(X, accept_sparse=True, distance_matrices=True)
         validate_params(
             self.get_params(), self._hyperparameters, exclude=['n_jobs',
                                                                'filtration'])
@@ -941,7 +941,7 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         """
         check_is_fitted(self)
-        X = check_point_clouds(X, allow_sparse=True, distance_matrices=True)
+        X = check_point_clouds(X, accept_sparse=True, distance_matrices=True)
 
         Xt = Parallel(n_jobs=self.n_jobs)(
             delayed(self._flagser_diagram)(x) for x in X)

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -152,9 +152,9 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             was not set to ``'precomputed'``, and of distance matrices or
             adjacency matrices of weighted undirected graphs otherwise. Can be
             either a 3D ndarray whose zeroth dimension has size ``n_samples``,
-            or a list containing ``n_samples`` 2D ndarrays. If `metric` was
-            set to ``'precomputed'``, each entry of `X` must be a square
-            array and should be compatible with a filtration, i.e. the value
+            or a list containing ``n_samples`` 2D ndarrays/sparse matrices.
+            If `metric` was set to ``'precomputed'``, each entry of `X` must be
+            square and should be compatible with a filtration, i.e. the value
             at index (i, j) should be no smaller than the values at diagonal
             indices (i, i) and (j, j).
 
@@ -170,7 +170,8 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         validate_params(
             self.get_params(), self._hyperparameters, exclude=['n_jobs'])
         self._is_precomputed = self.metric == 'precomputed'
-        check_point_clouds(X, distance_matrices=self._is_precomputed)
+        check_point_clouds(X, accept_sparse=self._is_precomputed,
+                           distance_matrices=self._is_precomputed)
 
         if self.infinity_values is None:
             self.infinity_values_ = self.max_edge_length
@@ -200,9 +201,9 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             was not set to ``'precomputed'``, and of distance matrices or
             adjacency matrices of weighted undirected graphs otherwise. Can be
             either a 3D ndarray whose zeroth dimension has size ``n_samples``,
-            or a list containing ``n_samples`` 2D ndarrays. If `metric` was
-            set to ``'precomputed'``, each entry of `X` must be a square
-            array and should be compatible with a filtration, i.e. the value
+            or a list containing ``n_samples`` 2D ndarrays/sparse matrices.
+            If `metric` was set to ``'precomputed'``, each entry of `X` must be
+            square and should be compatible with a filtration, i.e. the value
             at index (i, j) should be no smaller than the values at diagonal
             indices (i, i) and (j, j).
 
@@ -221,7 +222,8 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         """
         check_is_fitted(self)
-        X = check_point_clouds(X, distance_matrices=self._is_precomputed)
+        X = check_point_clouds(X, accept_sparse=self._is_precomputed,
+                               distance_matrices=self._is_precomputed)
 
         Xt = Parallel(n_jobs=self.n_jobs)(
             delayed(self._ripser_diagram)(x) for x in X)
@@ -613,8 +615,8 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             Input data representing a collection of point clouds. Can be
             either a 3D ndarray whose zeroth dimension has size ``n_samples``,
             or a list containing ``n_samples`` 2D ndarrays. The rows of
-            elements in `X` are interpreted as vectors in Euclidean space and.
-            and, when `X` is a list, warnings are issued when the number of
+            elements in `X` are interpreted as vectors in Euclidean space and,
+            when `X` is a list, warnings are issued when the number of
             columns (dimension of the Euclidean space) differs among samples.
 
         y : None
@@ -657,8 +659,8 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             Input data representing a collection of point clouds. Can be
             either a 3D ndarray whose zeroth dimension has size ``n_samples``,
             or a list containing ``n_samples`` 2D ndarrays. The rows of
-            elements in `X` are interpreted as vectors in Euclidean space and.
-            and, when `X` is a list, warnings are issued when the number of
+            elements in `X` are interpreted as vectors in Euclidean space and,
+            when `X` is a list, warnings are issued when the number of
             columns (dimension of the Euclidean space) differs among samples.
 
         y : None
@@ -852,20 +854,20 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         Parameters
         ----------
-        X : ndarray of shape (n_samples, n_vertices, n_vertices) or list of \
-            n_samples ``scipy.sparse`` matrices of shape (n_vertices, \
-            n_vertices)
-            Input collection. Each entry along axis 0 is the adjacency matrix
-            of a weighted directed or undirected graph. In each of those
-            adjacency matrices, diagonal elements are vertex weights and
-            off-diagonal elements are edges weights. It is assumed that a
-            vertex weight cannot be larger than the weight of the edges it
+        X : ndarray or list
+            Input collection of adjacency matrices of weighted directed or
+            undirected graphs. Can be either a 3D ndarray whose zeroth
+            dimension has size ``n_samples``, or a list containing
+            ``n_samples`` 2D ndarrays/sparse matrices. In each adjacency
+            matrix, diagonal elements are vertex weights and off-diagonal
+            elements are edges weights. It is assumed that a vertex weight
+            cannot be larger than the weight of the edges it
             forms. The way zero values are handled depends on the format of the
             matrix. If the matrix is a dense ``numpy.ndarray``, zero values
             denote zero-weighted edges. If the matrix is a sparse
             ``scipy.sparse`` matrix, explicitly stored off-diagonal zeros and
             all diagonal zeros denote zero-weighted edges. Off-diagonal values
-            that have not been explicitely stored are treated by
+            that have not been explicitly stored are treated by
             ``scipy.sparse`` as zeros but will be understood as
             infinitely-valued edges, i.e., edges absent from the filtration.
 
@@ -878,7 +880,7 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         self : object
 
         """
-        check_point_clouds(X, distance_matrices=True)
+        check_point_clouds(X, allow_sparse=True, distance_matrices=True)
         validate_params(
             self.get_params(), self._hyperparameters, exclude=['n_jobs',
                                                                'filtration'])
@@ -907,20 +909,20 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         Parameters
         ----------
-        X : ndarray of shape (n_samples, n_vertices, n_vertices) or list of \
-            n_samples ``scipy.sparse`` matrices of shape (n_vertices, \
-            n_vertices)
-            Input collection. Each entry along axis 0 is the adjacency matrix
-            of a weighted directed or undirected graph. In each of those
-            adjacency matrices, diagonal elements are vertex weights and
-            off-diagonal elements are edges weights. It is assumed that a
-            vertex weight cannot be larger than the weight of the edges it
+        X : ndarray or list
+            Input collection of adjacency matrices of weighted directed or
+            undirected graphs. Can be either a 3D ndarray whose zeroth
+            dimension has size ``n_samples``, or a list containing
+            ``n_samples`` 2D ndarrays/sparse matrices. In each adjacency
+            matrix, diagonal elements are vertex weights and off-diagonal
+            elements are edges weights. It is assumed that a vertex weight
+            cannot be larger than the weight of the edges it
             forms. The way zero values are handled depends on the format of the
             matrix. If the matrix is a dense ``numpy.ndarray``, zero values
             denote zero-weighted edges. If the matrix is a sparse
             ``scipy.sparse`` matrix, explicitly stored off-diagonal zeros and
             all diagonal zeros denote zero-weighted edges. Off-diagonal values
-            that have not been explicitely stored are treated by
+            that have not been explicitly stored are treated by
             ``scipy.sparse`` as zeros but will be understood as
             infinitely-valued edges, i.e., edges absent from the filtration.
 
@@ -939,7 +941,7 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         """
         check_is_fitted(self)
-        X = check_point_clouds(X, distance_matrices=True)
+        X = check_point_clouds(X, allow_sparse=True, distance_matrices=True)
 
         Xt = Parallel(n_jobs=self.n_jobs)(
             delayed(self._flagser_diagram)(x) for x in X)

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -153,10 +153,10 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             adjacency matrices of weighted undirected graphs otherwise. Can be
             either a 3D ndarray whose zeroth dimension has size ``n_samples``,
             or a list containing ``n_samples`` 2D ndarrays/sparse matrices.
-            If `metric` was set to ``'precomputed'``, each entry of `X` must be
-            square and should be compatible with a filtration, i.e. the value
-            at index (i, j) should be no smaller than the values at diagonal
-            indices (i, i) and (j, j).
+            If `metric` was set to ``'precomputed'``, each entry of `X` should
+            be compatible with a filtration, i.e. the value at index (i, j)
+            should be no smaller than the values at diagonal indices (i, i)
+            and (j, j).
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -202,10 +202,10 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             adjacency matrices of weighted undirected graphs otherwise. Can be
             either a 3D ndarray whose zeroth dimension has size ``n_samples``,
             or a list containing ``n_samples`` 2D ndarrays/sparse matrices.
-            If `metric` was set to ``'precomputed'``, each entry of `X` must be
-            square and should be compatible with a filtration, i.e. the value
-            at index (i, j) should be no smaller than the values at diagonal
-            indices (i, i) and (j, j).
+            If `metric` was set to ``'precomputed'``, each entry of `X` should
+            be compatible with a filtration, i.e. the value at index (i, j)
+            should be no smaller than the values at diagonal indices (i, i)
+            and (j, j).
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -397,14 +397,14 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         Parameters
         ----------
         X : ndarray or list
-            Input data representing a collection of point clouds or of distance
-            matrices. Can be either a 3D ndarray whose zeroth dimension has
+            Input data representing a collection of point clouds if `metric`
+            was not set to ``'precomputed'``, and of distance matrices
+            otherwise. Can be either a 3D ndarray whose zeroth dimension has
             size ``n_samples``, or a list containing ``n_samples`` 2D ndarrays.
-            If ``metric == 'precomputed'``, elements of `X` must be square
-            arrays representing distance matrices; otherwise, their rows are
-            interpreted as vectors in Euclidean space and, when `X` is a list,
-            warnings are issued when the number of columns (dimension of the
-            Euclidean space) differs among samples.
+            If `metric` was set to ``'precomputed'``, entries of `X` must be
+            square arrays and should be compatible with a filtration, i.e. the
+            value at index (i, j) should be no smaller than the values at
+            diagonal indices (i, i) and (j, j).
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -444,14 +444,14 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         Parameters
         ----------
         X : ndarray or list
-            Input data representing a collection of point clouds or of distance
-            matrices. Can be either a 3D ndarray whose zeroth dimension has
+            Input data representing a collection of point clouds if `metric`
+            was not set to ``'precomputed'``, and of distance matrices
+            otherwise. Can be either a 3D ndarray whose zeroth dimension has
             size ``n_samples``, or a list containing ``n_samples`` 2D ndarrays.
-            If ``metric == 'precomputed'``, elements of `X` must be square
-            arrays representing distance matrices; otherwise, their rows are
-            interpreted as vectors in Euclidean space and, when `X` is a list,
-            warnings are issued when the number of columns (dimension of the
-            Euclidean space) differs among samples.
+            If `metric` was set to ``'precomputed'``, entries of `X` must be
+            square arrays and should be compatible with a filtration, i.e. the
+            value at index (i, j) should be no smaller than the values at
+            diagonal indices (i, i) and (j, j).
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -612,12 +612,9 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         Parameters
         ----------
         X : ndarray or list
-            Input data representing a collection of point clouds. Can be
-            either a 3D ndarray whose zeroth dimension has size ``n_samples``,
-            or a list containing ``n_samples`` 2D ndarrays. The rows of
-            elements in `X` are interpreted as vectors in Euclidean space and,
-            when `X` is a list, warnings are issued when the number of
-            columns (dimension of the Euclidean space) differs among samples.
+            Input data representing a collection of point clouds. Can be either
+            a 3D ndarray whose zeroth dimension has size ``n_samples``, or a
+            list containing ``n_samples`` 2D ndarrays.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -656,12 +653,9 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         Parameters
         ----------
         X : ndarray of shape (n_samples, n_points, n_dimensions)
-            Input data representing a collection of point clouds. Can be
-            either a 3D ndarray whose zeroth dimension has size ``n_samples``,
-            or a list containing ``n_samples`` 2D ndarrays. The rows of
-            elements in `X` are interpreted as vectors in Euclidean space and,
-            when `X` is a list, warnings are issued when the number of
-            columns (dimension of the Euclidean space) differs among samples.
+            Input data representing a collection of point clouds. Can be either
+            a 3D ndarray whose zeroth dimension has size ``n_samples``, or a
+            list containing ``n_samples`` 2D ndarrays.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -170,7 +170,7 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         validate_params(
             self.get_params(), self._hyperparameters, exclude=['n_jobs'])
         self._is_precomputed = self.metric == 'precomputed'
-        check_point_clouds(X, accept_sparse=self._is_precomputed,
+        check_point_clouds(X, accept_sparse=True,
                            distance_matrices=self._is_precomputed)
 
         if self.infinity_values is None:
@@ -222,7 +222,7 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         """
         check_is_fitted(self)
-        X = check_point_clouds(X, accept_sparse=self._is_precomputed,
+        X = check_point_clouds(X, accept_sparse=True,
                                distance_matrices=self._is_precomputed)
 
         Xt = Parallel(n_jobs=self.n_jobs)(
@@ -418,7 +418,8 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         validate_params(
             self.get_params(), self._hyperparameters, exclude=['n_jobs'])
         self._is_precomputed = self.metric == 'precomputed'
-        check_point_clouds(X, distance_matrices=self._is_precomputed)
+        check_point_clouds(X, accept_sparse=True,
+                           distance_matrices=self._is_precomputed)
 
         if self.infinity_values is None:
             self.infinity_values_ = self.max_edge_length
@@ -468,7 +469,8 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         """
         check_is_fitted(self)
-        X = check_point_clouds(X, distance_matrices=self._is_precomputed)
+        X = check_point_clouds(X, accept_sparse=True,
+                               distance_matrices=self._is_precomputed)
 
         Xt = Parallel(n_jobs=self.n_jobs)(
             delayed(self._gudhi_diagram)(x) for x in X)

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -799,8 +799,8 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
     References
     ----------
     [1] D. Luetgehetmann, D. Govc, J. P. Smith, and R. Levi, "Computing \
-        persistent homology of directed flag complexes", Algorithms,
-        13(1), 2020.
+        persistent homology of directed flag complexes", Algorithms, 13(1), \
+        2020.
 
     """
 

--- a/gtda/homology/tests/test_simplicial.py
+++ b/gtda/homology/tests/test_simplicial.py
@@ -5,6 +5,7 @@ import numpy as np
 import plotly.io as pio
 import pytest
 from numpy.testing import assert_almost_equal
+from scipy.sparse import csr_matrix
 from scipy.spatial.distance import pdist, squareform
 from sklearn.exceptions import NotFittedError
 
@@ -13,11 +14,22 @@ from gtda.homology import VietorisRipsPersistence, SparseRipsPersistence, \
 
 pio.renderers.default = 'plotly_mimetype'
 
-X = np.array([[[2., 2.47942554], [2.47942554, 2.84147098],
-               [2.98935825, 2.79848711], [2.79848711, 2.41211849],
-               [2.41211849, 1.92484888]]])
+X_pc = np.array([
+    [[2., 2.47942554],
+     [2.47942554, 2.84147098],
+     [2.98935825, 2.79848711],
+     [2.79848711, 2.41211849],
+     [2.41211849, 1.92484888]]
+])
+X_pc_list = list(X_pc)
 
-X_dist = squareform(pdist(X[0])).reshape(*X.shape[:2], X.shape[1])
+X_dist = np.array([
+    squareform(pdist(x)) for x in X_pc
+])
+X_dist_list = list(X_dist)
+
+X_pc_sparse = [csr_matrix(x) for x in X_pc]
+X_dist_sparse = [csr_matrix(x) for x in X_dist]
 
 
 def test_vrp_params():
@@ -25,25 +37,36 @@ def test_vrp_params():
     vrp = VietorisRipsPersistence(metric=metric)
 
     with pytest.raises(ValueError):
-        vrp.fit_transform(X)
+        vrp.fit_transform(X_pc)
 
 
 def test_vrp_not_fitted():
     vrp = VietorisRipsPersistence()
 
     with pytest.raises(NotFittedError):
-        vrp.transform(X)
+        vrp.transform(X_pc)
 
 
-X_vrp_res = np.array([[[0., 0.43094373, 0], [0., 0.5117411, 0],
-                       [0., 0.60077095, 0], [0., 0.62186205, 0],
-                       [0.69093919, 0.80131882, 1]]])
+X_vrp_res = np.array([
+    [[0., 0.43094373, 0.],
+     [0., 0.5117411, 0.],
+     [0., 0.60077095, 0.],
+     [0., 0.62186205, 0.],
+     [0.69093919, 0.80131882, 1.]]
+])
 
 
+@pytest.mark.parametrize('X, metric', [(X_pc, 'euclidean'),
+                                       (X_pc_list, 'euclidean'),
+                                       (X_pc_sparse, 'euclidean'),
+                                       (X_dist, 'precomputed'),
+                                       (X_dist_list, 'precomputed'),
+                                       (X_dist_sparse, 'precomputed')])
 @pytest.mark.parametrize('max_edge_length', [np.inf, 0.8])
 @pytest.mark.parametrize('infinity_values', [10, 30])
-def test_vrp_transform(max_edge_length, infinity_values):
+def test_vrp_transform(X, metric, max_edge_length, infinity_values):
     vrp = VietorisRipsPersistence(max_edge_length=max_edge_length,
+                                  metric=metric,
                                   infinity_values=infinity_values)
     # This is not generally true, it is only a way to obtain the res array
     # in this specific case
@@ -52,23 +75,35 @@ def test_vrp_transform(max_edge_length, infinity_values):
     assert_almost_equal(vrp.fit_transform(X), X_res)
 
 
-def test_vrp_list_of_arrays():
+def test_vrp_list_of_arrays_different_size():
     X_2 = np.array([[0., 1.], [1., 2.]])
-    X_list = [X[0].copy(), X_2]
     vrp = VietorisRipsPersistence()
-    vrp.fit(X_list)
+    assert_almost_equal(vrp.fit_transform([X_pc[0], X_2])[0], X_vrp_res[0])
 
 
-def test_vrp_low_infinty_values():
+@pytest.mark.parametrize('X, metric', [(X_pc, 'euclidean'),
+                                       (X_pc_list, 'euclidean'),
+                                       (X_pc_sparse, 'euclidean'),
+                                       (X_dist, 'precomputed'),
+                                       (X_dist_list, 'precomputed'),
+                                       (X_dist_sparse, 'precomputed')])
+def test_vrp_low_infinity_values(X, metric):
     vrp = VietorisRipsPersistence(max_edge_length=0.001,
+                                  metric=metric,
                                   infinity_values=-1)
     assert_almost_equal(vrp.fit_transform(X)[:, :, :2],
                         np.zeros((1, 2, 2)))
 
 
+@pytest.mark.parametrize('X, metric', [(X_pc, 'euclidean'),
+                                       (X_pc_list, 'euclidean'),
+                                       (X_pc_sparse, 'euclidean'),
+                                       (X_dist, 'precomputed'),
+                                       (X_dist_list, 'precomputed'),
+                                       (X_dist_sparse, 'precomputed')])
 @pytest.mark.parametrize('hom_dims', [None, (0,), (1,), (0, 1)])
-def test_vrp_fit_transform_plot(hom_dims):
-    VietorisRipsPersistence().fit_transform_plot(
+def test_vrp_fit_transform_plot(X, metric, hom_dims):
+    VietorisRipsPersistence(metric=metric).fit_transform_plot(
         X, sample=0, homology_dimensions=hom_dims)
 
 
@@ -77,34 +112,47 @@ def test_srp_params():
     vrp = SparseRipsPersistence(metric=metric)
 
     with pytest.raises(ValueError):
-        vrp.fit_transform(X)
+        vrp.fit_transform(X_pc)
 
 
 def test_srp_not_fitted():
     srp = SparseRipsPersistence()
 
     with pytest.raises(NotFittedError):
-        srp.transform(X)
+        srp.transform(X_pc)
 
 
-X_srp_res = np.array([[[0., 0.43094373, 0], [0., 0.5117411, 0],
-                       [0., 0.60077095, 0], [0., 0.62186205, 0],
-                       [0.69093919, 0.80131882, 1]]])
+X_srp_res = np.array([
+    [[0., 0.43094373, 0.],
+     [0., 0.5117411, 0.],
+     [0., 0.60077095, 0.],
+     [0., 0.62186205, 0.],
+     [0.69093919, 0.80131882, 1.]]
+])
 
 
-@pytest.mark.parametrize("epsilon, point_clouds, diagrams",
-                         [(0.0, X, X_vrp_res),
-                          (1.0, X, X_srp_res)])
-def test_srp_transform(epsilon, point_clouds, diagrams):
-    srp = SparseRipsPersistence(epsilon=epsilon)
+@pytest.mark.parametrize('X, metric', [(X_pc, 'euclidean'),
+                                       (X_pc_list, 'euclidean'),
+                                       (X_pc_sparse, 'euclidean'),
+                                       (X_dist, 'precomputed'),
+                                       (X_dist_list, 'precomputed')])
+@pytest.mark.parametrize("epsilon, diagrams",
+                         [(0.0, X_vrp_res), (1.0, X_srp_res)])
+def test_srp_transform(X, metric, epsilon, diagrams):
+    srp = SparseRipsPersistence(metric=metric, epsilon=epsilon)
 
-    assert_almost_equal(np.sort(srp.fit_transform(point_clouds), axis=1),
+    assert_almost_equal(np.sort(srp.fit_transform(X), axis=1),
                         np.sort(diagrams, axis=1))
 
 
+@pytest.mark.parametrize('X, metric', [(X_pc, 'euclidean'),
+                                       (X_pc_list, 'euclidean'),
+                                       (X_pc_sparse, 'euclidean'),
+                                       (X_dist, 'precomputed'),
+                                       (X_dist_list, 'precomputed')])
 @pytest.mark.parametrize('hom_dims', [None, (0,), (1,), (0, 1)])
-def test_srp_fit_transform_plot(hom_dims):
-    SparseRipsPersistence().fit_transform_plot(
+def test_srp_fit_transform_plot(X, metric, hom_dims):
+    SparseRipsPersistence(metric=metric).fit_transform_plot(
         X, sample=0, homology_dimensions=hom_dims)
 
 
@@ -113,32 +161,40 @@ def test_cp_params():
     cp = EuclideanCechPersistence(coeff=coeff)
 
     with pytest.raises(TypeError):
-        cp.fit_transform(X)
+        cp.fit_transform(X_pc)
 
 
 def test_cp_not_fitted():
     cp = EuclideanCechPersistence()
 
     with pytest.raises(NotFittedError):
-        cp.transform(X)
+        cp.transform(X_pc)
 
 
-X_cp_res = np.array(
-    [[[0., 0.31093103, 0.], [0., 0.30038548, 0.],
-      [0., 0.25587055, 0.], [0., 0.21547186, 0.],
-      [0.34546959, 0.41473758, 1.], [0.51976681, 0.55287585, 1.],
-      [0.26746207, 0.28740871, 1.], [0.52355742, 0.52358794, 1.],
-      [0.40065941, 0.40067135, 1.], [0.45954496, 0.45954497, 1.]]])
+X_cp_res = np.array([
+    [[0., 0.31093103, 0.],
+     [0., 0.30038548, 0.],
+     [0., 0.25587055, 0.],
+     [0., 0.21547186, 0.],
+     [0.34546959, 0.41473758, 1.],
+     [0.51976681, 0.55287585, 1.],
+     [0.26746207, 0.28740871, 1.],
+     [0.52355742, 0.52358794, 1.],
+     [0.40065941, 0.40067135, 1.],
+     [0.45954496, 0.45954497, 1.]]
+])
 
 
-def test_cp_transform():
+@pytest.mark.parametrize('X', [X_pc, X_pc_list])
+def test_cp_transform(X):
     cp = EuclideanCechPersistence()
 
     assert_almost_equal(cp.fit_transform(X), X_cp_res)
 
 
+@pytest.mark.parametrize('X', [X_pc, X_pc_list])
 @pytest.mark.parametrize('hom_dims', [None, (0,), (1,), (0, 1)])
-def test_cp_fit_transform_plot(hom_dims):
+def test_cp_fit_transform_plot(X, hom_dims):
     EuclideanCechPersistence().fit_transform_plot(
         X, sample=0, homology_dimensions=hom_dims)
 
@@ -162,14 +218,24 @@ X_dir_graph = X_dist.copy()
 X_dir_graph[0, 0, :] = X_dir_graph[0, 0, :] / 2.
 X_dir_graph[0][np.tril_indices(5, k=-1)] = np.inf
 
-X_fp_dir_res = np.array([[[0., 0.30038548, 0.], [0., 0.34546959, 0.],
-                          [0., 0.40065941, 0.], [0., 0.43094373, 0.],
-                          [0.5117411,  0.51976681, 1.]]])
+X_dir_graph_list = [x for x in X_dir_graph]
+
+X_dir_graph_sparse = [csr_matrix(x) for x in X_dir_graph]
+
+X_fp_dir_res = np.array([
+    [[0., 0.30038548, 0.],
+     [0., 0.34546959, 0.],
+     [0., 0.40065941, 0.],
+     [0., 0.43094373, 0.],
+     [0.5117411,  0.51976681, 1.]]
+])
 
 
+@pytest.mark.parametrize('X',
+                         [X_dir_graph, X_dir_graph_list, X_dir_graph_sparse])
 @pytest.mark.parametrize('max_edge_weight', [np.inf, 0.8])
 @pytest.mark.parametrize('infinity_values', [10, 30])
-def test_fp_transform_directed(max_edge_weight, infinity_values):
+def test_fp_transform_directed(X, max_edge_weight, infinity_values):
     fp = FlagserPersistence(directed=True, max_edge_weight=max_edge_weight,
                             infinity_values=infinity_values)
     # In the undirected case with "max" filtration, the results are always the
@@ -178,12 +244,13 @@ def test_fp_transform_directed(max_edge_weight, infinity_values):
     # This is not generally true, it is only a way to obtain the res array
     # in this specific case
     X_res[:, :, :2][X_res[:, :, :2] >= max_edge_weight] = infinity_values
-    assert_almost_equal(fp.fit_transform(X_dir_graph), X_res)
+    assert_almost_equal(fp.fit_transform(X), X_res)
 
 
+@pytest.mark.parametrize('X', [X_dist, X_dist_list, X_dist_sparse])
 @pytest.mark.parametrize('max_edge_weight', [np.inf, 0.8, 0.6])
 @pytest.mark.parametrize('infinity_values', [10, 30])
-def test_fp_transform_undirected(max_edge_weight, infinity_values):
+def test_fp_transform_undirected(X, max_edge_weight, infinity_values):
     fp = FlagserPersistence(directed=False, max_edge_weight=max_edge_weight,
                             infinity_values=infinity_values)
     # In the undirected case with "max" filtration, the results are always the
@@ -197,10 +264,11 @@ def test_fp_transform_undirected(max_edge_weight, infinity_values):
     # This is not generally true, it is only a way to obtain the res array
     # in this specific case
     X_res[:, :, :2][X_res[:, :, :2] >= max_edge_weight] = infinity_values
-    assert_almost_equal(fp.fit_transform(X_dist), X_res)
+    assert_almost_equal(fp.fit_transform(X), X_res)
 
 
+@pytest.mark.parametrize('X', [X_dist, X_dist_list, X_dist_sparse])
 @pytest.mark.parametrize('hom_dims', [None, (0,), (1,), (0, 1)])
-def test_fp_fit_transform_plot(hom_dims):
+def test_fp_fit_transform_plot(X, hom_dims):
     FlagserPersistence(directed=False).fit_transform_plot(
         X_dist, sample=0, homology_dimensions=hom_dims)

--- a/gtda/utils/tests/test_validation.py
+++ b/gtda/utils/tests/test_validation.py
@@ -173,11 +173,6 @@ def test_check_point_clouds_warn_finite():
     with pytest.warns(DataDimensionalityWarning):
         check_point_clouds(ex.X_list)
 
-    # Check that we throw warnings on list input when arrays have different
-    # number of columns
-    with pytest.warns(DataDimensionalityWarning):
-        check_point_clouds(ex.X_list_rectang_diff_cols)
-
 
 def test_check_point_clouds_regular_inf():
     """Cases in which part of the input is infinite and no warnings or errors
@@ -238,7 +233,7 @@ def test_check_point_clouds_regular_nan():
 
 @pytest.mark.parametrize("force_all_finite", [True, False])
 def test_check_point_clouds_value_err_nan(force_all_finite):
-    """Cases in which part of the input is nan and we throw a
+    """Cases in which part of the input is NaN and we throw a
     ValueError."""
 
     ex = CreateInputs(

--- a/gtda/utils/validation.py
+++ b/gtda/utils/validation.py
@@ -299,8 +299,12 @@ def check_point_clouds(X, distance_matrices=False, **kwargs):
                 warn(
                     "All arrays/matrices are square. This is consistent with "
                     "a collection of distance/adjacency matrices, but the "
-                    "entries are being treated as collections of vectors in "
+                    "entries will be treated as collections of vectors in "
                     "Euclidean space.", DataDimensionalityWarning,
                     stacklevel=2)
+
+        ref_dim = X[0].shape  # Shape of first sample
+        if reduce(and_, (x.shape == ref_dim for x in X[1:]), True):
+            Xnew = np.asarray(Xnew)
 
     return Xnew

--- a/gtda/utils/validation.py
+++ b/gtda/utils/validation.py
@@ -6,6 +6,7 @@ from operator import and_
 from warnings import warn
 
 import numpy as np
+from scipy.sparse import issparse
 
 from sklearn.utils.validation import check_array
 from sklearn.exceptions import DataDimensionalityWarning
@@ -194,9 +195,9 @@ def _check_array_mod(X, **kwargs):
     accepted but infinity is."""
     if not kwargs['force_all_finite']:
         Xnew = check_array(X, **kwargs)
-        if np.isnan(Xnew).any():
+        if np.isnan(Xnew if not issparse(Xnew) else Xnew.data).any():
             raise ValueError(
-                "Input contains NaN. Only finite values and infinity are "
+                "Input contains NaNs. Only finite values and infinity are "
                 "allowed when parameter `force_all_finite` is False.")
         return Xnew
     return check_array(X, **kwargs)
@@ -257,8 +258,9 @@ def check_point_clouds(X, distance_matrices=False, **kwargs):
             else:
                 extra_2D = ""
             raise ValueError(
-                f"Input must be a single 3D array or a list of 2D arrays. "
-                f"Array of dimension {X.ndim} passed." + extra_2D)
+                f"Input must be a single 3D array or a list of 2D arrays or "
+                f"sparse matrices. Structure of dimension {X.ndim} passed."
+                + extra_2D)
         if (X.shape[1] != X.shape[2]) and distance_matrices:
             raise ValueError(
                 f"Input array X must have X.shape[1] == X.shape[2]: "
@@ -278,7 +280,7 @@ def check_point_clouds(X, distance_matrices=False, **kwargs):
         for i, x in enumerate(X):
             try:
                 xnew = _check_array_mod(x, **kwargs_, ensure_2d=True)
-                if distance_matrices:
+                if distance_matrices and not issparse(xnew):
                     if not x.shape[0] == x.shape[1]:
                         raise ValueError(
                             f"All arrays must be square: {x.shape[0]} rows "
@@ -295,10 +297,11 @@ def check_point_clouds(X, distance_matrices=False, **kwargs):
         if not distance_matrices:
             if reduce(and_, (x.shape[0] == x.shape[1] for x in X), True):
                 warn(
-                    "All arrays are square. This is consistent with a "
-                    "collection of distance/adjacency matrices, but the input "
-                    "is being treated as a collection of vectors in Euclidean "
-                    "space.", DataDimensionalityWarning, stacklevel=2)
+                    "All arrays/matrices are square. This is consistent with "
+                    "a collection of distance/adjacency matrices, but the "
+                    "entries are being treated as collections of vectors in "
+                    "Euclidean space.", DataDimensionalityWarning,
+                    stacklevel=2)
 
             ref_dim = X[0].shape[1]  # Embedding dimension of first sample
             if not reduce(and_, (x.shape[1] == ref_dim for x in X[1:]), True):

--- a/gtda/utils/validation.py
+++ b/gtda/utils/validation.py
@@ -303,10 +303,4 @@ def check_point_clouds(X, distance_matrices=False, **kwargs):
                     "Euclidean space.", DataDimensionalityWarning,
                     stacklevel=2)
 
-            ref_dim = X[0].shape[1]  # Embedding dimension of first sample
-            if not reduce(and_, (x.shape[1] == ref_dim for x in X[1:]), True):
-                warn(
-                    "Not all point clouds have the same embedding dimension.",
-                    DataDimensionalityWarning, stacklevel=2)
-
     return Xnew

--- a/gtda/utils/validation.py
+++ b/gtda/utils/validation.py
@@ -260,7 +260,8 @@ def check_point_clouds(X, distance_matrices=False, **kwargs):
             raise ValueError(
                 f"Input must be a single 3D array or a list of 2D arrays or "
                 f"sparse matrices. Structure of dimension {X.ndim} passed."
-                + extra_2D)
+                + extra_2D
+            )
         if (X.shape[1] != X.shape[2]) and distance_matrices:
             raise ValueError(
                 f"Input array X must have X.shape[1] == X.shape[2]: "
@@ -271,7 +272,8 @@ def check_point_clouds(X, distance_matrices=False, **kwargs):
                 "consistent with a collection of distance/adjacency "
                 "matrices, but the input is being treated as a collection "
                 "of vectors in Euclidean space.",
-                DataDimensionalityWarning, stacklevel=2)
+                DataDimensionalityWarning, stacklevel=2
+            )
         Xnew = _check_array_mod(X, **kwargs_, allow_nd=True)
     else:
         has_check_failed = False
@@ -284,7 +286,8 @@ def check_point_clouds(X, distance_matrices=False, **kwargs):
                     if not x.shape[0] == x.shape[1]:
                         raise ValueError(
                             f"All arrays must be square: {x.shape[0]} rows "
-                            f"and {x.shape[1]} columns found in this array.")
+                            f"and {x.shape[1]} columns found in this array."
+                        )
                 Xnew.append(xnew)
             except ValueError as e:
                 has_check_failed = True
@@ -292,7 +295,8 @@ def check_point_clouds(X, distance_matrices=False, **kwargs):
         if has_check_failed:
             raise ValueError(
                 "The following errors were raised by the inputs:\n\n" +
-                "\n\n".join(messages))
+                "\n\n".join(messages)
+            )
 
         if not distance_matrices:
             if reduce(and_, (x.shape[0] == x.shape[1] for x in X), True):
@@ -301,7 +305,8 @@ def check_point_clouds(X, distance_matrices=False, **kwargs):
                     "a collection of distance/adjacency matrices, but the "
                     "entries will be treated as collections of vectors in "
                     "Euclidean space.", DataDimensionalityWarning,
-                    stacklevel=2)
+                    stacklevel=2
+                )
 
         ref_dim = X[0].shape  # Shape of first sample
         if reduce(and_, (x.shape == ref_dim for x in X[1:]), True):


### PR DESCRIPTION
**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
Following the addition of `FlagserPersistence` in #339 and the added support for list input in the simplicial homology transformers, it is a shame to keep excluding list of sparse matrix input, especially since the performance gains can be considerable for situations in which several edges are infinitely-valued (as @lewtun found out recently when using `ripser`). This PR modifies the `check_point_clouds` validation function to accept list of sparse matrix input, while still performing important checks. Furthermore, some docstrings have been edited for clarity/consistency.

**Any other comments?**
~~I tried to extend the changes to `SparseRipsPersistence` but got a mysterious error thrown when trying it on a single 2x2 sparse matrix with ones in the off-diagonal entries. @MonkeyBreaker @gtauzin, do you know why this might be happening?~~ UPDATE: It is now clear that `SparseRipsPersistence` is not meant to receive sparse input yet.

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.