### PR TITLE
Return figures instead of showing them

### DIFF
--- a/gtda/base.py
+++ b/gtda/base.py
@@ -140,6 +140,6 @@ class PlotterMixin:
 
         """
         Xt = self.transform(X[sample:sample+1])
-        self.plot(Xt, sample=0, **plot_params)
+        self.plot(Xt, sample=0, **plot_params).show()
 
         return Xt

--- a/gtda/base.py
+++ b/gtda/base.py
@@ -130,7 +130,7 @@ class PlotterMixin:
         sample : int
             Sample to be plotted.
 
-        plot_params : dict
+        **plot_params
             Optional plotting parameters.
 
         Returns

--- a/gtda/diagrams/preprocessing.py
+++ b/gtda/diagrams/preprocessing.py
@@ -108,11 +108,16 @@ class ForgetDimension(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
-        plot_diagram(
+        return plot_diagram(
             Xt[sample], homology_dimensions=[np.inf],
             plotly_params=plotly_params
-        ).show()
+        )
 
 
 @adapt_fit_transform_docs
@@ -315,16 +320,21 @@ class Scaler(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
         if homology_dimensions is None:
             _homology_dimensions = self.homology_dimensions_
         else:
             _homology_dimensions = homology_dimensions
 
-        plot_diagram(
+        return plot_diagram(
             Xt[sample], homology_dimensions=_homology_dimensions,
             plotly_params=plotly_params
-        ).show()
+        )
 
 
 @adapt_fit_transform_docs
@@ -461,13 +471,18 @@ class Filtering(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
         if homology_dimensions is None:
             _homology_dimensions = self.homology_dimensions_
         else:
             _homology_dimensions = homology_dimensions
 
-        plot_diagram(
+        return plot_diagram(
             Xt[sample], homology_dimensions=_homology_dimensions,
             plotly_params=plotly_params
-        ).show()
+        )

--- a/gtda/diagrams/preprocessing.py
+++ b/gtda/diagrams/preprocessing.py
@@ -89,7 +89,7 @@ class ForgetDimension(BaseEstimator, TransformerMixin, PlotterMixin):
         return Xt
 
     @staticmethod
-    def plot(Xt, sample=0):
+    def plot(Xt, sample=0, plotly_params=None):
         """Plot a sample from a collection of persistence diagrams.
 
         Parameters
@@ -101,9 +101,18 @@ class ForgetDimension(BaseEstimator, TransformerMixin, PlotterMixin):
         sample : int, optional, default: ``0``
             Index of the sample in `Xt` to be plotted.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"traces"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
-        return plot_diagram(
-            Xt[sample], homology_dimensions=[np.inf])
+        plot_diagram(
+            Xt[sample], homology_dimensions=[np.inf],
+            plotly_params=plotly_params
+        ).show()
 
 
 @adapt_fit_transform_docs
@@ -282,7 +291,7 @@ class Scaler(BaseEstimator, TransformerMixin, PlotterMixin):
         Xs[:, :, :2] *= self.scale_
         return Xs
 
-    def plot(self, Xt, sample=0, homology_dimensions=None):
+    def plot(self, Xt, sample=0, homology_dimensions=None, plotly_params=None):
         """Plot a sample from a collection of persistence diagrams, with
         homology in multiple dimensions.
 
@@ -299,14 +308,23 @@ class Scaler(BaseEstimator, TransformerMixin, PlotterMixin):
             Which homology dimensions to include in the plot. ``None`` is
             equivalent to passing :attr:`homology_dimensions_`.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"traces"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
         if homology_dimensions is None:
             _homology_dimensions = self.homology_dimensions_
         else:
             _homology_dimensions = homology_dimensions
 
-        return plot_diagram(
-            Xt[sample], homology_dimensions=_homology_dimensions)
+        plot_diagram(
+            Xt[sample], homology_dimensions=_homology_dimensions,
+            plotly_params=plotly_params
+        ).show()
 
 
 @adapt_fit_transform_docs
@@ -419,7 +437,7 @@ class Filtering(BaseEstimator, TransformerMixin, PlotterMixin):
         Xt = _filter(X, self.homology_dimensions_, self.epsilon)
         return Xt
 
-    def plot(self, Xt, sample=0, homology_dimensions=None):
+    def plot(self, Xt, sample=0, homology_dimensions=None, plotly_params=None):
         """Plot a sample from a collection of persistence diagrams, with
         homology in multiple dimensions.
 
@@ -436,11 +454,20 @@ class Filtering(BaseEstimator, TransformerMixin, PlotterMixin):
             Which homology dimensions to include in the plot. ``None`` is
             equivalent to passing :attr:`homology_dimensions_`.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"traces"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
         if homology_dimensions is None:
             _homology_dimensions = self.homology_dimensions_
         else:
             _homology_dimensions = homology_dimensions
 
-        return plot_diagram(
-            Xt[sample], homology_dimensions=_homology_dimensions)
+        plot_diagram(
+            Xt[sample], homology_dimensions=_homology_dimensions,
+            plotly_params=plotly_params
+        ).show()

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -168,6 +168,11 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
             Which homology dimensions to include in the plot. ``None`` means
             plotting all dimensions present in :attr:`homology_dimensions_`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
         check_is_fitted(self)
 
@@ -224,7 +229,7 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
                                        mode='lines', showlegend=True,
                                        name=f"H{int(dim)}"))
 
-        fig.show()
+        return fig
 
 
 @adapt_fit_transform_docs
@@ -383,6 +388,11 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
             ``None`` means plotting all dimensions present in
             :attr:`homology_dimensions_`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
         check_is_fitted(self)
 
@@ -445,7 +455,7 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
                                            hoverinfo='none',
                                            name=f"Layer {layer + 1}"))
 
-            fig.show()
+            return fig
 
 
 @adapt_fit_transform_docs
@@ -627,14 +637,19 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
         check_is_fitted(self)
-        plot_heatmap(
+        return plot_heatmap(
             Xt[sample][homology_dimension_ix],
             x=self.samplings_[homology_dimension_ix],
             y=self.samplings_[homology_dimension_ix],
             colorscale=colorscale, plotly_params=plotly_params
-        ).show()
+        )
 
 
 @adapt_fit_transform_docs
@@ -847,13 +862,18 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
         check_is_fitted(self)
         samplings_x, samplings_y = self.samplings_[homology_dimension_ix]
-        plot_heatmap(
+        return plot_heatmap(
             Xt[sample][homology_dimension_ix], x=samplings_x, y=samplings_y,
             colorscale=colorscale, plotly_params=plotly_params
-        ).show()
+        )
 
 
 @adapt_fit_transform_docs
