### PR TITLE
[DOCS] Clarify expected diagram properties to fix #233

### DIFF
--- a/gtda/diagrams/distance.py
+++ b/gtda/diagrams/distance.py
@@ -24,6 +24,9 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
     matrices or a single distance matrix between pairs of diagrams is
     calculated according to the following steps:
 
+    Input collections of persistence diagrams for this transformer must
+    satisfy certain requirements, see e.g. :meth:`fit`.
+
         1. All diagrams are partitioned into subdiagrams corresponding to
            distinct homology dimensions.
         2. Pairwise distances between subdiagrams of equal homology
@@ -146,6 +149,9 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
             Input data. Array of persistence diagrams, each a collection of
             triples [b, d, q] representing persistent topological features
             through their birth (b), death (d) and homology dimension (q).
+            It is important that, for each possible homology dimension, the
+            number of triples for which q equals that homology dimension is
+            constants across the entries of `X`.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -190,6 +196,9 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
             Input data. Array of persistence diagrams, each a collection of
             triples [b, d, q] representing persistent topological features
             through their birth (b), death (d) and homology dimension (q).
+            It is important that, for each possible homology dimension, the
+            number of triples for which q equals that homology dimension is
+            constants across the entries of `X`.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -54,7 +54,7 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
         self.n_jobs = n_jobs
 
     @staticmethod
