### PR TITLE
Fix Azure CI for nightly releases

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,10 @@
 # These jobs are triggered automatically and they test code, examples, and wheels.
 # Additional checks can be manually triggered
 variables:
+  nc: eq(variables['nightly_check'], 'true')
+  bsc: variables['Build.SourceBranch']
+  br: variables['Build.Reason']
+  nrf: eq(variables['nightly_release'], 'False')
   nightly_release: and(eq(variables['nightly_check'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['Build.Reason'], 'PullRequest'))
 
 trigger:
@@ -141,11 +145,9 @@ jobs:
     displayName: ccache
 
   - script: |
-      echo (eq(variables['nightly_check'], 'true'))
-      echo (variables['Build.SourceBranch'])
-      echo (variables['Build.Reason'])
-      echo (variables['nightly_release'])
-      echo eq(variables['nightly_release'], 'False')
+      echo $(nc)
+      echo $(br)
+      echo $(nightly_release)
       set -e
       brew update
       brew install boost ccache

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,7 +144,8 @@ jobs:
     displayName: ccache
 
   - script: |
-      echo ${{ variables.br }}
+      echo $[variables.br]
+      echo $(br)
       set -e
       brew update
       brew install boost ccache

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,9 +144,9 @@ jobs:
     displayName: ccache
 
   - script: |
-      echo $(nc)
-      echo $(br)
-      echo $(nightly_release)
+      echo $"nc"
+      echo $"br"
+      echo $"nightly_release"
       set -e
       brew update
       brew install boost ccache

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,6 @@ variables:
   nc: eq(variables['nightly_check'], 'true')
   bsc: variables['Build.SourceBranch']
   br: variables['Build.Reason']
-  nrf: eq(variables['nightly_release'], 'False')
   nightly_release: and(eq(variables['nightly_check'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['Build.Reason'], 'PullRequest'))
 
 trigger:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,9 +1,9 @@
 # These jobs are triggered automatically and they test code, examples, and wheels.
 # Additional checks can be manually triggered
 variables:
-  nc: $[eq(variables['nightly_check'], true)]
-  sb: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
-  br: $[ne(variables['Build.Reason'], 'PullRequest')]
+  nc: $[eq(variables['nightly_check'], 'true')]
+  sb: $[variables['Build.SourceBranch']]
+  br: $[variables['Build.Reason']]
   nightly_release: $[and(eq(variables['nightly_check'], true), eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['Build.Reason'], 'PullRequest'))]
 
 trigger:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,10 +1,7 @@
 # These jobs are triggered automatically and they test code, examples, and wheels.
 # Additional checks can be manually triggered
 variables:
-  nc: $[eq(variables['nightly_check'], 'True')]
-  sb: $[variables['Build.SourceBranch']]
-  br: $[variables['Build.Reason']]
-  nightly_release: $[and(eq(variables['nightly_check'], true), eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['Build.Reason'], 'PullRequest'))]
+  nightlyRelease: $[and(eq(variables['nightly_check'], true), eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['Build.Reason'], 'PullRequest'))]
 
 trigger:
 - master
@@ -52,7 +49,7 @@ jobs:
       set -e
       sed -i "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
       sed -i "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
-    condition: eq('True', variables['nightly_release'])
+    condition: eq(variables.nightlyRelease, true)
     displayName: 'Change name to giotto-tda-nightly'
 
   - task: Bash@3
@@ -105,7 +102,7 @@ jobs:
       set -e
       pip install twine
       twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*manylinux2010*.whl
-    condition: eq('True', variables['nightly_release'])
+    condition: eq(variables.nightlyRelease, true)
     displayName: 'Upload nightly wheels to PyPI'
 
 
@@ -134,7 +131,7 @@ jobs:
       rm setup.py.bak
       sed -i.bak "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
       rm gtda/_version.py.bak
-    condition: eq('True', variables['nightly_release'])
+    condition: eq(variables.nightlyRelease, true)
     displayName: 'Change name to giotto-tda-nightly'
 
   - task: Cache@2
@@ -144,10 +141,6 @@ jobs:
     displayName: ccache
 
   - script: |
-      echo $(nc)
-      echo $(sb)
-      echo $(br)
-      echo $(nightly_release)
       set -e
       brew update
       brew install boost ccache
@@ -225,7 +218,7 @@ jobs:
   - bash: |
       set -e
       twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*
-    condition: eq('True', variables['nightly_release'])
+    condition: eq(variables.nightlyRelease, true)
     displayName: 'Upload nightly wheels to PyPI'
 
 
@@ -253,7 +246,7 @@ jobs:
       set -e
       sed -i "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
       sed -i "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
-    condition: eq('True', variables['nightly_release'])
+    condition: eq(variables.nightlyRelease, true)
     displayName: 'Change name to giotto-tda-nightly'
 
   # Set BOOST_ROOT_PIPELINE to the version used in the pipeline
