### PR TITLE
Add *.pyo and *.pyd to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Compiled python modules.
 *.pyc
+*.pyo
+*.pyd
 
 # Setuptools distribution folder.
 /dist/


### PR DESCRIPTION
Extend list of ignored extensions to other Python bytecode-type files