### PR TITLE
Fix mmap settings used by joblib.Parallel

### DIFF
--- a/CODE_AUTHORS.rst
+++ b/CODE_AUTHORS.rst
@@ -13,3 +13,4 @@ Where component authors are known, add them here.
 | Anibal Medina-Mardones, anibal.medinamardones@epfl.ch
 | Wojciech Reise, reisewojciech@gmail.com
 | Roman Yurchak, roman.yurchak@symerio.com
+| Nick Sale, nicholas.j.sale@gmail.com

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -75,7 +75,7 @@ def landscapes(diagrams, sampling, n_layers):
 
 
 def _heat(image, sampled_diag, sigma):
-    _sample_image(image, sampled_diag)  # modifies `heat` inplace
+    _sample_image(image, sampled_diag)
     image[:] = gaussian_filter(image, sigma, mode="reflect")
 
 

--- a/gtda/diagrams/_utils.py
+++ b/gtda/diagrams/_utils.py
@@ -29,6 +29,7 @@ def _sort(Xs):
 
 
 def _sample_image(image, sampled_diag):
+    # NOTE: Modifies `image` in-place
     unique, counts = np.unique(sampled_diag, axis=0, return_counts=True)
     unique = tuple(tuple(row) for row in unique.astype(np.int).T)
     image[unique] = counts

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -113,7 +113,7 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
 
         with np.errstate(divide='ignore', invalid='ignore'):
             Xt = Parallel(n_jobs=self.n_jobs)(
-                delayed(self._persistence_entropy)(_subdiagrams(X, [dim])[s])
+                delayed(self._persistence_entropy)(_subdiagrams(X[s], [dim]))
                 for dim in self.homology_dimensions_
                 for s in gen_even_slices(
                     X.shape[0], effective_n_jobs(self.n_jobs))

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -115,8 +115,7 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
             Xt = Parallel(n_jobs=self.n_jobs)(
                 delayed(self._persistence_entropy)(_subdiagrams(X[s], [dim]))
                 for dim in self.homology_dimensions_
-                for s in gen_even_slices(
-                    X.shape[0], effective_n_jobs(self.n_jobs))
+                for s in gen_even_slices(len(X), effective_n_jobs(self.n_jobs))
             )
         Xt = np.concatenate(Xt).reshape(self._n_dimensions, X.shape[0]).T
         return Xt

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -142,13 +142,12 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
         X = check_diagrams(X)
 
         Xt = Parallel(n_jobs=self.n_jobs)(delayed(betti_curves)(
-                _subdiagrams(X, [dim], remove_dim=True)[s],
+                _subdiagrams(X[s], [dim], remove_dim=True),
                 self._samplings[dim])
             for dim in self.homology_dimensions_
-            for s in gen_even_slices(X.shape[0],
-                                     effective_n_jobs(self.n_jobs)))
+            for s in gen_even_slices(len(X), effective_n_jobs(self.n_jobs)))
         Xt = np.concatenate(Xt).\
-            reshape(self._n_dimensions, X.shape[0], -1).\
+            reshape(self._n_dimensions, len(X), -1).\
             transpose((1, 0, 2))
         return Xt
 
@@ -354,14 +353,13 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
         X = check_diagrams(X)
 
         Xt = Parallel(n_jobs=self.n_jobs)(delayed(landscapes)(
-                _subdiagrams(X, [dim], remove_dim=True)[s],
+                _subdiagrams(X[s], [dim], remove_dim=True),
                 self._samplings[dim],
                 self.n_layers)
             for dim in self.homology_dimensions_
-            for s in gen_even_slices(X.shape[0],
-                                     effective_n_jobs(self.n_jobs)))
-        Xt = np.concatenate(Xt).reshape(self._n_dimensions, X.shape[0],
-                                        self.n_layers, self.n_bins).\
+            for s in gen_even_slices(len(X), effective_n_jobs(self.n_jobs)))
+        Xt = np.concatenate(Xt).\
+            reshape(self._n_dimensions, len(X), self.n_layers, self.n_bins).\
             transpose((1, 0, 2, 3))
         return Xt
 
@@ -591,10 +589,9 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
             heats)(_subdiagrams(X[s], [dim], remove_dim=True),
                    self._samplings[dim], self._step_size[dim], self.sigma)
             for dim in self.homology_dimensions_
-            for s in gen_even_slices(X.shape[0],
-                                     effective_n_jobs(self.n_jobs)))
+            for s in gen_even_slices(len(X), effective_n_jobs(self.n_jobs)))
         Xt = np.concatenate(Xt).\
-            reshape(self._n_dimensions, X.shape[0], self.n_bins, self.n_bins).\
+            reshape(self._n_dimensions, len(X), self.n_bins, self.n_bins).\
             transpose((1, 0, 2, 3))
         return Xt
 
@@ -801,11 +798,10 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
                 self.sigma
             )
             for dim in self.homology_dimensions_