@@ -1024,6 +1044,11 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
         check_is_fitted(self)
 
@@ -1085,4 +1110,4 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
             fig.update_traces(plotly_params.get("traces", None))
             fig.update_layout(plotly_params.get("layout", None))
 
-        fig.show()
+        return fig

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -595,7 +595,8 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
             transpose((1, 0, 2, 3))
         return Xt
 
-    def plot(self, Xt, sample=0, homology_dimension_ix=0, colorscale='blues'):
+    def plot(self, Xt, sample=0, homology_dimension_ix=0, colorscale='blues',
+             plotly_params=None):
         """Plot a single channel – corresponding to a given homology
         dimension – in a sample from a collection of heat kernel images.
 
@@ -619,12 +620,21 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
             Color scale to be used in the heat map. Can be anything allowed by
             :class:`plotly.graph_objects.Heatmap`.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"trace"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
         check_is_fitted(self)
-        return plot_heatmap(Xt[sample][homology_dimension_ix],
-                            x=self.samplings_[homology_dimension_ix],
-                            y=self.samplings_[homology_dimension_ix],
-                            colorscale=colorscale)
+        plot_heatmap(
+            Xt[sample][homology_dimension_ix],
+            x=self.samplings_[homology_dimension_ix],
+            y=self.samplings_[homology_dimension_ix],
+            colorscale=colorscale, plotly_params=plotly_params
+        ).show()
 
 
 @adapt_fit_transform_docs
@@ -805,7 +815,8 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
             transpose((1, 0, 2, 3))
         return Xt
 
-    def plot(self, Xt, sample=0, homology_dimension_ix=0, colorscale='blues'):
+    def plot(self, Xt, sample=0, homology_dimension_ix=0, colorscale='blues',
+             plotly_params=None):
         """Plot a single channel – corresponding to a given homology
         dimension – in a sample from a collection of persistence images.
 
@@ -829,13 +840,20 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
             Color scale to be used in the heat map. Can be anything allowed by
             :class:`plotly.graph_objects.Heatmap`.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"trace"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
         check_is_fitted(self)
         samplings_x, samplings_y = self.samplings_[homology_dimension_ix]
-        return plot_heatmap(Xt[sample][homology_dimension_ix],
-                            x=samplings_x,
-                            y=samplings_y,
-                            colorscale=colorscale)
+        plot_heatmap(
+            Xt[sample][homology_dimension_ix], x=samplings_x, y=samplings_y,
+            colorscale=colorscale, plotly_params=plotly_params
+        ).show()
 
 
 @adapt_fit_transform_docs
@@ -982,7 +1000,7 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
             transpose((1, 0, 2))
         return Xt
 
-    def plot(self, Xt, sample=0, homology_dimensions=None):
+    def plot(self, Xt, sample=0, homology_dimensions=None, plotly_params=None):
         """Plot a sample from a collection of silhouettes arranged as in
         the output of :meth:`transform`. Include homology in multiple
         dimensions.
@@ -998,6 +1016,13 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
         homology_dimensions : list, tuple or None, optional, default: ``None``
             Which homology dimensions to include in the plot. ``None`` means
             plotting all dimensions present in :attr:`homology_dimensions_`.
+
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"traces"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
 
         """
         check_is_fitted(self)
@@ -1054,5 +1079,10 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
                                        mode="lines", showlegend=True,
                                        hoverinfo="none",
                                        name=f"H{int(dim)}"))
+
+        # Update trace and layout according to user input
+        if plotly_params:
+            fig.update_traces(plotly_params.get("traces", None))
+            fig.update_layout(plotly_params.get("layout", None))
 
         fig.show()

--- a/gtda/graphs/geodesic_distance.py
+++ b/gtda/graphs/geodesic_distance.py
@@ -180,7 +180,7 @@ class GraphGeodesicDistance(BaseEstimator, TransformerMixin, PlotterMixin):
         return Xt
 
     @staticmethod
-    def plot(Xt, sample=0, colorscale='blues'):
+    def plot(Xt, sample=0, colorscale='blues', plotly_params=None):
         """Plot a sample from a collection of distance matrices.
 
         Parameters
@@ -197,5 +197,14 @@ class GraphGeodesicDistance(BaseEstimator, TransformerMixin, PlotterMixin):
             Color scale to be used in the heat map. Can be anything allowed by
             :class:`plotly.graph_objects.Heatmap`.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"trace"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
-        return plot_heatmap(Xt[sample], colorscale=colorscale)
+        plot_heatmap(
+            Xt[sample], colorscale=colorscale, plotly_params=plotly_params
+        ).show()

--- a/gtda/graphs/geodesic_distance.py
+++ b/gtda/graphs/geodesic_distance.py
@@ -204,7 +204,12 @@ class GraphGeodesicDistance(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
-        plot_heatmap(
+        return plot_heatmap(
             Xt[sample], colorscale=colorscale, plotly_params=plotly_params
-        ).show()
+        )

--- a/gtda/graphs/tests/test_geodesic_distance.py
+++ b/gtda/graphs/tests/test_geodesic_distance.py
@@ -1,5 +1,7 @@
 """Testing for GraphGeodesicDistance."""
 
+import warnings
+
 import numpy as np
 import plotly.io as pio
 import pytest
@@ -85,15 +87,20 @@ def test_ggd_not_fitted():
 
 def test_ggd_fit_transform_plot():
     X = X_ggd[0][0]
-    GraphGeodesicDistance().fit_transform_plot(X, sample=0)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="Methods .*")
+        GraphGeodesicDistance().fit_transform_plot(X, sample=0)
 
 
 @pytest.mark.parametrize("X, X_res", X_ggd)
 @pytest.mark.parametrize("method", ["auto", "FW", "D", "J", "BF"])
 def test_ggd_transform(X, X_res, method):
-    ggd = GraphGeodesicDistance(directed=False, method=method)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="Methods .*")
+        ggd = GraphGeodesicDistance(directed=False, method=method)
+        X_ft = ggd.fit_transform(X)
 
-    assert_almost_equal(ggd.fit_transform(X), X_res)
+    assert_almost_equal(X_ft, X_res)
 
 
 def test_parallel_ggd_transform():
@@ -101,4 +108,7 @@ def test_parallel_ggd_transform():
     ggd = GraphGeodesicDistance(n_jobs=1)
     ggd_parallel = GraphGeodesicDistance(n_jobs=2)
 
-    assert_almost_equal(ggd.fit_transform(X), ggd_parallel.fit_transform(X))
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="Methods .*")
+        assert_almost_equal(ggd.fit_transform(X),
+                            ggd_parallel.fit_transform(X))

--- a/gtda/homology/cubical.py
+++ b/gtda/homology/cubical.py
@@ -246,8 +246,13 @@ class CubicalPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
-        plot_diagram(
+        return plot_diagram(
             Xt[sample], homology_dimensions=homology_dimensions,
             plotly_params=plotly_params
-        ).show()
+        )

--- a/gtda/homology/cubical.py
+++ b/gtda/homology/cubical.py
@@ -197,6 +197,7 @@ class CubicalPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             :math:`\\sum_q n_q`, where :math:`n_q` is the maximum number of
             topological features in dimension :math:`q` across all samples in
             `X`.
+
         """
         check_is_fitted(self)
         Xt = check_array(X, allow_nd=True)