-    def _persistence_entropy(self, X):
+    def _persistence_entropy(X):
         X_lifespan = X[:, :, 1] - X[:, :, 0]
         X_normalized = X_lifespan / np.sum(X_lifespan, axis=1).reshape(-1, 1)
         return - np.sum(np.nan_to_num(

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -27,6 +27,9 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
     calculated as the (base e) entropies of the collections of differences
     d - b, normalized by the sum of all such differences.
 
+    Input collections of persistence diagrams for this transformer must
+    satisfy certain requirements, see e.g. :meth:`fit`.
+
     Parameters
     ----------
     n_jobs : int or None, optional, default: ``None``
@@ -50,6 +53,7 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
     def __init__(self, n_jobs=None):
         self.n_jobs = n_jobs
 
+    @staticmethod
     def _persistence_entropy(self, X):
         X_lifespan = X[:, :, 1] - X[:, :, 0]
         X_normalized = X_lifespan / np.sum(X_lifespan, axis=1).reshape(-1, 1)
@@ -69,6 +73,9 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
             Input data. Array of persistence diagrams, each a collection of
             triples [b, d, q] representing persistent topological features
             through their birth (b), death (d) and homology dimension (q).
+            It is important that, for each possible homology dimension, the
+            number of triples for which q equals that homology dimension is
+            constants across the entries of `X`.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -95,6 +102,9 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
             Input data. Array of persistence diagrams, each a collection of
             triples [b, d, q] representing persistent topological features
             through their birth (b), death (d) and homology dimension (q).
+            It is important that, for each possible homology dimension, the
+            number of triples for which q equals that homology dimension is
+            constants across the entries of `X`.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -136,6 +146,9 @@ class Amplitude(BaseEstimator, TransformerMixin):
            the :math:`q_i` range over the available homology dimensions.
         3. The final result is either :math:`\\mathbf{a}` itself or
            a norm of :math:`\\mathbf{a}`, specified by the parameter `order`.
+
+    Input collections of persistence diagrams for this transformer must
+    satisfy certain requirements, see e.g. :meth:`fit`.
 
     Parameters
     ----------
@@ -242,6 +255,9 @@ class Amplitude(BaseEstimator, TransformerMixin):
             Input data. Array of persistence diagrams, each a collection of
             triples [b, d, q] representing persistent topological features
             through their birth (b), death (d) and homology dimension (q).
+            It is important that, for each possible homology dimension, the
+            number of triples for which q equals that homology dimension is
+            constants across the entries of X.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -284,6 +300,9 @@ class Amplitude(BaseEstimator, TransformerMixin):
             Input data. Array of persistence diagrams, each a collection of
             triples [b, d, q] representing persistent topological features
             through their birth (b), death (d) and homology dimension (q).
+            It is important that, for each possible homology dimension, the
+            number of triples for which q equals that homology dimension is
+            constants across the entries of X.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline

--- a/gtda/diagrams/preprocessing.py
+++ b/gtda/diagrams/preprocessing.py
@@ -125,6 +125,9 @@ class Scaler(BaseEstimator, TransformerMixin, PlotterMixin):
           two-dimensional array of amplitudes (one per diagram and homology
           dimension) to obtain :attr:`scale_`.
 
+    Input collections of persistence diagrams for this transformer must
+    satisfy certain requirements, see e.g. :meth:`fit`.
+
     Parameters
     ----------
     metric : ``'bottleneck'`` | ``'wasserstein'`` | ``'betti'`` | \
@@ -196,6 +199,9 @@ class Scaler(BaseEstimator, TransformerMixin, PlotterMixin):
             Input data. Array of persistence diagrams, each a collection of
             triples [b, d, q] representing persistent topological features
             through their birth (b), death (d) and homology dimension (q).
+            It is important that, for each possible homology dimension, the
+            number of triples for which q equals that homology dimension is
+            constants across the entries of X.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -244,6 +250,9 @@ class Scaler(BaseEstimator, TransformerMixin, PlotterMixin):
             Input data. Array of persistence diagrams, each a collection of
             triples [b, d, q] representing persistent topological features
             through their birth (b), death (d) and homology dimension (q).
+            It is important that, for each possible homology dimension, the
+            number of triples for which q equals that homology dimension is
+            constants across the entries of X.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -262,13 +271,13 @@ class Scaler(BaseEstimator, TransformerMixin, PlotterMixin):
         return Xs
 
     def inverse_transform(self, X):
-        """Scale back the data to the original representation. Multiplies
-        by the scale found in :meth:`fit`.
+        """Scale back the data to the original representation. Multiplies by
+        the scale found in :meth:`fit`.
 
         Parameters
         ----------
         X : ndarray of shape (n_samples, n_features, 3)
-            Data to apply the inverse transform to.
+            Data to apply the inverse transform to, c.f. :meth:`transform`.
 
         Returns
         -------

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -35,6 +35,9 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
     considered separately, and their respective Betti curves are obtained by
     evenly sampling the :ref:`filtration parameter <filtered_complex>`.
 
+    Input collections of persistence diagrams for this transformer must
+    satisfy certain requirements, see e.g. :meth:`fit`.
+
     Parameters
     ----------
     n_bins : int, optional, default: ``100``
@@ -93,6 +96,9 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
             Input data. Array of persistence diagrams, each a collection of
             triples [b, d, q] representing persistent topological features
             through their birth (b), death (d) and homology dimension (q).
+            It is important that, for each possible homology dimension, the
+            number of triples for which q equals that homology dimension is
+            constants across the entries of X.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -124,6 +130,9 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
             Input data. Array of persistence diagrams, each a collection of
             triples [b, d, q] representing persistent topological features
             through their birth (b), death (d) and homology dimension (q).
+            It is important that, for each possible homology dimension, the
+            number of triples for which q equals that homology dimension is
+            constants across the entries of X.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -238,6 +247,9 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
     landscapes are obtained by evenly sampling the :ref:`filtration parameter
     <filtered_complex>`.
 
+    Input collections of persistence diagrams for this transformer must
+    satisfy certain requirements, see e.g. :meth:`fit`.
+
     Parameters
     ----------
     n_layers : int, optional, default: ``1``
@@ -302,6 +314,9 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
             Input data. Array of persistence diagrams, each a collection of
             triples [b, d, q] representing persistent topological features
             through their birth (b), death (d) and homology dimension (q).
+            It is important that, for each possible homology dimension, the
+            number of triples for which q equals that homology dimension is
+            constants across the entries of X.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -333,6 +348,9 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
             Input data. Array of persistence diagrams, each a collection of
             triples [b, d, q] representing persistent topological features
             through their birth (b), death (d) and homology dimension (q).
+            It is important that, for each possible homology dimension, the
+            number of triples for which q equals that homology dimension is
+            constants across the entries of X.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -462,6 +480,9 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
     diagonal, and the difference between the results of the two convolutions is
     computed. The result can be thought of as a (multi-channel) raster image.
 
+    Input collections of persistence diagrams for this transformer must
+    satisfy certain requirements, see e.g. :meth:`fit`.
+
     Parameters
     ----------
     sigma : float, optional default ``1.``
@@ -534,6 +555,9 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
             Input data. Array of persistence diagrams, each a collection of
             triples [b, d, q] representing persistent topological features
             through their birth (b), death (d) and homology dimension (q).
+            It is important that, for each possible homology dimension, the
+            number of triples for which q equals that homology dimension is
+            constants across the entries of X.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -567,6 +591,9 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
             Input data. Array of persistence diagrams, each a collection of
             triples [b, d, q] representing persistent topological features
             through their birth (b), death (d) and homology dimension (q).
+            It is important that, for each possible homology dimension, the
+            number of triples for which q equals that homology dimension is
+            constants across the entries of X.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -641,6 +668,9 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
     evenly sampled from appropriate ranges of the :ref:`filtration parameter
     <filtered_complex>`. The result can be thought of as a (multi-channel)
     raster image.
+
+    Input collections of persistence diagrams for this transformer must
+    satisfy certain requirements, see e.g. :meth:`fit`.
 
     Parameters
     ----------
@@ -731,6 +761,9 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
             Input data. Array of persistence diagrams, each a collection of
             triples [b, d, q] representing persistent topological features
             through their birth (b), death (d) and homology dimension (q).
+            It is important that, for each possible homology dimension, the
+            number of triples for which q equals that homology dimension is
+            constants across the entries of X.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -771,6 +804,9 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
             Input data. Array of persistence diagrams, each a collection of
             triples [b, d, q] representing persistent topological features
             through their birth (b), death (d) and homology dimension (q).
+            It is important that, for each possible homology dimension, the
+            number of triples for which q equals that homology dimension is
+            constants across the entries of X.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -850,6 +886,9 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
     spaced locations from appropriate ranges of the :ref:`filtration parameter
     <filtered_complex>`.
 
+    Input collections of persistence diagrams for this transformer must
+    satisfy certain requirements, see e.g. :meth:`fit`.
+
     Parameters
     ----------
     power: float, optional, default: ``1.``
@@ -923,6 +962,9 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
             Input data. Array of persistence diagrams, each a collection of
             triples [b, d, q] representing persistent topological features
             through their birth (b), death (d) and homology dimension (q).
+            It is important that, for each possible homology dimension, the
+            number of triples for which q equals that homology dimension is
+            constants across the entries of X.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -954,6 +996,9 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
             Input data. Array of persistence diagrams, each a collection of
             triples [b, d, q] representing persistent topological features
             through their birth (b), death (d) and homology dimension (q).
+            It is important that, for each possible homology dimension, the
+            number of triples for which q equals that homology dimension is
+            constants across the entries of X.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline


### PR DESCRIPTION
**Reference issues/PRs**
Fixes #233.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
As observed in #233, there are implicit assumptions on the input diagrams to the `fit` and `transform` methods of most transformers in `gtda/diagrams`. Most stem from the fact that we call the `_subdiagrams` function which will break unless all sample diagrams in a collection `X`  have the same number of persistence triples in each homology dimension. This PR extends the approach introduced in https://github.com/giotto-ai/giotto-tda/pull/436/commits/9068c9d978d87ad4279a89fc2a9f26bb6ceea1b7 for `Filtering` to all transformers in `gtda/diagrams` with the only exception of `ForgetDimension` (which does not make use of `_subdiagrams`).

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] ~~I have added tests to cover my changes.~~
- [ ] All new and existing tests passed. I used `pytest` to check this on Python tests.