### PR TITLE
Fix axis ranges in `plot_diagram`

### DIFF
--- a/gtda/plotting/persistence_diagrams.py
+++ b/gtda/plotting/persistence_diagrams.py
@@ -44,8 +44,7 @@ def plot_diagram(diagram, homology_dimensions=None):
 
     for dim in homology_dimensions:
         name = f'H{int(dim)}' if dim != np.inf else 'Any homology dimension'
-        subdiagram = _subdiagrams(np.asarray([diagram]), [dim],
-                                  remove_dim=True)[0]
+        subdiagram = diagram[diagram[:, 2] == dim]
         diff = (subdiagram[:, 1] != subdiagram[:, 0])
         subdiagram = subdiagram[diff]
         fig.add_trace(gobj.Scatter(x=subdiagram[:, 0], y=subdiagram[:, 1],

--- a/gtda/plotting/persistence_diagrams.py
+++ b/gtda/plotting/persistence_diagrams.py
@@ -5,7 +5,7 @@ import numpy as np
 import plotly.graph_objs as gobj
 
 
-def plot_diagram(diagram, homology_dimensions=None, **input_layout):
+def plot_diagram(diagram, homology_dimensions=None):
     """Plot a single persistence diagram.
 
     Parameters
@@ -26,50 +26,19 @@ def plot_diagram(diagram, homology_dimensions=None, **input_layout):
     if homology_dimensions is None:
         homology_dimensions = np.unique(diagram[:, 2])
 
-    max_filt_param = np.where(np.isinf(diagram), -np.inf, diagram).max()
+    diagram_no_dims = diagram[:, :2]
+    max_birth, max_death = np.where(
+        np.isposinf(diagram_no_dims), -np.inf, diagram_no_dims
+    ).max(axis=0)
+    min_birth, min_death = np.where(
+        np.isneginf(diagram_no_dims), np.inf, diagram_no_dims
+    ).min(axis=0)
 
-    layout = dict(
-        width=500,
-        height=500,
-        xaxis1=dict(
-            title='Birth',
-            side='bottom',
-            type='linear',
-            range=[0, 1.1 * max_filt_param],
-            ticks='outside',
-            anchor='y1',
-            showline=True,
-            zeroline=True,
-            showexponent='all',
-            exponentformat='e'
-        ),
-        yaxis1=dict(
-            title='Death',
-            side='left',
-            type='linear',
-            range=[0, 1.1 * max_filt_param],
-            ticks='outside',
-            anchor='x1',
-            showline=True,
-            zeroline=True,
-            showexponent='all',
-            exponentformat='e'
-        ),
-        plot_bgcolor='white'
-    )
-
-    layout.update(input_layout)
-
-    fig = gobj.Figure(layout=layout)
-    fig.update_xaxes(zeroline=True, linewidth=1, linecolor='black',
-                     mirror=False)
-    fig.update_yaxes(zeroline=True, linewidth=1, linecolor='black',
-                     mirror=False)
-
-    fig.add_trace(gobj.Scatter(x=np.array([-100 * max_filt_param,
-                                           100 * max_filt_param]),
-                               y=np.array([-100 * max_filt_param,
-                                           100 * max_filt_param]),
+    fig = gobj.Figure()
+    fig.add_trace(gobj.Scatter(x=[100 * min(-np.abs(max_death), min_birth),
+                                  100 * max_death],
+                               y=[100 * min(-np.abs(max_death), min_birth),
+                                  100 * max_death],
                                mode='lines',
                                line=dict(dash='dash', width=1, color='black'),
                                showlegend=False, hoverinfo='none'))
@@ -82,5 +51,46 @@ def plot_diagram(diagram, homology_dimensions=None, **input_layout):
         subdiagram = subdiagram[diff]
         fig.add_trace(gobj.Scatter(x=subdiagram[:, 0], y=subdiagram[:, 1],
                                    mode='markers', name=name))
+
+    range = max_death - min_birth
+    extra_space = 0.02 * range
+
+    fig.update_layout(
+        width=500,
+        height=500,
+        xaxis1=dict(
+            title='Birth',
+            side='bottom',
+            type='linear',
+            range=[min_birth - extra_space, max_death + extra_space],
+            autorange=False,
+            ticks='outside',
+            showline=True,
+            zeroline=True,
+            linewidth=1,
+            linecolor='black',
+            mirror=False,
+            showexponent='all',
+            exponentformat='e'
+        ),
+        yaxis1=dict(
+            title='Death',
+            side='left',
+            type='linear',
+            range=[min_birth - extra_space, max_death + extra_space],
+            autorange=False,
+            scaleanchor="x",
+            scaleratio=1,
+            ticks='outside',
+            showline=True,
+            zeroline=True,
+            linewidth=1,
+            linecolor='black',
+            mirror=False,
+            showexponent='all',
+            exponentformat='e'
+        ),
+        plot_bgcolor='white'
+    )
 
     fig.show()


### PR DESCRIPTION
**Reference issues/PRs**
Fixes #409 which was due to an incorrect assumption that filtration parameters would never be negative.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
- Fixes #409 by prescribing that the ranges of both the x and y axis be `[min_birth, max_death]` plus some "wiggle room".
- Fixes a calculation of the maximum filtration parameter which incorrectly included the homology dimensions.
- Simplifies the definition of the figure layout.
- Removes undocumented `**input_layout` kwargs (this is technically a breaking change).

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.