@@ -221,7 +222,7 @@ class CubicalPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         return Xt
 
     @staticmethod
-    def plot(Xt, sample=0, homology_dimensions=None):
+    def plot(Xt, sample=0, homology_dimensions=None, plotly_params=None):
         """Plot a sample from a collection of persistence diagrams, with
         homology in multiple dimensions.
 
@@ -238,6 +239,15 @@ class CubicalPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             Which homology dimensions to include in the plot. ``None`` means
             plotting all dimensions present in ``Xt[sample]``.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"traces"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
-        return plot_diagram(
-            Xt[sample], homology_dimensions=homology_dimensions)
+        plot_diagram(
+            Xt[sample], homology_dimensions=homology_dimensions,
+            plotly_params=plotly_params
+        ).show()

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -233,7 +233,7 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         return Xt
 
     @staticmethod
-    def plot(Xt, sample=0, homology_dimensions=None):
+    def plot(Xt, sample=0, homology_dimensions=None, plotly_params=None):
         """Plot a sample from a collection of persistence diagrams, with
         homology in multiple dimensions.
 
@@ -250,9 +250,18 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             Which homology dimensions to include in the plot. ``None`` means
             plotting all dimensions present in ``Xt[sample]``.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"traces"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
-        return plot_diagram(
-            Xt[sample], homology_dimensions=homology_dimensions)
+        plot_diagram(
+            Xt[sample], homology_dimensions=homology_dimensions,
+            plotly_params=plotly_params
+        ).show()
 
 
 @adapt_fit_transform_docs
@@ -480,7 +489,7 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         return Xt
 
     @staticmethod
-    def plot(Xt, sample=0, homology_dimensions=None):
+    def plot(Xt, sample=0, homology_dimensions=None, plotly_params=None):
         """Plot a sample from a collection of persistence diagrams, with
         homology in multiple dimensions.
 
@@ -497,9 +506,18 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             Which homology dimensions to include in the plot. ``None`` means
             plotting all dimensions present in ``Xt[sample]``.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"traces"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
-        return plot_diagram(
-            Xt[sample], homology_dimensions=homology_dimensions)
+        plot_diagram(
+            Xt[sample], homology_dimensions=homology_dimensions,
+            plotly_params=plotly_params
+        ).show()
 
 
 @adapt_fit_transform_docs
@@ -683,7 +701,7 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         return Xt
 
     @staticmethod
-    def plot(Xt, sample=0, homology_dimensions=None):
+    def plot(Xt, sample=0, homology_dimensions=None, plotly_params=None):
         """Plot a sample from a collection of persistence diagrams, with
         homology in multiple dimensions.
 
@@ -700,9 +718,18 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             Which homology dimensions to include in the plot. ``None`` means
             plotting all dimensions present in ``Xt[sample]``.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"traces"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
-        return plot_diagram(
-            Xt[sample], homology_dimensions=homology_dimensions)
+        plot_diagram(
+            Xt[sample], homology_dimensions=homology_dimensions,
+            plotly_params=plotly_params
+        ).show()
 
 
 @adapt_fit_transform_docs
@@ -947,7 +974,7 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         return Xt
 
     @staticmethod
-    def plot(Xt, sample=0, homology_dimensions=None):
+    def plot(Xt, sample=0, homology_dimensions=None, plotly_params=None):
         """Plot a sample from a collection of persistence diagrams, with
         homology in multiple dimensions.
 
@@ -964,6 +991,15 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             Which homology dimensions to include in the plot. ``None`` means
             plotting all dimensions present in ``Xt[sample]``.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"traces"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
-        return plot_diagram(
-            Xt[sample], homology_dimensions=homology_dimensions)
+        plot_diagram(
+            Xt[sample], homology_dimensions=homology_dimensions,
+            plotly_params=plotly_params
+        ).show()

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -257,11 +257,16 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
-        plot_diagram(
+        return plot_diagram(
             Xt[sample], homology_dimensions=homology_dimensions,
             plotly_params=plotly_params
-        ).show()
+        )
 
 
 @adapt_fit_transform_docs
@@ -513,11 +518,16 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
-        plot_diagram(
+        return plot_diagram(
             Xt[sample], homology_dimensions=homology_dimensions,
             plotly_params=plotly_params
-        ).show()
+        )
 
 
 @adapt_fit_transform_docs
@@ -725,11 +735,16 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
-        plot_diagram(
+        return plot_diagram(
             Xt[sample], homology_dimensions=homology_dimensions,
             plotly_params=plotly_params
-        ).show()
+        )
 
 
 @adapt_fit_transform_docs
@@ -998,8 +1013,13 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
-        plot_diagram(
+        return plot_diagram(
             Xt[sample], homology_dimensions=homology_dimensions,
             plotly_params=plotly_params
-        ).show()
+        )

--- a/gtda/images/filtrations.py
+++ b/gtda/images/filtrations.py
@@ -209,11 +209,16 @@ class HeightFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
-        plot_heatmap(
+        return plot_heatmap(
             Xt[sample], colorscale=colorscale, origin=origin,
             plotly_params=plotly_params
-        ).show()
+        )
 
 
 @adapt_fit_transform_docs
@@ -446,11 +451,16 @@ class RadialFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
-        plot_heatmap(
+        return plot_heatmap(
             Xt[sample], colorscale=colorscale, origin=origin,
             plotly_params=plotly_params
-        ).show()
+        )
 
 
 @adapt_fit_transform_docs
@@ -630,11 +640,16 @@ class DilationFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
-        plot_heatmap(
+        return plot_heatmap(
             Xt[sample], colorscale=colorscale, origin=origin,
             plotly_params=plotly_params
-        ).show()
+        )
 
 
 @adapt_fit_transform_docs
@@ -813,11 +828,16 @@ class ErosionFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
-        plot_heatmap(
+        return plot_heatmap(
             Xt[sample], colorscale=colorscale, origin=origin,
             plotly_params=plotly_params
-        ).show()
+        )
 
 
 @adapt_fit_transform_docs
@@ -1006,8 +1026,13 @@ class SignedDistanceFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
-        plot_heatmap(
+        return plot_heatmap(
             Xt[sample], colorscale=colorscale, origin=origin,
             plotly_params=plotly_params
-        ).show()
+        )

--- a/gtda/images/filtrations.py
+++ b/gtda/images/filtrations.py
@@ -180,7 +180,8 @@ class HeightFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
         return Xt
 
     @staticmethod
-    def plot(Xt, sample=0, colorscale='greys', origin='upper'):
+    def plot(Xt, sample=0, colorscale='greys', origin='upper',
+             plotly_params=None):
         """Plot a sample from a collection of 2D greyscale images.
 
         Parameters