-            for s in gen_even_slices(X.shape[0],
-                                     effective_n_jobs(self.n_jobs))
+            for s in gen_even_slices(len(X), effective_n_jobs(self.n_jobs))
         )
         Xt = np.concatenate(Xt).\
-            reshape(self._n_dimensions, X.shape[0], self.n_bins, self.n_bins).\
+            reshape(self._n_dimensions, len(X), self.n_bins, self.n_bins).\
             transpose((1, 0, 2, 3))
         return Xt
 
@@ -979,11 +975,10 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
               (delayed(silhouettes)(_subdiagrams(X[s], [dim], remove_dim=True),
                                     self._samplings[dim], power=self.power)
               for dim in self.homology_dimensions_
-              for s in gen_even_slices(X.shape[0],
-                                       effective_n_jobs(self.n_jobs))))
+              for s in gen_even_slices(len(X), effective_n_jobs(self.n_jobs))))
 
-        Xt = np.concatenate(Xt). \
-            reshape(self._n_dimensions, X.shape[0], -1). \
+        Xt = np.concatenate(Xt).\
+            reshape(self._n_dimensions, len(X), -1).\
             transpose((1, 0, 2))
         return Xt
 

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -588,13 +588,13 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
         X = check_diagrams(X, copy=True)
 
         Xt = Parallel(n_jobs=self.n_jobs, mmap_mode='c')(delayed(
-            heats)(_subdiagrams(X, [dim], remove_dim=True)[s],
+            heats)(_subdiagrams(X[s], [dim], remove_dim=True),
                    self._samplings[dim], self._step_size[dim], self.sigma)
             for dim in self.homology_dimensions_
             for s in gen_even_slices(X.shape[0],
                                      effective_n_jobs(self.n_jobs)))
-        Xt = np.concatenate(Xt).reshape(self._n_dimensions, X.shape[0],
-                                        self.n_bins, self.n_bins).\
+        Xt = np.concatenate(Xt).\
+            reshape(self._n_dimensions, X.shape[0], self.n_bins, self.n_bins).\
             transpose((1, 0, 2, 3))
         return Xt
 
@@ -793,18 +793,19 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
         X = check_diagrams(X, copy=True)
 
         Xt = Parallel(n_jobs=self.n_jobs, mmap_mode='c')(
-            delayed(persistence_images)(_subdiagrams(X, [dim],
-                                                     remove_dim=True)[s],
-                                        self._samplings[dim],
-                                        self._step_size[dim],
-                                        self.weights_[dim],
-                                        self.sigma)
+            delayed(persistence_images)(
+                _subdiagrams(X[s], [dim], remove_dim=True),
+                self._samplings[dim],
+                self._step_size[dim],
+                self.weights_[dim],
+                self.sigma
+            )
             for dim in self.homology_dimensions_
             for s in gen_even_slices(X.shape[0],
                                      effective_n_jobs(self.n_jobs))
         )
-        Xt = np.concatenate(Xt).reshape(self._n_dimensions, X.shape[0],
-                                        self.n_bins, self.n_bins).\
+        Xt = np.concatenate(Xt).\
+            reshape(self._n_dimensions, X.shape[0], self.n_bins, self.n_bins).\
             transpose((1, 0, 2, 3))
         return Xt
 
