### PR TITLE
Replace pip install with python -m pip install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ User installation
 
 The simplest way to install ``giotto-tda`` is using ``pip``   ::
 
-    pip install -U giotto-tda
+    python -m pip install -U giotto-tda
 
 If necessary, this will also automatically install all the above dependencies. Note: we recommend
 upgrading ``pip`` to a recent version as the above may fail on very old versions.
@@ -87,7 +87,7 @@ upgrading ``pip`` to a recent version as the above may fail on very old versions
 Pre-release, experimental builds containing recently added features, and/or
 bug fixes can be installed by running   ::
 
-    pip install -U giotto-tda-nightly
+    python -m pip install -U giotto-tda-nightly
 
 The main difference between ``giotto-tda-nightly`` and the developer installation (see the section
 on contributing, below) is that the former is shipped with pre-compiled wheels (similarly to the stable

--- a/doc/contributing/index.rst
+++ b/doc/contributing/index.rst
@@ -104,7 +104,7 @@ changes. To install ``flake8`` just do
 
 .. code-block:: python
 
-    pip install flake8
+    python -m pip install flake8
 
 You can use ``flake8`` on your python code via the following instructions:
 
@@ -131,7 +131,7 @@ There are two ways to run unit tests for ``giotto-tda``.
 
 .. code-block:: python
 
-    pip install pytest
+    python -m pip install pytest
 
 You can use ``pytest`` on your python code via the following instructions:
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -29,7 +29,7 @@ User installation
 
 The simplest way to install giotto-tda is using ``pip``   ::
 
-    pip install -U giotto-tda
+    python -m pip install -U giotto-tda
 
 If necessary, this will also automatically install all the above dependencies. Note: we recommend
 upgrading ``pip`` to a recent version as the above may fail on very old versions.
@@ -37,7 +37,7 @@ upgrading ``pip`` to a recent version as the above may fail on very old versions
 Pre-release, experimental builds containing recently added features, and/or
 bug fixes can be installed by running   ::
 
-    pip install -U giotto-tda-nightly
+    python -m pip install -U giotto-tda-nightly
 
 The main difference between giotto-tda-nightly and the developer installation (see the section
 on contributing, below) is that the former is shipped with pre-compiled wheels (similarly to the stable
@@ -137,7 +137,7 @@ Troubleshooting
 If you need to understand where the compiler tries to look for ``boost`` headers,
 you can install ``giotto-tda`` with::
 
-   pip install -e . -v
+   python -m pip install -e . -v
 
 Then you can look at the output for lines starting with::
 

--- a/doc/ipynb_to_py.py
+++ b/doc/ipynb_to_py.py
@@ -3,7 +3,7 @@
 Usage: python ipynb_to_gallery.py <notebook.ipynb>
 
 Dependencies:
-pypandoc: install using `pip install pypandoc`
+pypandoc: install using `python -m pip install pypandoc`
 """
 import pypandoc as pdoc
 import json

--- a/doc/release.rst
+++ b/doc/release.rst
@@ -259,7 +259,7 @@ package ``giotto-tda`` will start at v0.1.4 for project continuity.
 
 Short summary: install via ::
 
-    pip install -U giotto-tda
+    python -m pip install -U giotto-tda
 
 and ``import gtda`` in your scripts or notebooks!
 


### PR DESCRIPTION
**Types of changes**
Adapting to modern recommendations on the use of `pip`.

**Description**
It is recommended that Python packages are installed via `python -m pip install <package>` instead of `pip install <package>`. This PR makes this global replacement in the codebase.

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] ~~I have added tests to cover my changes.~~
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.