@@ -201,8 +202,18 @@ class HeightFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
             left corner. The convention ``'upper'`` is typically used for
             matrices and images.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"trace"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
-        return plot_heatmap(Xt[sample], colorscale=colorscale, origin=origin)
+        plot_heatmap(
+            Xt[sample], colorscale=colorscale, origin=origin,
+            plotly_params=plotly_params
+        ).show()
 
 
 @adapt_fit_transform_docs
@@ -406,7 +417,8 @@ class RadialFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
         return Xt
 
     @staticmethod
-    def plot(Xt, sample=0, colorscale='greys', origin='upper'):
+    def plot(Xt, sample=0, colorscale='greys', origin='upper',
+             plotly_params=None):
         """Plot a sample from a collection of 2D greyscale images.
 
         Parameters
@@ -427,8 +439,18 @@ class RadialFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
             left corner. The convention ``'upper'`` is typically used for
             matrices and images.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"trace"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
-        return plot_heatmap(Xt[sample], colorscale=colorscale, origin=origin)
+        plot_heatmap(
+            Xt[sample], colorscale=colorscale, origin=origin,
+            plotly_params=plotly_params
+        ).show()
 
 
 @adapt_fit_transform_docs
@@ -579,7 +601,8 @@ class DilationFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
         return Xt
 
     @staticmethod
-    def plot(Xt, sample=0, colorscale='greys', origin='upper'):
+    def plot(Xt, sample=0, colorscale='greys', origin='upper',
+             plotly_params=None):
         """Plot a sample from a collection of 2D greyscale images.
 
         Parameters
@@ -600,8 +623,18 @@ class DilationFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
             left corner. The convention ``'upper'`` is typically used for
             matrices and images.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"trace"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
-        return plot_heatmap(Xt[sample], colorscale=colorscale, origin=origin)
+        plot_heatmap(
+            Xt[sample], colorscale=colorscale, origin=origin,
+            plotly_params=plotly_params
+        ).show()
 
 
 @adapt_fit_transform_docs
@@ -751,7 +784,8 @@ class ErosionFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
         return Xt
 
     @staticmethod
-    def plot(Xt, sample=0, colorscale='greys', origin='upper'):
+    def plot(Xt, sample=0, colorscale='greys', origin='upper',
+             plotly_params=None):
         """Plot a sample from a collection of 2D greyscale images.
 
         Parameters
@@ -772,8 +806,18 @@ class ErosionFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
             left corner. The convention ``'upper'`` is typically used for
             matrices and images.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"trace"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
-        return plot_heatmap(Xt[sample], colorscale=colorscale, origin=origin)
+        plot_heatmap(
+            Xt[sample], colorscale=colorscale, origin=origin,
+            plotly_params=plotly_params
+        ).show()
 
 
 @adapt_fit_transform_docs
@@ -933,7 +977,8 @@ class SignedDistanceFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
         return Xt
 
     @staticmethod
-    def plot(Xt, sample=0, colorscale='greys', origin='upper'):
+    def plot(Xt, sample=0, colorscale='greys', origin='upper',
+             plotly_params=None):
         """Plot a sample from a collection of 2D greyscale images.
 
         Parameters
@@ -954,5 +999,15 @@ class SignedDistanceFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
             left corner. The convention ``'upper'`` is typically used for
             matrices and images.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"trace"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
-        return plot_heatmap(Xt[sample], colorscale=colorscale, origin=origin)
+        plot_heatmap(
+            Xt[sample], colorscale=colorscale, origin=origin,
+            plotly_params=plotly_params
+        ).show()

--- a/gtda/images/preprocessing.py
+++ b/gtda/images/preprocessing.py
@@ -141,7 +141,8 @@ class Binarizer(BaseEstimator, TransformerMixin, PlotterMixin):
         return Xt
 
     @staticmethod
-    def plot(Xt, sample=0, colorscale='greys', origin='upper'):
+    def plot(Xt, sample=0, colorscale='greys', origin='upper',
+             plotly_params=None):
         """Plot a sample from a collection of 2D binary images.
 
         Parameters
@@ -162,9 +163,18 @@ class Binarizer(BaseEstimator, TransformerMixin, PlotterMixin):
             left corner. The convention ``'upper'`` is typically used for
             matrices and images.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"trace"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
-        return plot_heatmap(
-            Xt[sample] * 1, colorscale=colorscale, origin=origin)
+        plot_heatmap(
+            Xt[sample] * 1, colorscale=colorscale, origin=origin,
+            plotly_params=plotly_params
+        )
 
 
 @adapt_fit_transform_docs
@@ -249,7 +259,8 @@ class Inverter(BaseEstimator, TransformerMixin, PlotterMixin):
         return Xt
 
     @staticmethod
-    def plot(Xt, sample=0, colorscale='greys', origin='upper'):
+    def plot(Xt, sample=0, colorscale='greys', origin='upper',
+             plotly_params=None):
         """Plot a sample from a collection of 2D binary images.
 
         Parameters
@@ -270,9 +281,18 @@ class Inverter(BaseEstimator, TransformerMixin, PlotterMixin):
             left corner. The convention ``'upper'`` is typically used for
             matrices and images.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"trace"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
-        return plot_heatmap(
-            Xt[sample] * 1, colorscale=colorscale, origin=origin)
+        plot_heatmap(
+            Xt[sample] * 1, colorscale=colorscale, origin=origin,
+            plotly_params=plotly_params
+        ).show()
 
 
 @adapt_fit_transform_docs
