### PR TITLE
Remove incorrect assumptions in Filtering

### DIFF
--- a/gtda/diagrams/_utils.py
+++ b/gtda/diagrams/_utils.py
@@ -63,19 +63,32 @@ def _filter(X, filtered_homology_dimensions, cutoff):
     else:
         Xuf = _subdiagrams(X, unfiltered_homology_dimensions)
 
+    # Compute a global 2D cutoff mask once
     cutoff_mask = X[:, :, 1] - X[:, :, 0] > cutoff
     Xf = []
     for dim in filtered_homology_dimensions:
+        # Compute a 2D mask for persistence pairs in dimension dim
         dim_mask = X[:, :, 2] == dim
+        # Need the indices relative to X of persistence triples in dimension
+        # dim surviving the cutoff
         indices = np.nonzero(np.logical_and(dim_mask, cutoff_mask))
         if not indices[0].size:
             Xdim = np.tile([0., 0., dim], (n, 1, 1))
         else:
+            # A unique element k is repeated N times *consecutively* in
+            # indices[0] iff there are exactly N valid persistence triples
+            # in the k-th diagram
             unique, counts = np.unique(indices[0], return_counts=True)
             max_n_points = np.max(counts)
+            # Make a global 2D array of all valid triples
             X_indices = X[indices]
-            min_value = np.min(X_indices[:, 0])
+            min_value = np.min(X_indices[:, 0])  # For padding
+            # Initialise the array of filtered subdiagrams in dimension m
             Xdim = np.tile([min_value, min_value, dim], (n, max_n_points, 1))
+            # Since repeated indices in indices[0] are consecutive and we know
+            # the counts per unique index, we can fill the top portion of
+            # each 2D array entry of Xdim with the filtered triples from the
+            # corresponding entry of X
             Xdim[indices[0], _multirange(counts)] = X_indices
         Xf.append(Xdim)
 

--- a/gtda/diagrams/_utils.py
+++ b/gtda/diagrams/_utils.py
@@ -49,16 +49,17 @@ def _filter(X, filtered_homology_dimensions, cutoff):
     else:
         Xuf = _subdiagrams(X, unfiltered_homology_dimensions)
 
+    cutoff_mask = X[:, :, 1] - X[:, :, 0] > cutoff
     Xf = []
     for dim in filtered_homology_dimensions:
-        Xdim = _subdiagrams(X, [dim])
-        indices = np.nonzero(Xdim[:, :, 1] - Xdim[:, :, 0] > cutoff)
+        dim_mask = X[:, :, 2] == dim
+        indices = np.nonzero(np.logical_and(dim_mask, cutoff_mask))
         if not indices[0].size:
             Xdim = np.tile([0., 0., dim], (n, 1, 1))
         else:
             unique, counts = np.unique(indices[0], return_counts=True)
             max_n_points = np.max(counts)
-            X_indices = Xdim[indices]
+            X_indices = X[indices]
             min_value = np.min(X_indices[:, 0])
             Xdim = np.tile([min_value, min_value, dim], (n, max_n_points, 1))
             Xdim[indices[0], reduce(iconcat, map(range, counts), [])] = \

--- a/gtda/diagrams/_utils.py
+++ b/gtda/diagrams/_utils.py
@@ -60,8 +60,7 @@ def _filter(X, filtered_homology_dimensions, cutoff):
             max_n_points = np.max(counts)
             X_indices = Xdim[indices]
             min_value = np.min(X_indices[:, 0])
-            Xdim = np.full((n, max_n_points, 3), min_value)
-            Xdim[:, :, 2] = dim
+            Xdim = np.tile([min_value, min_value, dim], (n, max_n_points, 1))
             Xdim[indices[0], reduce(iconcat, map(range, counts), [])] = \
                 X_indices
         Xf.append(Xdim)

--- a/gtda/diagrams/_utils.py
+++ b/gtda/diagrams/_utils.py
@@ -12,9 +12,12 @@ def _subdiagrams(X, homology_dimensions, remove_dim=False):
     list of homology dimensions. It is assumed that all diagrams in X contain
     the same number of points in each homology dimension."""
     n = len(X)
-    Xs = np.concatenate([X[X[:, :, 2] == dim].reshape(n, -1, 3)
-                         for dim in homology_dimensions],
-                        axis=1)
+    if len(homology_dimensions) == 1:
+        Xs = X[X[:, :, 2] == homology_dimensions[0]].reshape(n, -1, 3)
+    else:
+        Xs = np.concatenate([X[X[:, :, 2] == dim].reshape(n, -1, 3)
+                             for dim in homology_dimensions],
+                            axis=1)
     if remove_dim:
         Xs = Xs[:, :, :2]
     return Xs

--- a/gtda/diagrams/_utils.py
+++ b/gtda/diagrams/_utils.py
@@ -1,9 +1,6 @@
 """Utility functions for diagrams."""
 # License: GNU AGPLv3
 
-from functools import reduce
-from operator import iconcat
-
 import numpy as np
 
 

--- a/gtda/diagrams/preprocessing.py
+++ b/gtda/diagrams/preprocessing.py
@@ -314,18 +314,21 @@ class Filtering(BaseEstimator, TransformerMixin, PlotterMixin):
     """Filtering of persistence diagrams.
 
     Filtering a diagram means discarding all points [b, d, q] representing