@@ -316,5 +309,5 @@ jobs:
       set -e
       pip install twine
       twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*
-    condition: eq('True', variables['nightly_release'])
+    condition: eq(variables.nightlyRelease, true)
     displayName: 'Upload nightly wheels to PyPI'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,7 +145,6 @@ jobs:
 
   - script: |
       echo ${{ variables.br }}
-      echo ${{ variables.nightly_release }}
       set -e
       brew update
       brew install boost ccache

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,6 +141,11 @@ jobs:
     displayName: ccache
 
   - script: |
+      echo $(eq(variables['nightly_check'], 'true'))
+      echo $(variables['Build.SourceBranch'])
+      echo $(variables['Build.Reason'])
+      echo $(variables['nightly_release'])
+      echo $eq(variables['nightly_release'])
       set -e
       brew update
       brew install boost ccache

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,9 +144,9 @@ jobs:
     displayName: ccache
 
   - script: |
-      echo $"nc"
-      echo $"br"
-      echo $"nightly_release"
+      echo ${{ variables.nc }}
+      echo ${{ variables.br }}
+      echo ${{ variables.nightly_release }}
       set -e
       brew update
       brew install boost ccache

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 # These jobs are triggered automatically and they test code, examples, and wheels.
 # Additional checks can be manually triggered
 variables:
-  nc: $[eq(variables['nightly_check'], 'true')]
+  nc: $[eq(variables['nightly_check'], 'True')]
   sb: $[variables['Build.SourceBranch']]
   br: $[variables['Build.Reason']]
   nightly_release: $[and(eq(variables['nightly_check'], true), eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['Build.Reason'], 'PullRequest'))]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,7 +144,6 @@ jobs:
     displayName: ccache
 
   - script: |
-      echo ${{ variables.nc }}
       echo ${{ variables.br }}
       echo ${{ variables.nightly_release }}
       set -e

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,7 +145,7 @@ jobs:
       echo $(variables['Build.SourceBranch'])
       echo $(variables['Build.Reason'])
       echo $(variables['nightly_release'])
-      echo $eq(variables['nightly_release'])
+      echo $eq(variables['nightly_release'], 'False')
       set -e
       brew update
       brew install boost ccache

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,9 +1,9 @@
 # These jobs are triggered automatically and they test code, examples, and wheels.
 # Additional checks can be manually triggered
 variables:
-  nc: eq(variables['nightly_check'], 'true')
-  bsc: variables['Build.SourceBranch']
-  br: variables['Build.Reason']
+  nc: $[eq(variables['nightly_check'], true)]
+  sb: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
+  br: $[ne(variables['Build.Reason'], 'PullRequest')]
   nightly_release: $[and(eq(variables['nightly_check'], true), eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['Build.Reason'], 'PullRequest'))]
 
 trigger:
@@ -144,7 +144,10 @@ jobs:
     displayName: ccache
 
   - script: |
-      echo $(nightly_check)
+      echo $(nc)
+      echo $(sb)
+      echo $(br)
+      echo $(nightly_release)
       set -e
       brew update
       brew install boost ccache

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,7 +144,7 @@ jobs:
     displayName: ccache
 
   - script: |
-      echo $(nigtly_check)
+      echo $(nightly_check)
       set -e
       brew update
       brew install boost ccache

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,11 +141,11 @@ jobs:
     displayName: ccache
 
   - script: |
-      echo $(eq(variables['nightly_check'], 'true'))
-      echo $(variables['Build.SourceBranch'])
-      echo $(variables['Build.Reason'])
-      echo $(variables['nightly_release'])
-      echo $eq(variables['nightly_release'], 'False')
+      echo (eq(variables['nightly_check'], 'true'))
+      echo (variables['Build.SourceBranch'])
+      echo (variables['Build.Reason'])
+      echo (variables['nightly_release'])
+      echo eq(variables['nightly_release'], 'False')
       set -e
       brew update
       brew install boost ccache

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ variables:
   nc: eq(variables['nightly_check'], 'true')
   bsc: variables['Build.SourceBranch']
   br: variables['Build.Reason']
-  nightly_release: and(eq(variables['nightly_check'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['Build.Reason'], 'PullRequest'))
+  nightly_release: $[and(eq(variables['nightly_check'], true), eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['Build.Reason'], 'PullRequest'))]
 
 trigger:
 - master
@@ -144,8 +144,7 @@ jobs:
     displayName: ccache
 
   - script: |
-      echo $[variables.br]
-      echo $(br)
+      echo $(nigtly_check)
       set -e
       brew update
       brew install boost ccache


### PR DESCRIPTION
Nightly releases to PyPI are no longer triggered when setting `nightly_check` to `true` in Azure DevOps and running a build pipeline from master. This PR attempts a fix.