@@ -401,7 +421,8 @@ class Padder(BaseEstimator, TransformerMixin, PlotterMixin):
         return Xt
 
     @staticmethod
-    def plot(Xt, sample=0, colorscale='greys', origin='upper'):
+    def plot(Xt, sample=0, colorscale='greys', origin='upper',
+             plotly_params=None):
         """Plot a sample from a collection of 2D binary images.
 
         Parameters
@@ -422,9 +443,18 @@ class Padder(BaseEstimator, TransformerMixin, PlotterMixin):
             left corner. The convention ``'upper'`` is typically used for
             matrices and images.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"trace"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
-        return plot_heatmap(
-            Xt[sample] * 1, colorscale=colorscale, origin=origin)
+        plot_heatmap(
+            Xt[sample] * 1, colorscale=colorscale, origin=origin,
+            plotly_params=plotly_params
+        ).show()
 
 
 @adapt_fit_transform_docs
@@ -531,7 +561,7 @@ class ImageToPointCloud(BaseEstimator, TransformerMixin, PlotterMixin):
         return Xt
 
     @staticmethod
-    def plot(Xt, sample=0):
+    def plot(Xt, sample=0, plotly_params=None):
         """Plot a sample from a collection of point clouds. If the point cloud
         is in more than three dimensions, only the first three are plotted.
 
@@ -544,5 +574,12 @@ class ImageToPointCloud(BaseEstimator, TransformerMixin, PlotterMixin):
         sample : int, optional, default: ``0``
             Index of the sample in `Xt` to be plotted.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"trace"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
-        return plot_point_cloud(Xt[sample])
+        plot_point_cloud(Xt[sample], plotly_params=plotly_params).show()

