### PR TITLE
Allow plot_heatmap to take boolean arguments

### DIFF
--- a/gtda/plotting/images.py
+++ b/gtda/plotting/images.py
@@ -40,8 +40,6 @@ def plot_heatmap(data, x=None, y=None, colorscale='greys', origin='upper',
         title=title
     )
     fig = gobj.Figure(layout=layout)
-    fig.add_trace(gobj.Heatmap(
-        z=data, x=x, y=y, colorscale=colorscale
-    ))
+    fig.add_trace(gobj.Heatmap(z=data * 1, x=x, y=y, colorscale=colorscale))
 
     fig.show()


### PR DESCRIPTION
**Reference issues/PRs**
Follows observations made in #442.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
A simple multiplication by `1` is used to automatically cast `data` to a numeric dtype. In this way, boolean arrays are allowed in `plot_heatmap`.

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.