@@ -975,7 +976,7 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
         X = check_diagrams(X)
 
         Xt = (Parallel(n_jobs=self.n_jobs)
-              (delayed(silhouettes)(_subdiagrams(X, [dim], remove_dim=True)[s],
+              (delayed(silhouettes)(_subdiagrams(X[s], [dim], remove_dim=True),
                                     self._samplings[dim], power=self.power)
               for dim in self.homology_dimensions_
               for s in gen_even_slices(X.shape[0],

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -587,7 +587,7 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
         check_is_fitted(self)
         X = check_diagrams(X, copy=True)
 
-        Xt = Parallel(n_jobs=self.n_jobs)(delayed(
+        Xt = Parallel(n_jobs=self.n_jobs, mmap_mode='c')(delayed(
             heats)(_subdiagrams(X, [dim], remove_dim=True)[s],
                    self._samplings[dim], self._step_size[dim], self.sigma)
             for dim in self.homology_dimensions_
@@ -792,7 +792,7 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
         check_is_fitted(self)
         X = check_diagrams(X, copy=True)
 
-        Xt = Parallel(n_jobs=self.n_jobs)(
+        Xt = Parallel(n_jobs=self.n_jobs, mmap_mode='c')(
             delayed(persistence_images)(_subdiagrams(X, [dim],
                                                      remove_dim=True)[s],
                                         self._samplings[dim],

--- a/gtda/diagrams/tests/test_features_representations.py
+++ b/gtda/diagrams/tests/test_features_representations.py
@@ -116,7 +116,6 @@ def test_large_pi_null_multithreaded():
     joblib's use of memmaps"""
     X = np.linspace(0, 100, 300000)
     pi = PersistenceImage(sigma=1, n_bins=10, n_jobs=2)
-    X = np.append(X, 1 + X[-1])
     diagrams = np.expand_dims(np.stack([X, X,
                                         np.zeros((X.shape[0],),
                                                  dtype=int)]).transpose(),

--- a/gtda/diagrams/tests/test_features_representations.py
+++ b/gtda/diagrams/tests/test_features_representations.py
@@ -109,10 +109,11 @@ def test_pi_positive(pts):
         axis=1), axis=0)
     assert np.all(pi.fit_transform(diagrams) >= 0.)
 
+
 def test_large_pi_null_multithreaded():
-    """Test that, if one trivial diagram (all pts on the diagonal) is provided,
-    (along with a non-trivial one), then its pi is null when the input array is at
-    least 1MB and more than 1 process is used, triggering joblib's use of memmaps"""
+    """Test that pi is computed correctly when the input array
+    is at least 1MB and more than 1 process is used, triggering
+    joblib's use of memmaps"""
     X = np.linspace(0, 100, 300000)
     pi = PersistenceImage(sigma=1, n_bins=10, n_jobs=2)
     X = np.append(X, 1 + X[-1])
@@ -124,6 +125,7 @@ def test_large_pi_null_multithreaded():
     diagrams[1, :, 1] += 1
 
     assert_almost_equal(pi.fit_transform(diagrams)[0], 0)
+
 
 def test_silhouette_transform():
     sht = Silhouette(n_bins=31, power=1.)
@@ -249,6 +251,7 @@ def test_hk_with_diag_points(pts):
                                  for x_ in [x, x_with_diag_points]]
 
     assert_almost_equal(x_with_diag_points_t, x_t, decimal=13)
+
 
 def test_large_hk_shape_multithreaded():
     """Test that HeatKernel returns something of the right shape when the input

--- a/gtda/plotting/persistence_diagrams.py
+++ b/gtda/plotting/persistence_diagrams.py
@@ -76,8 +76,7 @@ def plot_diagram(diagram, homology_dimensions=None, **input_layout):
 
     for dim in homology_dimensions:
         name = f'H{int(dim)}' if dim != np.inf else 'Any homology dimension'
-        subdiagram = _subdiagrams(np.asarray([diagram]), [dim],
-                                  remove_dim=True)[0]
+        subdiagram = diagram[diagram[:, 2] == dim]
         diff = (subdiagram[:, 1] != subdiagram[:, 0])
         subdiagram = subdiagram[diff]
         fig.add_trace(gobj.Scatter(x=subdiagram[:, 0], y=subdiagram[:, 1],

--- a/gtda/plotting/persistence_diagrams.py
+++ b/gtda/plotting/persistence_diagrams.py
@@ -20,7 +20,6 @@ def plot_diagram(diagram, homology_dimensions=None, **input_layout):
         homology dimensions which appear in `diagram` will be plotted.
 
     """
-    from ..diagrams._utils import _subdiagrams  # To avoid circular imports
 
     # TODO: increase the marker size
     if homology_dimensions is None:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the guidelines for contributing: https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines
-->

**Reference issues/PRs**
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.

Pull requests which are not related to open issues may be rejected!
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

Fixes #427.

**Types of changes**
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
<!--
Describe your changes in detail.
-->

I determined that the bug described in Issue #427 was being caused due to the behavior of joblib.Parallel when passing in large amounts of data which needs to be copied to workers. By default, if the input is larger than 1MB (default value of max_nbytes), then it is memory mapped to disk in read-only 'r' mode (default value of mmap_mode) (see https://joblib.readthedocs.io/en/latest/generated/joblib.Parallel.html). The functions persistence_images and heats in gtda/diagrams/_metrics.py directly modify the passed in diagrams directly, causing the "ValueError: assignment destination is read-only" error when diagrams is a read-only memmap.

My fix is to explicitly pass in mmap_mode='c' to joblib.Parallel for these cases, making the memory-mapped arrays 'copy-on-write', allowing the workers to modify diagrams in memory without writing this change to disk.

I also implemented two tests which fail with the current version of giotto-tda but which pass after making the changes. See the relevant parts of the diff of the pytest output pre- and post-fix: https://gist.github.com/NickSale/9daf2569a7640852a248e0966cfb8fda

**Screenshots (if appropriate)**

**Any other comments?**

This could be fixed in a couple of other ways:
- The functions persistence_image and heats could be changed so that they do not modify their inputs. However this seemed more invasive.
- The automatic memory mapping functionality of joblib.Parallel could be disabled completely by setting max_nbytes=None. However I'm not sure of the performance implications this could cause when passing large amounts of data to many workers.


**Checklist**
<!--
Go over all the following points, and put an `x` in all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.

<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