--- a/gtda/images/preprocessing.py
+++ b/gtda/images/preprocessing.py
@@ -170,8 +170,13 @@ class Binarizer(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
-        plot_heatmap(
+        return plot_heatmap(
             Xt[sample] * 1, colorscale=colorscale, origin=origin,
             plotly_params=plotly_params
         )
@@ -288,11 +293,16 @@ class Inverter(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
-        plot_heatmap(
+        return plot_heatmap(
             Xt[sample] * 1, colorscale=colorscale, origin=origin,
             plotly_params=plotly_params
-        ).show()
+        )
 
 
 @adapt_fit_transform_docs
@@ -450,11 +460,16 @@ class Padder(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
-        plot_heatmap(
+        return plot_heatmap(
             Xt[sample] * 1, colorscale=colorscale, origin=origin,
             plotly_params=plotly_params
-        ).show()
+        )
 
 
 @adapt_fit_transform_docs
@@ -581,5 +596,10 @@ class ImageToPointCloud(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
-        plot_point_cloud(Xt[sample], plotly_params=plotly_params).show()
+        return plot_point_cloud(Xt[sample], plotly_params=plotly_params)

--- a/gtda/mapper/tests/test_filter.py
+++ b/gtda/mapper/tests/test_filter.py
@@ -1,24 +1,25 @@
+import warnings
+
 import numpy as np
 from hypothesis import given
 from hypothesis.extra.numpy import array_shapes, arrays
 from hypothesis.strategies import integers, floats
 from numpy.testing import assert_almost_equal
 from scipy.spatial.distance import pdist, squareform
+from sklearn.neighbors import KernelDensity
 
 from gtda.mapper import Eccentricity, Entropy, Projection
 from gtda.mapper.utils._list_feature_union import ListFeatureUnion
 from gtda.mapper.utils.decorators import method_to_transform
 
-from sklearn.neighbors import KernelDensity
 
-
-@given(
-    X=arrays(dtype=np.float,
-             elements=floats(allow_nan=False,
-                             allow_infinity=False),
-             shape=array_shapes(min_dims=2, max_dims=2)),
-    exponent=integers(min_value=1, max_value=100)
-)
+@given(X=arrays(dtype=np.float,
+                elements=floats(allow_nan=False,
+                                allow_infinity=False,
+                                min_value=-1e3,
+                                max_value=1e3),
+                shape=array_shapes(min_dims=2, max_dims=2)),
+       exponent=integers(min_value=1, max_value=10))
 def test_eccentricity_shape_equals_number_of_samples(X, exponent):
     """Verify that eccentricity preserves the nb of samples in the input."""
     eccentricity = Eccentricity(exponent=exponent)
@@ -28,7 +29,9 @@ def test_eccentricity_shape_equals_number_of_samples(X, exponent):
 
 @given(X=arrays(dtype=np.float,
                 elements=floats(allow_nan=False,
-                                allow_infinity=False),
+                                allow_infinity=False,
+                                min_value=-1e3,
+                                max_value=1e3),
                 shape=array_shapes(min_dims=2, max_dims=2)))
 def test_eccentricity_values_with_infinity_norm_equals_max_row_values(X):
     eccentricity = Eccentricity(exponent=np.inf)
@@ -37,35 +40,33 @@ def test_eccentricity_values_with_infinity_norm_equals_max_row_values(X):
     assert_almost_equal(Xt, np.max(distance_matrix, axis=1).reshape(-1, 1))
 
 
-@given(X=arrays(
-    dtype=np.float,
-    elements=floats(allow_nan=False,
-                    allow_infinity=False,
-                    min_value=-1e3,
-                    max_value=-1),
-    shape=array_shapes(min_dims=2, max_dims=2, min_side=2)
-))
+@given(X=arrays(dtype=np.float,
+                elements=floats(allow_nan=False,
+                                allow_infinity=False,
+                                min_value=-1e3,
+                                max_value=-1),
+                shape=array_shapes(min_dims=2, max_dims=2, min_side=2)))
 def test_entropy_values_for_negative_inputs(X):
     """Verify the numerical results of entropy (does it have the correct
     logic), on a collection of **negative** inputs."""
     entropy = Entropy()
-    Xt = entropy.fit_transform(X)
-    probs = X / X.sum(axis=1, keepdims=True)
-    entropies = - np.einsum('ij,ij->i', probs,
-                            np.where(probs != 0, np.log2(probs), 0))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        Xt = entropy.fit_transform(X)
+        probs = X / X.sum(axis=1, keepdims=True)
+        entropies = - np.einsum('ij,ij->i', probs,
+                                np.where(probs != 0, np.log2(probs), 0))
     assert_almost_equal(Xt, entropies[:, None])
 
 
-@given(X=arrays(
-    dtype=np.float,
-    elements=floats(allow_nan=False,
-                    allow_infinity=False,
-                    min_value=1,
-                    max_value=1e3),
-    shape=array_shapes(min_dims=2, max_dims=2, min_side=2)
-))
+@given(X=arrays(dtype=np.float,
+                elements=floats(allow_nan=False,
+                                allow_infinity=False,
+                                min_value=1,
+                                max_value=1e3),
+                shape=array_shapes(min_dims=2, max_dims=2, min_side=2)))
 def test_entropy_values_for_positive_inputs(X):
-    """Verify the numerical results of entropy (does it have the correct logic),
+    """Verify the numerical results of entropy (does it have the correct logic)
     on a collection of **positive** inputs."""
     entropy = Entropy()
     Xt = entropy.fit_transform(X)
@@ -77,25 +78,25 @@ def test_entropy_values_for_positive_inputs(X):
 
 @given(X=arrays(dtype=np.float,
                 elements=floats(allow_nan=False,
-                                allow_infinity=False),
-                shape=array_shapes(min_dims=2, max_dims=2)))
+                                allow_infinity=False,
+                                min_value=-1e3,
+                                max_value=1e3),
+                shape=array_shapes(min_dims=2, max_dims=2, min_side=2)))
 def test_projection_values_equal_slice(X):
     """Test the logic of the ``Projection`` transformer."""
     columns = np.random.choice(
-        X.shape[1], 1 + np.random.randint(X.shape[1]))
+        X.shape[1], 1 + np.random.randint(X.shape[1] - 1))
     Xt = Projection(columns=columns).fit_transform(X)
     assert_almost_equal(Xt, X[:, columns])
 
 
-@given(X=arrays(
-    dtype=np.float,
-    elements=floats(allow_nan=False,
-                    allow_infinity=False,
-                    min_value=1,
-                    max_value=1e3),
-    shape=array_shapes(min_dims=2, max_dims=2, min_side=2),
-    unique=True
-))
+@given(X=arrays(dtype=np.float,
+                elements=floats(allow_nan=False,
+                                allow_infinity=False,
+                                min_value=1,
+                                max_value=1e3),
+                shape=array_shapes(min_dims=2, max_dims=2, min_side=2),
+                unique=True))
 def test_gaussian_density_values(X):
     """Check that ``fit_transform`` and ``fit + score_samples``
     of ``KernelDensity`` are the same."""
@@ -107,15 +108,13 @@ def test_gaussian_density_values(X):
     assert_almost_equal(Xt_actual, Xt_desired)
 
 
-@given(X=arrays(
-    dtype=np.float,
-    elements=floats(allow_nan=False,
-                    allow_infinity=False,
-                    min_value=1,
-                    max_value=1e3),
-    shape=array_shapes(min_dims=2, max_dims=2, min_side=2),
-    unique=True
-))
+@given(X=arrays(dtype=np.float,
+                elements=floats(allow_nan=False,
+                                allow_infinity=False,
+                                min_value=1,
+                                max_value=1e3),
+                shape=array_shapes(min_dims=2, max_dims=2, min_side=2),
+                unique=True))
 def test_list_feature_union_transform(X):
     """Check that a ``ListFeatureUnion`` of two projections gives the same
     result as stacking the projections."""
@@ -131,15 +130,13 @@ def test_list_feature_union_transform(X):
     assert_almost_equal(x_12, x_1_2)
 
 
-@given(X=arrays(
-    dtype=np.float,
-    elements=floats(allow_nan=False,
-                    allow_infinity=False,
-                    min_value=1,
-                    max_value=1e3),
-    shape=array_shapes(min_dims=2, max_dims=2, min_side=2),
-    unique=True
-))
+@given(X=arrays(dtype=np.float,
+                elements=floats(allow_nan=False,
+                                allow_infinity=False,
+                                min_value=1,
+                                max_value=1e3),
+                shape=array_shapes(min_dims=2, max_dims=2, min_side=2),
+                unique=True))
 def test_list_feature_union_drops(X):
     """Check the the drop of ``ListFeatureUnion`` keeps the correct number
     of samples"""

--- a/gtda/plotting/diagram_representations.py
+++ b/gtda/plotting/diagram_representations.py
@@ -5,7 +5,8 @@ import numpy as np
 import plotly.graph_objs as gobj
 
 
-def plot_betti_curves(betti_numbers, samplings, homology_dimensions=None):
+def plot_betti_curves(betti_numbers, samplings, homology_dimensions=None,
+                      plotly_params=None):
     """Plot Betti curves by homology dimension.
 
     Parameters
@@ -22,6 +23,18 @@ def plot_betti_curves(betti_numbers, samplings, homology_dimensions=None):
     homology_dimensions : list, tuple or None, optional, default: ``None``
         Which homology dimensions to include in the plot. If ``None``,
         all available homology dimensions will be used.
+
+    plotly_params : dict or None, optional, default: ``None``
+        Custom parameters to configure the plotly figure. Allowed keys are
+        ``"traces"`` and ``"layout"``, and the corresponding values should be
+        dictionaries containing keyword arguments as would be fed to the
+        :meth:`update_traces` and :meth:`update_layout` methods of
+        :class:`plotly.graph_objects.Figure`.
+
+    Returns
+    -------
+    fig : :class:`plotly.graph_objects.Figure` object
+        Figure representing the Betti curves.
 
     """
     if homology_dimensions is None:
@@ -67,11 +80,16 @@ def plot_betti_curves(betti_numbers, samplings, homology_dimensions=None):
                                    hoverinfo='none',
                                    name=f'H{int(dim)}'))
 
-    fig.show()
+    # Update trace and layout according to user input
+    if plotly_params:
+        fig.update_traces(plotly_params.get("traces", None))
+        fig.update_layout(plotly_params.get("layout", None))
+
+    return fig
 
 
 def plot_betti_surfaces(betti_curves, samplings=None,
-                        homology_dimensions=None):
+                        homology_dimensions=None, plotly_params=None):
     """Plot Betti surfaces (Betti numbers against "time" and filtration
     parameter) by homology dimension.
 
@@ -96,6 +114,22 @@ def plot_betti_surfaces(betti_curves, samplings=None,
         For each homology dimension, (filtration parameter) values to be used
         on the x-axis against the corresponding values in `betti_curves` on the
         y-axis.
+
+    plotly_params : dict or None, optional, default: ``None``
+        Custom parameters to configure the plotly figure. Allowed keys are
+        ``"traces"`` and ``"layout"``, and the corresponding values should be
+        dictionaries containing keyword arguments as would be fed to the
+        :meth:`update_traces` and :meth:`update_layout` methods of
+        :class:`plotly.graph_objects.Figure`.
+
+    Returns
+    -------
+    figs/fig : tuple of :class:`plotly.graph_objects.Figure`/\
+        :class:`plotly.graph_objects.Figure` object
+        If ``n_samples > 1``, a tuple of figures representing the Betti
+        surfaces, with one figure per dimension in `homology_dimensions`.
+        Otherwise, a single figure representing the Betti curve of the
+        single sample present.
 
     """
     if homology_dimensions is None:
@@ -124,8 +158,11 @@ def plot_betti_surfaces(betti_curves, samplings=None,
         }
     }
     if betti_curves.shape[0] == 1:
-        plot_betti_curves(betti_curves[0], samplings, homology_dimensions)
+        return plot_betti_curves(
+            betti_curves[0], samplings, homology_dimensions, plotly_params
+        )
     else:
+        figs = []
         for dim in _homology_dimensions:
             fig = gobj.Figure()
             fig.update_layout(scene=scene,
@@ -136,4 +173,11 @@ def plot_betti_surfaces(betti_curves, samplings=None,
                                        z=betti_curves[:, dim],
                                        connectgaps=True, hoverinfo='none'))
 
-            fig.show()
+            # Update trace and layout according to user input
+            if plotly_params:
+                fig.update_traces(plotly_params.get("traces", None))
+                fig.update_layout(plotly_params.get("layout", None))
+
+            figs.append(fig)
+
+        return tuple(figs)

--- a/gtda/plotting/images.py
+++ b/gtda/plotting/images.py
@@ -5,7 +5,7 @@ import plotly.graph_objects as gobj
 
 
 def plot_heatmap(data, x=None, y=None, colorscale='greys', origin='upper',
-                 title=None):
+                 title=None, plotly_params=None):
     """Plot a 2D single-channel image, as a heat map from 2D array data.
 
     Parameters
@@ -31,6 +31,18 @@ def plot_heatmap(data, x=None, y=None, colorscale='greys', origin='upper',
     title : str or None, optional, default: ``None``
         Title of the resulting figure.
 
+    plotly_params : dict or None, optional, default: ``None``
+        Custom parameters to configure the plotly figure. Allowed keys are
+        ``"trace"`` and ``"layout"``, and the corresponding values should be
+        dictionaries containing keyword arguments as would be fed to the
+        :meth:`update_traces` and :meth:`update_layout` methods of
+        :class:`plotly.graph_objects.Figure`.
+
+    Returns
+    -------
+    fig : :class:`plotly.graph_objects.Figure` object
+        Figure representing the 2D single-channel image.
+
     """
     autorange = True if origin == 'lower' else 'reversed'
     layout = dict(
@@ -44,4 +56,9 @@ def plot_heatmap(data, x=None, y=None, colorscale='greys', origin='upper',
         z=data, x=x, y=y, colorscale=colorscale
     ))
 
-    fig.show()
+    # Update trace and layout according to user input
+    if plotly_params:
+        fig.update_traces(plotly_params.get("trace", None))
+        fig.update_layout(plotly_params.get("layout", None))
+
+    return fig

--- a/gtda/plotting/persistence_diagrams.py
+++ b/gtda/plotting/persistence_diagrams.py
@@ -5,7 +5,7 @@ import numpy as np
 import plotly.graph_objs as gobj
 
 
-def plot_diagram(diagram, homology_dimensions=None):
+def plot_diagram(diagram, homology_dimensions=None, plotly_params=None):
     """Plot a single persistence diagram.
 
     Parameters
@@ -19,8 +19,19 @@ def plot_diagram(diagram, homology_dimensions=None):
         Homology dimensions which will appear on the plot. If ``None``, all
         homology dimensions which appear in `diagram` will be plotted.
 
-    """
+    plotly_params : dict or None, optional, default: ``None``
+        Custom parameters to configure the plotly figure. Allowed keys are
+        ``"traces"`` and ``"layout"``, and the corresponding values should be
+        dictionaries containing keyword arguments as would be fed to the
+        :meth:`update_traces` and :meth:`update_layout` methods of
+        :class:`plotly.graph_objects.Figure`.
 
+    Returns
+    -------
+    fig : :class:`plotly.graph_objects.Figure` object
+        Figure representing the persistence diagram.
+
+    """
     # TODO: increase the marker size
     if homology_dimensions is None:
         homology_dimensions = np.unique(diagram[:, 2])
@@ -91,4 +102,9 @@ def plot_diagram(diagram, homology_dimensions=None):
         plot_bgcolor='white'
     )
 
-    fig.show()
+    # Update trace and layout according to user input
+    if plotly_params:
+        fig.update_traces(plotly_params.get("traces", None))
+        fig.update_layout(plotly_params.get("layout", None))
+
+    return fig

--- a/gtda/plotting/point_clouds.py
+++ b/gtda/plotting/point_clouds.py
@@ -5,10 +5,10 @@ import numpy as np
 import plotly.graph_objs as gobj
 
 
-def plot_point_cloud(point_cloud, dimension=None):
+def plot_point_cloud(point_cloud, dimension=None, plotly_params=None):
     """Plot the first 2 or 3 coordinates of a point cloud.
 
-     This function will not work on 1D arrays.
+    Note: this function does not work on 1D arrays.
 
     Parameters
     ----------
@@ -20,6 +20,18 @@ def plot_point_cloud(point_cloud, dimension=None):
         Sets the dimension of the resulting plot. If ``None``, the dimension
         will be chosen between 2 and 3 depending on the shape of `point_cloud`.
 
+    plotly_params : dict or None, optional, default: ``None``
+        Custom parameters to configure the plotly figure. Allowed keys are
+        ``"trace"`` and ``"layout"``, and the corresponding values should be
+        dictionaries containing keyword arguments as would be fed to the
+        :meth:`update_traces` and :meth:`update_layout` methods of
+        :class:`plotly.graph_objects.Figure`.
+
+    Returns
+    -------
+    fig : :class:`plotly.graph_objects.Figure` object
+        Figure representing a point cloud in 2D or 3D.
+
     """
     # TODO: increase the marker size
     if dimension is None:
@@ -30,7 +42,9 @@ def plot_point_cloud(point_cloud, dimension=None):
         raise ValueError("Not enough dimensions available in the input point "
                          "cloud.")
 
-    if dimension == 2:
+    if dimension not in [2, 3]:
+        raise ValueError("The value of the dimension is different from 2 or 3")
+    elif dimension == 2:
         layout = {
             "width": 800,
             "height": 800,
@@ -73,7 +87,6 @@ def plot_point_cloud(point_cloud, dimension=None):
                                                    point_cloud.shape[0])),
                                                colorscale='Viridis',
                                                opacity=0.8)))
-        fig.show()
     elif dimension == 3:
         scene = {
             "xaxis": {
@@ -109,6 +122,9 @@ def plot_point_cloud(point_cloud, dimension=None):
                                                  colorscale='Viridis',
                                                  opacity=0.8)))
 