-    topological features whose lifetime d - b is less than or equal to a
-    cutoff value. Technically, discarded points are replaced by points on the
-    diagonal (i.e. whose birth and death values coincide), which carry no
-    information.
+    non-trivial topological features whose lifetime d - b is less than or
+    equal to a cutoff value. Points on the diagonal (i.e. for which b and d
+    are equal) may still appear in the output for padding purposes, but carry
+    no information.
+
+    Input collections of persistence diagrams for this transformer must
+    satisfy certain requirements, see e.g. :meth:`fit`.
 
     Parameters
     ----------
     homology_dimensions : list, tuple, or None, optional, default: ``None``
         When set to ``None``, subdiagrams corresponding to all homology
-        dimensions seen in :meth:`fit` will be filtered.
-        Otherwise, it contains the homology dimensions (as non-negative
-        integers) at which filtering should occur.
+        dimensions seen in :meth:`fit` will be filtered. Otherwise, it contains
+        the homology dimensions (as non-negative integers) at which filtering
+        should occur.
 
     epsilon : float, optional, default: ``0.01``
         The cutoff value controlling the amount of filtering.
@@ -368,6 +371,9 @@ class Filtering(BaseEstimator, TransformerMixin, PlotterMixin):
             Input data. Array of persistence diagrams, each a collection of
             triples [b, d, q] representing persistent topological features
             through their birth (b), death (d) and homology dimension (q).
+            It is important that, for each possible homology dimension, the
+            number of triples for which q equals that homology dimension is
+            constants across the entries of `X`.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -399,6 +405,9 @@ class Filtering(BaseEstimator, TransformerMixin, PlotterMixin):
             Input data. Array of persistence diagrams, each a collection of
             triples [b, d, q] representing persistent topological features
             through their birth (b), death (d) and homology dimension (q).
+            It is important that, for each possible homology dimension, the
+            number of triples for which q equals that homology dimension is
+            constants across the entries of X.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -406,10 +415,10 @@ class Filtering(BaseEstimator, TransformerMixin, PlotterMixin):
 
         Returns
         -------
-        Xt : ndarray of shape (n_samples, n_features, 3)
+        Xt : ndarray of shape (n_samples, n_features_filtered, 3)
             Filtered persistence diagrams. Only the subdiagrams corresponding
             to dimensions in :attr:`homology_dimensions_` are filtered.
-            Discarded points are replaced by points on the diagonal.
+            ``n_features_filtered`` is less than or equal to ``n_features`.
 
         """
         check_is_fitted(self)

--- a/gtda/diagrams/preprocessing.py
+++ b/gtda/diagrams/preprocessing.py
@@ -9,7 +9,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
 from ._metrics import _AVAILABLE_AMPLITUDE_METRICS, _parallel_amplitude
-from ._utils import _sort, _filter, _bin, _calculate_weights
+from ._utils import _filter, _bin, _calculate_weights
 from ..base import PlotterMixin
 from ..plotting.persistence_diagrams import plot_diagram
 from ..utils._docs import adapt_fit_transform_docs
@@ -415,7 +415,6 @@ class Filtering(BaseEstimator, TransformerMixin, PlotterMixin):
         check_is_fitted(self)
         X = check_diagrams(X)
 
-        X = _sort(X)
         Xt = _filter(X, self.homology_dimensions_, self.epsilon)
         return Xt
 

--- a/gtda/diagrams/tests/test_preprocessing.py
+++ b/gtda/diagrams/tests/test_preprocessing.py
@@ -277,7 +277,7 @@ epsilons_1 = np.linspace(np.min(lifetimes_1), np.max(lifetimes_1), num=3)
 def test_filt_transform(epsilon):
     filt = Filtering(epsilon=epsilon)
     X_res_1 = filt.fit_transform(X_1)
-    assert X_res_1.shape == X_1.shape
+    assert X_res_1.shape[1] <= X_1.shape[1]
 
     lifetimes_res_1 = X_res_1[:, :, 1] - X_res_1[:, :, 0]
     assert not ((lifetimes_res_1 > 0.) & (lifetimes_res_1 <= epsilon)).any()


### PR DESCRIPTION
**Reference issues/PRs**
Fixes #91. No assumptions are made on the nature of birth/death values beyond the fact that birth >= death.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
Arrays are no longer sorted by lifetime using the `_sort` utility function before calling `_filter` in `Filtering`'s `transform`. Since `_sort` was not needed anywhere else, it has been removed completely from the codebase. The fact that no sorting is made before filtering means that the outputs of `Filtering` are now closer to the inputs in the following sense:
- if a persistence pair came after another in the input array and both are kept by the filtering, then the first pair still comes after the other in the output filtered array (and vice-versa);
- the problematic line pointed out in #91 has been removed;
- some issues with the documentation have been fixed (including a fix for #233 in this transformer).

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.