### PR TITLE
Refactor _subdiagrams to take all homology dimensions into account

### DIFF
--- a/gtda/diagrams/_utils.py
+++ b/gtda/diagrams/_utils.py
@@ -5,9 +5,13 @@ import numpy as np
 
 
 def _subdiagrams(X, homology_dimensions, remove_dim=False):
-    for dim in homology_dimensions:
-        Xs = X[X[:, :, 2] == dim]
-        Xs = Xs.reshape(X.shape[0], -1, 3)
+    """For each diagram in a collection, extract the subdiagrams in a given
+    list of homology dimensions. It is assumed that all diagrams in X contain
+    the same number of points in each homology dimension."""
+    n = len(X)
+    Xs = np.concatenate([X[X[:, :, 2] == dim].reshape(n, -1, 3)
+                         for dim in homology_dimensions],
+                        axis=1)
     if remove_dim:
         Xs = Xs[:, :, :2]
     return Xs


### PR DESCRIPTION
**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
Currently, the `_subdiagrams` utility function actually disregards all homology dimensions but the last listed in its `homology_dimensions` argument. This in particular causes an obvious bug in https://github.com/giotto-ai/giotto-tda/blob/f6e27d4d7d4d8f772e0c412aef097fc197355337/gtda/diagrams/_utils.py#L45 (and hence also in `Filtering`). I believe this was spotted long ago by @nphilou (thanks!) but somehow never got this simple fix.

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.