-        fig.show()
-    else:
-        raise ValueError("The value of the dimension is different from 2 or 3")
+    # Update trace and layout according to user input
+    if plotly_params:
+        fig.update_traces(plotly_params.get("trace", None))
+        fig.update_layout(plotly_params.get("layout", None))
+
+    return fig

--- a/gtda/point_clouds/rescaling.py
+++ b/gtda/point_clouds/rescaling.py
@@ -192,7 +192,7 @@ class ConsistentRescaling(BaseEstimator, TransformerMixin, PlotterMixin):
         return Xt
 
     @staticmethod
-    def plot(Xt, sample=0, colorscale='blues'):
+    def plot(Xt, sample=0, colorscale='blues', plotly_params=None):
         """Plot a sample from a collection of distance matrices.
 
         Parameters
@@ -208,8 +208,17 @@ class ConsistentRescaling(BaseEstimator, TransformerMixin, PlotterMixin):
             Color scale to be used in the heat map. Can be anything allowed by
             :class:`plotly.graph_objects.Heatmap`.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"trace"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
-        return plot_heatmap(Xt[sample], colorscale=colorscale)
+        plot_heatmap(
+            Xt[sample], colorscale=colorscale, plotly_params=plotly_params
+        ).show()
 
 
 @adapt_fit_transform_docs
@@ -371,7 +380,7 @@ class ConsecutiveRescaling(BaseEstimator, TransformerMixin, PlotterMixin):
         return Xt
 
     @staticmethod
-    def plot(Xt, sample=0, colorscale='blues'):
+    def plot(Xt, sample=0, colorscale='blues', plotly_params=None):
         """Plot a sample from a collection of distance matrices.
 
         Parameters
@@ -387,5 +396,14 @@ class ConsecutiveRescaling(BaseEstimator, TransformerMixin, PlotterMixin):
             Color scale to be used in the heat map. Can be anything allowed by
             :class:`plotly.graph_objects.Heatmap`.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"trace"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
-        return plot_heatmap(Xt[sample], colorscale=colorscale)
+        plot_heatmap(
+            Xt[sample], colorscale=colorscale, plotly_params=plotly_params
+        ).show()

--- a/gtda/point_clouds/rescaling.py
+++ b/gtda/point_clouds/rescaling.py
@@ -215,10 +215,15 @@ class ConsistentRescaling(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
-        plot_heatmap(
+        return plot_heatmap(
             Xt[sample], colorscale=colorscale, plotly_params=plotly_params
-        ).show()
+        )
 
 
 @adapt_fit_transform_docs
@@ -403,7 +408,12 @@ class ConsecutiveRescaling(BaseEstimator, TransformerMixin, PlotterMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
-        plot_heatmap(
+        return plot_heatmap(
             Xt[sample], colorscale=colorscale, plotly_params=plotly_params
-        ).show()
+        )

--- a/gtda/time_series/embedding.py
+++ b/gtda/time_series/embedding.py
@@ -199,8 +199,13 @@ class SlidingWindow(BaseEstimator, TransformerResamplerMixin):
             :meth:`update_traces` and :meth:`update_layout` methods of
             :class:`plotly.graph_objects.Figure`.
 
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
         """
-        plot_point_cloud(Xt[sample], plotly_params=plotly_params).show()
+        return plot_point_cloud(Xt[sample], plotly_params=plotly_params)
 
 
 @adapt_fit_transform_docs

--- a/gtda/time_series/embedding.py
+++ b/gtda/time_series/embedding.py
@@ -173,7 +173,7 @@ class SlidingWindow(BaseEstimator, TransformerResamplerMixin):
         return yr
 
     @staticmethod
-    def plot(Xt, sample=0):
+    def plot(Xt, sample=0, plotly_params=None):
         """Plot a sample from a collection of sliding windows, as a point
         cloud in 2D or 3D. If points in the window have more than three
         dimensions, only the first three are plotted.
@@ -192,8 +192,15 @@ class SlidingWindow(BaseEstimator, TransformerResamplerMixin):
         sample : int, optional, default: ``0``
             Index of the sample in `Xt` to be plotted.
 
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"trace"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
         """
-        return plot_point_cloud(Xt[sample])
+        plot_point_cloud(Xt[sample], plotly_params=plotly_params).show()
 
 
 @adapt_fit_transform_docs

--- a/gtda/utils/tests/test_validation.py
+++ b/gtda/utils/tests/test_validation.py
@@ -142,7 +142,7 @@ def test_check_point_clouds_value_err_finite():
 
     # Check that we error on 1d array input
     with pytest.raises(ValueError):
-        check_point_clouds(np.asarray(ex.X_list_tot))
+        check_point_clouds(np.asarray(ex.X_list_tot, dtype=object))
 
     # Check that we error on 2d array input
     with pytest.raises(ValueError):


### PR DESCRIPTION
**Reference issues/PRs**
Addresses #387.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
With the exception of our Mapper plotting functions, all our plotting utilities currently *show* figures automatically without returning them. But it would be more desirable, as has emerged in discussion in #387, to give the user full control of the produced figure by returning it. In this way, the user can freely modify any attribute of the figure or save it to disk. The `transform_plot` and `fit_transform_plot` methods can still show the figure without returning it to preserve the original design of the `PlotterMixin` API, as they are just convenience methods anyway. In this PR:

- All functions in `gtda/plotting` and all `plot` methods return figures and no longer call `.show()` for the user. A notable exception is  `betti_surfaces` which now returns a tuple of figures.
- `transform_plot` and `fit_transform_plot` of `PlotterMixin` behave just as before.
- A `plot_params` kwarg is available throughout to allow user customisability of output figures. The user must pass a dictionary with keys "`layout"` and/or `"trace"` (or `"traces" in some cases`). This was already available in the Mapper plotting functions.

Unrelated to the rest of this refactoring, some long-standing warnings in our tests have also been resolved.

**Any other comments?**
The output of our example jupyter notebooks still needs to be carefully checked to make sure it will be properly rendered on the online docs.

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. I used `pytest` to check this on Python tests.