### PR TITLE
Refactor igraph.Graph output of Nerve, modify `fit` behaviour of Nerve, add `store_edge_elements` kwarg to Nerve and make_mapper_pipeline, add Nerve and ParallelClustering to docs

### DIFF
--- a/doc/modules/mapper.rst
+++ b/doc/modules/mapper.rst
@@ -43,6 +43,19 @@ Clustering
 
    mapper.FirstSimpleGap
    mapper.FirstHistogramGap
+   mapper.ParallelClustering
+
+Nerve (graph construction)
+--------------------------
+
+.. currentmodule:: gtda
+
+.. autosummary::
+   :toctree: generated/mapper/nerve/
+   :template: class.rst
+
+   mapper.Nerve
+
 
 Pipeline
 --------

--- a/examples/mapper_quickstart.ipynb
+++ b/examples/mapper_quickstart.ipynb
@@ -342,7 +342,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The resulting graph is a [`python-igraph`](https://igraph.org/python/) object that contains metadata that is stored in the form of dictionaries. We can access this data as follows:"
+    "The resulting graph is a [`python-igraph`](https://igraph.org/python/) object which stores node metadata in the form of attributes. We can access this data as follows:"
    ]
   },
   {
@@ -351,14 +351,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "graph[\"node_metadata\"].keys()"
+    "graph.vs.attributes()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here `node_id` is a globally unique node identifier used to construct the graph, while `pullback_set_label` and `partial_cluster_label` refer to the interval and cluster sets described above. The `node_elements` refers to the indices of our original data that belong to each node. For example, to find which points belong to the first node of the graph we can access the desired data as follows:"
+    "Here `'pullback_set_label'` and `'partial_cluster_label'` refer to the interval and cluster sets described above. `'node_elements'` refers to the indices of our original data that belong to each node. For example, to find which points belong to the first node of the graph we can access the desired data as follows:"
    ]
   },
   {
@@ -367,23 +367,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "node_id, node_elements = (\n",
-    "    graph[\"node_metadata\"][\"node_id\"],\n",
-    "    graph[\"node_metadata\"][\"node_elements\"],\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\n",
-    "    \"Node ID: {}, \\nNode elements: {}, \\nData points: {}\".format(\n",
-    "        node_id[0], node_elements[0], data[node_elements[0]]\n",
-    "    )\n",
-    ")"
+    "node_id = 0\n",
+    "node_elements = graph.vs[\"node_elements\"]\n",
+    "\n",
+    "print(f\"\"\"\n",
+    "Node ID: {node_id}\n",
+    "Node elements: {node_elements[node_id]}\n",
+    "Data points: {data[node_elements[node_id]]}\n",
+    "\"\"\")"
    ]
   },
   {

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -75,7 +75,7 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
     """
 
     _hyperparameters = {
-        'n_bins': {'type': int, 'in': Interval(1, np.inf, closed='left')}}
+        "n_bins": {"type": int, "in": Interval(1, np.inf, closed="left")}}
 
     def __init__(self, n_bins=100, n_jobs=None):
         self.n_bins = n_bins
@@ -111,11 +111,11 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
         """
         X = check_diagrams(X)
         validate_params(
-            self.get_params(), self._hyperparameters, exclude=['n_jobs'])
+            self.get_params(), self._hyperparameters, exclude=["n_jobs"])
 
         self.homology_dimensions_ = sorted(list(set(X[0, :, 2])))
         self._n_dimensions = len(self.homology_dimensions_)
-        self._samplings, _ = _bin(X, metric='betti', n_bins=self.n_bins)
+        self._samplings, _ = _bin(X, metric="betti", n_bins=self.n_bins)
         self.samplings_ = {dim: s.flatten()
                            for dim, s in self._samplings.items()}
 
@@ -160,7 +160,7 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
             transpose((1, 0, 2))
         return Xt
 
-    def plot(self, Xt, sample=0, homology_dimensions=None):
+    def plot(self, Xt, sample=0, homology_dimensions=None, plotly_params=None):
         """Plot a sample from a collection of Betti curves arranged as in
         the output of :meth:`transform`. Include homology in multiple
         dimensions.
@@ -176,6 +176,13 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
         homology_dimensions : list, tuple or None, optional, default: ``None``
             Which homology dimensions to include in the plot. ``None`` means
             plotting all dimensions present in :attr:`homology_dimensions_`.
+
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"traces"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
 
         Returns
         -------
@@ -201,31 +208,32 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
                     ix = np.flatnonzero(homology_dimensions_arr == dim)[0]
                     _homology_dimensions.append((ix, dim))
 
-        layout = dict(
-            xaxis1=dict(
-                title="Filtration parameter",
-                side="bottom",
-                type="linear",
-                ticks="outside",
-                anchor="x1",
-                showline=True,
-                zeroline=True,
-                showexponent="all",
-                exponentformat="e"
-            ),
-            yaxis1=dict(
-                title="Betti number",
-                side="left",
-                type="linear",
-                ticks="outside",
-                anchor="y1",
-                showline=True,
-                zeroline=True,
-                showexponent="all",
-                exponentformat="e"
-            ),
-            plot_bgcolor="white"
-        )
+        layout = {
+            "xaxis1": {
+                "title": "Filtration parameter",
+                "side": "bottom",
+                "type": "linear",
+                "ticks": "outside",
+                "anchor": "x1",
+                "showline": True,
+                "zeroline": True,
+                "showexponent": "all",
+                "exponentformat": "e"
+                },
+            "yaxis1": {
+                "title": "Betti number",
+                "side": "left",
+                "type": "linear",
+                "ticks": "outside",
+                "anchor": "y1",
+                "showline": True,
+                "zeroline": True,
+                "showexponent": "all",
+                "exponentformat": "e"
+                },
+            "plot_bgcolor": "white"
+            }
+
         fig = gobj.Figure(layout=layout)
         fig.update_xaxes(zeroline=True, linewidth=1, linecolor="black",
                          mirror=False)
@@ -235,8 +243,13 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
         for ix, dim in _homology_dimensions:
             fig.add_trace(gobj.Scatter(x=self.samplings_[dim],
                                        y=Xt[sample][ix],
-                                       mode='lines', showlegend=True,
+                                       mode="lines", showlegend=True,
                                        name=f"H{int(dim)}"))
+
+        # Update traces and layout according to user input
+        if plotly_params:
+            fig.update_traces(plotly_params.get("traces", None))
+            fig.update_layout(plotly_params.get("layout", None))
 
         return fig
 
@@ -296,8 +309,8 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
     """
 
     _hyperparameters = {
-        'n_bins': {'type': int, 'in': Interval(1, np.inf, closed='left')},
-        'n_layers': {'type': int, 'in': Interval(1, np.inf, closed='left')}}
+        "n_bins": {"type": int, "in": Interval(1, np.inf, closed="left")},
+        "n_layers": {"type": int, "in": Interval(1, np.inf, closed="left")}}
 
     def __init__(self, n_layers=1, n_bins=100, n_jobs=None):
         self.n_layers = n_layers
@@ -334,7 +347,7 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
         """
         X = check_diagrams(X)
         validate_params(
-            self.get_params(), self._hyperparameters, exclude=['n_jobs'])
+            self.get_params(), self._hyperparameters, exclude=["n_jobs"])
 
         self.homology_dimensions_ = sorted(list(set(X[0, :, 2])))
         self._n_dimensions = len(self.homology_dimensions_)
@@ -386,7 +399,7 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
             transpose((1, 0, 2, 3))
         return Xt
 
-    def plot(self, Xt, sample=0, homology_dimensions=None):
+    def plot(self, Xt, sample=0, homology_dimensions=None, plotly_params=None):
         """Plot a sample from a collection of persistence landscapes arranged
         as in the output of :meth:`transform`. Include homology in multiple
         dimensions.
@@ -405,6 +418,13 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
             Homology dimensions for which the landscape should be plotted.
             ``None`` means plotting all dimensions present in
             :attr:`homology_dimensions_`.
+
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"traces"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
 
         Returns
         -------
@@ -430,34 +450,34 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
                     ix = np.flatnonzero(homology_dimensions_arr == dim)[0]
                     _homology_dimensions.append((ix, dim))
 
-        layout = dict(
-            xaxis1=dict(
-                side="bottom",
-                type="linear",
-                ticks="outside",
-                anchor="y1",
-                showline=True,
-                zeroline=True,
-                showexponent="all",
-                exponentformat="e"
-            ),
-            yaxis1=dict(
-                side="left",
-                type="linear",
-                ticks="outside",
-                anchor="x1",
-                showline=True,
-                zeroline=True,
-                showexponent="all",
-                exponentformat="e"
-            ),
-            plot_bgcolor="white"
-        )
+        layout = {
+            "xaxis1": {
+                "side": "bottom",
+                "type": "linear",
+                "ticks": "outside",
+                "anchor": "y1",
+                "showline": True,
+                "zeroline": True,
+                "showexponent": "all",
+                "exponentformat": "e"
+                },
+            "yaxis1": {
+                "side": "left",
+                "type": "linear",
+                "ticks": "outside",
+                "anchor": "x1",
+                "showline": True,
+                "zeroline": True,
+                "showexponent": "all",
+                "exponentformat": "e"
+                },
+            "plot_bgcolor": "white"
+            }
 
         Xt_sample = Xt[sample]
         for ix, dim in _homology_dimensions:
             layout_dim = layout.copy()
-            layout_dim['title'] = "Persistence landscape for homology " + \
+            layout_dim["title"] = "Persistence landscape for homology " + \
                                   "dimension {}".format(int(dim))
             fig = gobj.Figure(layout=layout_dim)
             fig.update_xaxes(zeroline=True, linewidth=1, linecolor="black",
@@ -469,9 +489,14 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
             for layer in range(n_layers):
                 fig.add_trace(gobj.Scatter(x=self.samplings_[dim],
                                            y=Xt_sample[ix, layer],
-                                           mode='lines', showlegend=True,
-                                           hoverinfo='none',
+                                           mode="lines", showlegend=True,
+                                           hoverinfo="none",
                                            name=f"Layer {layer + 1}"))
+
+            # Update traces and layout according to user input
+            if plotly_params:
+                fig.update_traces(plotly_params.get("traces", None))
+                fig.update_layout(plotly_params.get("layout", None))
 
             return fig
 
@@ -542,8 +567,8 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
     """
 
     _hyperparameters = {
-        'n_bins': {'type': int, 'in': Interval(1, np.inf, closed='left')},
-        'sigma': {'type': Real, 'in': Interval(0, np.inf, closed='neither')}}
+        "n_bins": {"type": int, "in": Interval(1, np.inf, closed="left")},
+        "sigma": {"type": Real, "in": Interval(0, np.inf, closed="neither")}}
 
     def __init__(self, sigma=1., n_bins=100, n_jobs=None):
         self.sigma = sigma
@@ -580,12 +605,12 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
         """
         X = check_diagrams(X)
         validate_params(
-            self.get_params(), self._hyperparameters, exclude=['n_jobs'])
+            self.get_params(), self._hyperparameters, exclude=["n_jobs"])
 
         self.homology_dimensions_ = sorted(list(set(X[0, :, 2])))
         self._n_dimensions = len(self.homology_dimensions_)
         self._samplings, self._step_size = _bin(
-            X, metric='heat', n_bins=self.n_bins)
+            X, metric="heat", n_bins=self.n_bins)
         self.samplings_ = {dim: s.flatten()
                            for dim, s in self._samplings.items()}
 
@@ -622,7 +647,7 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
         check_is_fitted(self)
         X = check_diagrams(X, copy=True)
 
-        Xt = Parallel(n_jobs=self.n_jobs, mmap_mode='c')(delayed(
+        Xt = Parallel(n_jobs=self.n_jobs, mmap_mode="c")(delayed(
             heats)(_subdiagrams(X[s], [dim], remove_dim=True),
                    self._samplings[dim], self._step_size[dim], self.sigma)
             for dim in self.homology_dimensions_
@@ -632,7 +657,7 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
             transpose((1, 0, 2, 3))
         return Xt
 
-    def plot(self, Xt, sample=0, homology_dimension_ix=0, colorscale='blues',
+    def plot(self, Xt, sample=0, homology_dimension_ix=0, colorscale="blues",
              plotly_params=None):
         """Plot a single channel – corresponding to a given homology
         dimension – in a sample from a collection of heat kernel images.
@@ -653,7 +678,7 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
             index is i, the plot corresponds to the homology dimension given by
             the i-th entry in :attr:`homology_dimensions_`.
 
-        colorscale : str, optional, default: ``'blues'``
+        colorscale : str, optional, default: ``"blues"``
             Color scale to be used in the heat map. Can be anything allowed by
             :class:`plotly.graph_objects.Heatmap`.
 
@@ -676,7 +701,7 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
             x=self.samplings_[homology_dimension_ix],
             y=self.samplings_[homology_dimension_ix],
             colorscale=colorscale, plotly_params=plotly_params
-        )
+            )
 
 
 @adapt_fit_transform_docs
@@ -760,9 +785,9 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
     """
 
     _hyperparameters = {
-        'n_bins': {'type': int, 'in': Interval(1, np.inf, closed='left')},
-        'sigma': {'type': Real, 'in': Interval(0, np.inf, closed='neither')},
-        'weight_function': {'type': (types.FunctionType, type(None))}}
+        "n_bins": {"type": int, "in": Interval(1, np.inf, closed="left")},
+        "sigma": {"type": Real, "in": Interval(0, np.inf, closed="neither")},
+        "weight_function": {"type": (types.FunctionType, type(None))}}
 
     def __init__(self, sigma=1., n_bins=100, weight_function=None,
                  n_jobs=None):
@@ -801,7 +826,7 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
         """
         X = check_diagrams(X)
         validate_params(
-            self.get_params(), self._hyperparameters, exclude=['n_jobs'])
+            self.get_params(), self._hyperparameters, exclude=["n_jobs"])
 
         if self.weight_function is None:
             self.effective_weight_function_ = identity
@@ -811,7 +836,7 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
         self.homology_dimensions_ = sorted(list(set(X[0, :, 2])))
         self._n_dimensions = len(self.homology_dimensions_)
         self._samplings, self._step_size = _bin(
-            X, metric='persistence_image', n_bins=self.n_bins)
+            X, metric="persistence_image", n_bins=self.n_bins)
         self.samplings_ = {dim: s.transpose()
                            for dim, s in self._samplings.items()}
         self.weights_ = _calculate_weights(X, self.effective_weight_function_,
@@ -850,23 +875,23 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
         check_is_fitted(self)
         X = check_diagrams(X, copy=True)
 
-        Xt = Parallel(n_jobs=self.n_jobs, mmap_mode='c')(
+        Xt = Parallel(n_jobs=self.n_jobs, mmap_mode="c")(
             delayed(persistence_images)(
                 _subdiagrams(X[s], [dim], remove_dim=True),
                 self._samplings[dim],
                 self._step_size[dim],
                 self.weights_[dim],
                 self.sigma
-            )
+                )
             for dim in self.homology_dimensions_
             for s in gen_even_slices(len(X), effective_n_jobs(self.n_jobs))
-        )
+            )
         Xt = np.concatenate(Xt).\
             reshape(self._n_dimensions, len(X), self.n_bins, self.n_bins).\
             transpose((1, 0, 2, 3))
         return Xt
 
-    def plot(self, Xt, sample=0, homology_dimension_ix=0, colorscale='blues',
+    def plot(self, Xt, sample=0, homology_dimension_ix=0, colorscale="blues",
              plotly_params=None):
         """Plot a single channel – corresponding to a given homology
         dimension – in a sample from a collection of persistence images.
@@ -887,7 +912,7 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
             index is i, the plot corresponds to the homology dimension given by
             the i-th entry in :attr:`homology_dimensions_`.
 
-        colorscale : str, optional, default: ``'blues'``
+        colorscale : str, optional, default: ``"blues"``
             Color scale to be used in the heat map. Can be anything allowed by
             :class:`plotly.graph_objects.Heatmap`.
 
@@ -909,7 +934,7 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
         return plot_heatmap(
             Xt[sample][homology_dimension_ix], x=samplings_x, y=samplings_y,
             colorscale=colorscale, plotly_params=plotly_params
-        )
+            )
 
 
 @adapt_fit_transform_docs
@@ -977,8 +1002,8 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
     """
 
     _hyperparameters = {
-        'n_bins': {'type': int, 'in': Interval(1, np.inf, closed='left')},
-        'power': {'type': Real, 'in': Interval(0, np.inf, closed='right')}}
+        "n_bins": {"type": int, "in": Interval(1, np.inf, closed="left")},
+        "power": {"type": Real, "in": Interval(0, np.inf, closed="right")}}
 
     def __init__(self, power=1., n_bins=100, n_jobs=None):
         self.power = power
@@ -1015,11 +1040,11 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
         """
         X = check_diagrams(X)
         validate_params(
-            self.get_params(), self._hyperparameters, exclude=['n_jobs'])
+            self.get_params(), self._hyperparameters, exclude=["n_jobs"])
 
         self.homology_dimensions_ = sorted(list(set(X[0, :, 2])))
         self._n_dimensions = len(self.homology_dimensions_)
-        self._samplings, _ = _bin(X, metric='silhouette', n_bins=self.n_bins)
+        self._samplings, _ = _bin(X, metric="silhouette", n_bins=self.n_bins)
         self.samplings_ = {dim: s.flatten()
                            for dim, s in self._samplings.items()}
 
@@ -1113,30 +1138,31 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
                     ix = np.flatnonzero(homology_dimensions_arr == dim)[0]
                     _homology_dimensions.append((ix, dim))
 
-        layout = dict(
-            xaxis1=dict(
-                title="Filtration parameter",
-                side="bottom",
-                type="linear",
-                ticks="outside",
-                anchor="x1",
-                showline=True,
-                zeroline=True,
-                showexponent="all",
-                exponentformat="e"
-            ),
-            yaxis1=dict(
-                side="left",
-                type="linear",
-                ticks="outside",
-                anchor="y1",
-                showline=True,
-                zeroline=True,
-                showexponent="all",
-                exponentformat="e"
-            ),
-            plot_bgcolor="white"
-        )
+        layout = {
+            "xaxis1": {
+                "title": "Filtration parameter",
+                "side": "bottom",
+                "type": "linear",
+                "ticks": "outside",
+                "anchor": "x1",
+                "showline": True,
+                "zeroline": True,
+                "showexponent": "all",
+                "exponentformat": "e"
+                },
+            "yaxis1": {
+                "side": "left",
+                "type": "linear",
+                "ticks": "outside",
+                "anchor": "y1",
+                "showline": True,
+                "zeroline": True,
+                "showexponent": "all",
+                "exponentformat": "e"
+                },
+            "plot_bgcolor": "white"
+            }
+
         fig = gobj.Figure(layout=layout)
         fig.update_xaxes(zeroline=True, linewidth=1, linecolor="black",
                          mirror=False)
@@ -1150,7 +1176,7 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
                                        hoverinfo="none",
                                        name=f"H{int(dim)}"))
 
-        # Update trace and layout according to user input
+        # Update traces and layout according to user input
         if plotly_params:
             fig.update_traces(plotly_params.get("traces", None))
             fig.update_layout(plotly_params.get("layout", None))

--- a/gtda/images/tests/test_preprocessing.py
+++ b/gtda/images/tests/test_preprocessing.py
@@ -1,4 +1,4 @@
-"""Testing for images preprocessors."""
+"""Testing for image preprocessors."""
 # License: GNU AGPLv3
 
 import numpy as np

--- a/gtda/mapper/__init__.py
+++ b/gtda/mapper/__init__.py
@@ -1,9 +1,10 @@
 """The module :mod:`gtda.mapper` implements the Mapper algorithm for
 topological clustering and visualisation."""
 
-from .cluster import FirstHistogramGap, FirstSimpleGap
+from .cluster import FirstHistogramGap, FirstSimpleGap, ParallelClustering
 from .cover import CubicalCover, OneDimensionalCover
 from .filter import Eccentricity, Entropy, Projection
+from .nerve import Nerve
 from .pipeline import make_mapper_pipeline
 from .utils.decorators import method_to_transform
 from .utils.pipeline import transformer_from_callable_on_rows
@@ -18,6 +19,8 @@ __all__ = [
     'CubicalCover',
     'FirstSimpleGap',
     'FirstHistogramGap',
+    'ParallelClustering',
+    'Nerve',
     'make_mapper_pipeline',
     'plot_static_mapper_graph',
     'plot_interactive_mapper_graph',

--- a/gtda/mapper/cluster.py
+++ b/gtda/mapper/cluster.py
@@ -32,6 +32,8 @@ class ParallelClustering(BaseEstimator):
     location of a portion of ``X_tot`` to cluster separately. Parallelism is
     achieved over the columns of ``masks``.
 
+    This estimator is not intended for direct use.
+
     Parameters
     ----------
     clusterer : object, optional, default: ``None``

--- a/gtda/mapper/cluster.py
+++ b/gtda/mapper/cluster.py
@@ -96,7 +96,7 @@ class ParallelClustering(BaseEstimator):
             self._precomputed = precomputed[0]
         else:
             raise NotImplementedError("Behaviour when metric and affinity "
-                                      "are both set to 'precomputed' not yet"
+                                      "are both set to 'precomputed' not yet "
                                       "implemented by ParallelClustering.")
 
     def fit(self, X, y=None, sample_weight=None):

--- a/gtda/mapper/nerve.py
+++ b/gtda/mapper/nerve.py
@@ -97,7 +97,7 @@ class Nerve(BaseEstimator, TransformerMixin):
             Undirected Mapper graph according to `X` and `min_intersection`.
             Each node is an :class:`igraph.Vertex` object with attributes
             ``"pullback_set_label"``, ``"partial_cluster_label"`` and
-            ``"node_element"'``. Each edge is an :class:`igraph.Edge` object
+            ``"node_elements"'``. Each edge is an :class:`igraph.Edge` object
             with a ``"weight"`` attribute which is equal to the size of the
             intersection between the data subsets associated to its two nodes.
             If `store_edge_elements` is ``True`` each edge also has an
@@ -108,10 +108,15 @@ class Nerve(BaseEstimator, TransformerMixin):
         # Graph construction -- vertices with their metadata
         nodes = reduce(iconcat, X, [])
         graph = ig.Graph(len(nodes))
-        node_attribute_lists = zip(*nodes)
-        graph.vs["pullback_set_label"] = next(node_attribute_lists)
-        graph.vs["partial_cluster_label"] = next(node_attribute_lists)
-        node_elements = next(node_attribute_lists)
+
+        # Since `nodes` is a list, say of length N, of triples of the form
+        # (pullback_set_label, partial_cluster_label, node_elements),
+        # zip(*nodes) generates three tuples of length N, each corresponding to
+        # a type of node attribute.
+        node_attributes = zip(*nodes)
+        graph.vs["pullback_set_label"] = next(node_attributes)
+        graph.vs["partial_cluster_label"] = next(node_attributes)
+        node_elements = next(node_attributes)
         graph.vs["node_elements"] = node_elements
 
         # Graph construction -- edges with weights given by intersection sizes
@@ -134,20 +139,20 @@ class Nerve(BaseEstimator, TransformerMixin):
 
         # Boilerplate is just to avoid boolean checking at each iteration
         if not self.store_edge_elements:
-            for (node_1_ix, node_1_elements), (node_2_ix, node_2_elements) \
+            for (node_1_idx, node_1_elements), (node_2_idx, node_2_elements) \
                     in node_tuples:
                 intersection = np.intersect1d(node_1_elements, node_2_elements)
                 intersection_size = len(intersection)
                 if intersection_size >= self.min_intersection:
-                    node_index_pairs.append((node_1_ix, node_2_ix))
+                    node_index_pairs.append((node_1_idx, node_2_idx))
                     weights.append(intersection_size)
         else:
-            for (node_1_ix, node_1_elements), (node_2_ix, node_2_elements) \
+            for (node_1_idx, node_1_elements), (node_2_idx, node_2_elements) \
                     in node_tuples:
                 intersection = np.intersect1d(node_1_elements, node_2_elements)
                 intersection_size = len(intersection)
                 if intersection_size >= self.min_intersection:
-                    node_index_pairs.append((node_1_ix, node_2_ix))
+                    node_index_pairs.append((node_1_idx, node_2_idx))
                     weights.append(intersection_size)
                     intersections.append(intersection)
 

--- a/gtda/mapper/nerve.py
+++ b/gtda/mapper/nerve.py
@@ -1,4 +1,4 @@
-"""Construct the nerve of a Mapper cover."""
+"""Construct the nerve of a refined Mapper cover."""
 # License: GNU AGPLv3
 
 from functools import reduce
@@ -11,59 +11,49 @@ from sklearn.base import BaseEstimator, TransformerMixin
 
 
 class Nerve(BaseEstimator, TransformerMixin):
-    """One-dimensional skeleton of the nerve of a Mapper cover, i.e. the
-    Mapper graph.
+    """1-skeleton of the nerve of a refined Mapper cover, i.e. the Mapper
+    graph.
 
     This transformer is the final step in the
     :class:`gtda.mapper.pipeline.MapperPipeline` objects created
-    by :func:`gtda.mapper.make_mapper_pipeline`. It is not intended for
-    direct use.
+    by :func:`gtda.mapper.make_mapper_pipeline`. It corresponds the last two
+    arrows in `this diagram <../../../../_images/mapper_pipeline.svg>`_.
+
+    This transformer is not intended for direct use.
 
     Parameters
     ----------
     min_intersection : int, optional, default: ``1``
-        The minimum size of the intersection between Mapper cover sets
-        required to create an edge in the Mapper graph.
+        Minimum size of the intersection, between data subsets associated to
+        any two Mapper nodes, required to create an edge between the nodes in
+        the Mapper graph.
+
+    store_edge_elements : bool, options, default: ``False``
+        Whether the indices of data elements associated to Mapper edges (i.e.
+        in the intersections allowed by `min_intersection`) should be stored in
+        the :class:`igraph.Graph` object output by :meth:`fit_transform`. When
+        ``True``, might lead to a large :class:`igraph.Graph` object.
 
     Attributes
     ----------
-    X_ : list of tuple
-        Nodes of the Mapper graph obtained from the input data for
-        :meth:`fit`. It is a flattened version of the input Mapper cover,
-        with the addition of a globally unique node ID as the first entry in
-        each tuple. Created only when :meth:`fit` is called.
-
-    edges_ : list of dict
-        Edges of the Mapper graph obtained from the input data for
-        :meth:`fit`. Each edge is a dictionary with two keys:
-        ``'node_indices'`` is mapped to a pair of triples characterising the
-        two adjacent nodes; ``'intersection'`` is mapped to the array of
-        indices of points in the intersection between the two nodes. Created
-        only when :meth:`fit` is called.
+    graph_ : :class:`igraph.Graph` object
+        Mapper graph obtained from the input data. Created when :meth:`fit` is
+        called.
 
     """
 
-    def __init__(self, min_intersection=1):
+    def __init__(self, min_intersection=1, store_edge_elements=False):
         self.min_intersection = min_intersection
+        self.store_edge_elements = store_edge_elements
 
     def fit(self, X, y=None):
-        """Compute and store the nodes and edges of the Mapper graph,
-        and return the estimator.
+        """Compute the Mapper graph as in :meth:`fit_transform`, but store the
+        graph as :attr:`graph_` and return the estimator.
 
         Parameters
         ----------
         X : list of list of tuple
-            Input data structure describing an abstract Mapper cover. Each
-            sublist corresponds to a (non-empty) pullback cover set --
-            equivalently, to a cover set in the filter range which has
-            non-empty preimage -- and contains triples of the form ``( \
-            pullback_set_label, partial_cluster_label, indices)`` where
-            ``partial_cluster_label`` is a cluster label within the pullback
-            cover set identified by ``pullback_set_label``, and ``indices``
-            is the array of indices of points belonging to cluster ``( \
-            pullback_set_label, partial_cluster_label)``. In the context of a
-            :class:`gtda.mapper.MapperPipeline`, this is the output of the
-            clustering step.
+            See :meth:`fit_transform`.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -74,27 +64,28 @@ class Nerve(BaseEstimator, TransformerMixin):
         self : object
 
         """
-        # TODO: Include a validation step for X
-        self.X_, self.edges_ = self._graph_data_creation(X)
+        self.graph_ = self.fit_transform(X, y=y)
         return self
 
-    def fit_transform(self, X, y=None, **fit_params):
-        """Construct a Mapper graph from an abstract Mapper cover `X`.
+    def fit_transform(self, X, y=None):
+        """Construct a Mapper graph from a refined Mapper cover.
 
         Parameters
         ----------
         X : list of list of tuple
-            Input data structure describing an abstract Mapper cover. Each
-            sublist corresponds to a (non-empty) pullback cover set --
+            Data structure describing a cover of a dataset (e.g. as depicted in
+            `this diagram <../../../../_images/mapper_pipeline.svg>`_) produced
+            by the clustering step of a :class:`gtda.mapper.MapperPipeline`.
+            Each sublist corresponds to a (non-empty) pullback cover set --
             equivalently, to a cover set in the filter range which has
-            non-empty preimage -- and contains triples of the form ``( \
-            pullback_set_label, partial_cluster_label, indices)`` where
+            non-empty preimage. It contains triples of the form ``(\
+            pullback_set_label, partial_cluster_label, node_elements)`` where
             ``partial_cluster_label`` is a cluster label within the pullback
-            cover set identified by ``pullback_set_label``, and ``indices``
-            is the array of indices of points belonging to cluster ``( \
-            pullback_set_label, partial_cluster_label)``. In the context of a
-            :class:`gtda.mapper.MapperPipeline`, this is the output of the
-            clustering step.
+            cover set identified by ``pullback_set_label``, and
+            ``node_elements`` is an array of integer indices. To each pair
+            ``(pullback_set_label, partial_cluster_label)`` there corresponds
+            a unique node in the output Mapper graph. This node represents
+            the data subset defined by the indices in ``node_elements``.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -103,47 +94,61 @@ class Nerve(BaseEstimator, TransformerMixin):
         Returns
         -------
         graph : :class:`igraph.Graph` object
-            Mapper graph. Edges exist between two Mapper cover sets if and
-            only if the size of the intersection between the two sets is no
-            less than `min_intersection`.
+            Undirected Mapper graph according to `X` and `min_intersection`.
+            Each node is an :class:`igraph.Vertex` object with attributes
+            ``"pullback_set_label"``, ``"partial_cluster_label"`` and
+            ``"node_element"'``. Each edge is an :class:`igraph.Edge` object
+            with a ``"weight"`` attribute which is equal to the size of the
+            intersection between the data subsets associated to its two nodes.
+            If `store_edge_elements` is ``True`` each edge also has an
+            additional attribute ``"edge_elements"``.
 
         """
         # TODO: Include a validation step for X
-        _X, _edges = self._graph_data_creation(X)
+        # Graph construction -- vertices with their metadata
+        nodes = reduce(iconcat, X, [])
+        graph = ig.Graph(len(nodes))
+        node_attribute_lists = zip(*nodes)
+        graph.vs["pullback_set_label"] = next(node_attribute_lists)
+        graph.vs["partial_cluster_label"] = next(node_attribute_lists)
+        node_elements = next(node_attribute_lists)
+        graph.vs["node_elements"] = node_elements
 
-        # Graph construction
-        graph = ig.Graph()
-        graph.add_vertices([vertex[0] for vertex in _X])
-        graph.add_edges([
-            (edge['node_indices'][0][0], edge['node_indices'][1][0])
-            for edge in _edges
-        ])
-        graph['node_metadata'] = dict(
-            zip(['node_id', 'pullback_set_label', 'partial_cluster_label',
-                 'node_elements'],
-                zip(*_X)))
+        # Graph construction -- edges with weights given by intersection sizes
+        node_index_pairs, weights, intersections = \
+            self._generate_edge_data(node_elements)
+        graph.es["weight"] = 1
+        graph.add_edges(node_index_pairs)
+        graph.es["weight"] = weights
+        if self.store_edge_elements:
+            graph.es["edge_elements"] = intersections
+
         return graph
 
-    def _graph_data_creation(self, X):
-        X_ = reduce(iconcat, X, [])
-        # Preprocess X by 1) flattening and 2) extending each tuple
-        X_ = [(node_info[0], *node_info[1])
-              for node_info in zip(range(len(X_)), X_)]
-        edges_ = self._generate_edges(X_)
-        return X_, edges_
+    def _generate_edge_data(self, node_elements):
+        node_tuples = combinations(enumerate(node_elements), 2)
 
-    @staticmethod
-    def _pairwise_intersections(min_intersection, node_pair):
-        data = dict()
-        node_1, node_2 = node_pair
-        data['node_indices'] = tuple((node_1[0:3], node_2[0:3]))
-        data['intersection'] = np.intersect1d(node_1[3], node_2[3])
-        if data['intersection'].size >= min_intersection:
-            yield data
+        node_index_pairs = []
+        weights = []
+        intersections = []
 
-    def _generate_edges(self, nodes):
-        node_tuples = combinations(nodes, 2)
-        for pair in node_tuples:
-            for intersection in \
-             self._pairwise_intersections(self.min_intersection, pair):
-                yield intersection
+        # Boilerplate is just to avoid boolean checking at each iteration
+        if not self.store_edge_elements:
+            for (node_1_ix, node_1_elements), (node_2_ix, node_2_elements) \
+                    in node_tuples:
+                intersection = np.intersect1d(node_1_elements, node_2_elements)
+                intersection_size = len(intersection)
+                if intersection_size >= self.min_intersection:
+                    node_index_pairs.append((node_1_ix, node_2_ix))
+                    weights.append(intersection_size)
+        else:
+            for (node_1_ix, node_1_elements), (node_2_ix, node_2_elements) \
+                    in node_tuples:
+                intersection = np.intersect1d(node_1_elements, node_2_elements)
+                intersection_size = len(intersection)
+                if intersection_size >= self.min_intersection:
+                    node_index_pairs.append((node_1_ix, node_2_ix))
+                    weights.append(intersection_size)
+                    intersections.append(intersection)
+
+        return node_index_pairs, weights, intersections

--- a/gtda/mapper/tests/test_cluster.py
+++ b/gtda/mapper/tests/test_cluster.py
@@ -1,3 +1,6 @@
+"""Testing for FirstHistogramGap and FirstSimpleGap clusterers."""
+# License: GNU AGPLv3
+
 import numpy as np
 from hypothesis import given
 from hypothesis.extra.numpy import arrays

--- a/gtda/mapper/tests/test_cover.py
+++ b/gtda/mapper/tests/test_cover.py
@@ -1,3 +1,6 @@
+"""Testing for OneDimensionalCover and CubicalCover."""
+# License: GNU AGPLv3
+
 import numpy as np
 from hypothesis import given
 from hypothesis.extra.numpy import arrays, array_shapes

--- a/gtda/mapper/tests/test_filter.py
+++ b/gtda/mapper/tests/test_filter.py
@@ -1,3 +1,6 @@
+"""Testing for Mapper filter functions."""
+# License: GNU AGPLv3
+
 import warnings
 
 import numpy as np

--- a/gtda/mapper/tests/test_nerve.py
+++ b/gtda/mapper/tests/test_nerve.py
@@ -42,10 +42,10 @@ def test_edge_elements(X):
     # TODO: Improve the Hypothesis strategy to avoid needing to hardcode the
     # min_side to be greater than n_intervals (10 by default).
     pipe = make_mapper_pipeline()
-    pipe_store_edge_elems = make_mapper_pipeline(store_edge_elements=True)
+    pipe_edge_elems = make_mapper_pipeline(store_edge_elements=True)
 
     graph = pipe.fit_transform(X)
-    graph_ee = pipe_store_edge_elems.fit_transform(X)
+    graph_edge_elems = pipe_edge_elems.fit_transform(X)
 
     # Check that when store_edge_elements=False (default) there is no
     # "edge_elements" attribute.
@@ -54,29 +54,29 @@ def test_edge_elements(X):
 
     # Check that graph and graph_ee agree otherwise
     # Vertices
-    assert graph.vs.indices == graph_ee.vs.indices
+    assert graph.vs.indices == graph_edge_elems.vs.indices
     for attr_name in ["pullback_set_label", "partial_cluster_label"]:
-        assert graph.vs[attr_name] == graph_ee.vs[attr_name]
+        assert graph.vs[attr_name] == graph_edge_elems.vs[attr_name]
     node_elements = graph.vs["node_elements"]
-    node_elements_ee = graph_ee.vs["node_elements"]
+    node_elements_ee = graph_edge_elems.vs["node_elements"]
     assert all([
         np.array_equal(node, node_ee)
         for node, node_ee in zip(node_elements, node_elements_ee)
     ])
-    assert graph.vs.indices == graph_ee.vs.indices
+    assert graph.vs.indices == graph_edge_elems.vs.indices
     # Edges
-    assert graph.es.indices == graph_ee.es.indices
-    assert graph.es["weight"] == graph_ee.es["weight"]
+    assert graph.es.indices == graph_edge_elems.es.indices
+    assert graph.es["weight"] == graph_edge_elems.es["weight"]
     assert all([
         edge.tuple == edge_ee.tuple
-        for edge, edge_ee in zip(graph.es, graph_ee.es)
+        for edge, edge_ee in zip(graph.es, graph_edge_elems.es)
     ])
 
     # Check that the arrays edge_elements contain precisely those indices which
     # are in the element sets associated to both the first and second vertex,
     # and that the edge weight equals the size of edge_elements.
     flag = True
-    for edge in graph_ee.es:
+    for edge in graph_edge_elems.es:
         v1, v2 = edge.vertex_tuple
         flag *= np.array_equal(
             edge["edge_elements"],

--- a/gtda/mapper/tests/test_nerve.py
+++ b/gtda/mapper/tests/test_nerve.py
@@ -1,3 +1,6 @@
+"""Testing for Nerve (Mapper graph construction)."""
+# License: GNU AGPLv3
+
 import numpy as np
 import pytest
 from hypothesis import given

--- a/gtda/mapper/tests/test_nerve.py
+++ b/gtda/mapper/tests/test_nerve.py
@@ -22,9 +22,8 @@ def test_node_intersection(X):
     # Check if the elements of nodes defining an edge are disjoint or not:
     # If True, they are disjoint, i.e. the created edge is incorrect.
     # If all are False, all edges are correct.
-    disjoint_nodes = [set(graph['node_metadata']['node_elements'][node_1])
-                      .isdisjoint(graph['node_metadata']['node_elements']
-                                  [node_2])
+    disjoint_nodes = [set(graph.vs['node_elements'][node_1])
+                      .isdisjoint(graph.vs['node_elements'][node_2])
                       for node_1, node_2 in graph.get_edgelist()]
 
     # Check if there is a disjoint node pair given by an edge.

--- a/gtda/mapper/tests/test_nerve.py
+++ b/gtda/mapper/tests/test_nerve.py
@@ -1,7 +1,9 @@
 import numpy as np
+import pytest
 from hypothesis import given
 from hypothesis.extra.numpy import arrays, array_shapes
 from hypothesis.strategies import floats
+
 from gtda.mapper.pipeline import make_mapper_pipeline
 
 
@@ -9,8 +11,7 @@ from gtda.mapper.pipeline import make_mapper_pipeline
                 elements=floats(allow_nan=False,
                                 allow_infinity=False,
                                 min_value=-1e10,
-                                max_value=1e10
-                                ),
+                                max_value=1e10),
                 shape=array_shapes(min_dims=2, max_dims=2, min_side=11)))
 def test_node_intersection(X):
     # TODO: Replace pipe and graph by Nerve transformer
@@ -28,3 +29,76 @@ def test_node_intersection(X):
 
     # Check if there is a disjoint node pair given by an edge.
     assert not any(disjoint_nodes)
+
+
+@given(X=arrays(dtype=np.float, unique=True,
+                elements=floats(allow_nan=False,
+                                allow_infinity=False,
+                                min_value=-1e10,
+                                max_value=1e10),
+                shape=array_shapes(min_dims=2, max_dims=2, min_side=11)))
+def test_edge_elements(X):
+    # TODO: Replace pipe and graph by Nerve transformer
+    # TODO: Improve the Hypothesis strategy to avoid needing to hardcode the
+    # min_side to be greater than n_intervals (10 by default).
+    pipe = make_mapper_pipeline()
+    pipe_store_edge_elems = make_mapper_pipeline(store_edge_elements=True)
+
+    graph = pipe.fit_transform(X)
+    graph_ee = pipe_store_edge_elems.fit_transform(X)
+
+    # Check that when store_edge_elements=False (default) there is no
+    # "edge_elements" attribute.
+    with pytest.raises(KeyError):
+        _ = graph.es["edge_elements"]
+
+    # Check that graph and graph_ee agree otherwise
+    # Vertices
+    assert graph.vs.indices == graph_ee.vs.indices
+    for attr_name in ["pullback_set_label", "partial_cluster_label"]:
+        assert graph.vs[attr_name] == graph_ee.vs[attr_name]
+    node_elements = graph.vs["node_elements"]
+    node_elements_ee = graph_ee.vs["node_elements"]
+    assert all([
+        np.array_equal(node, node_ee)
+        for node, node_ee in zip(node_elements, node_elements_ee)
+    ])
+    assert graph.vs.indices == graph_ee.vs.indices
+    # Edges
+    assert graph.es.indices == graph_ee.es.indices
+    assert graph.es["weight"] == graph_ee.es["weight"]
+    assert all([
+        edge.tuple == edge_ee.tuple
+        for edge, edge_ee in zip(graph.es, graph_ee.es)
+    ])
+
+    # Check that the arrays edge_elements contain precisely those indices which
+    # are in the element sets associated to both the first and second vertex,
+    # and that the edge weight equals the size of edge_elements.
+    flag = True
+    for edge in graph_ee.es:
+        v1, v2 = edge.vertex_tuple
+        flag *= np.array_equal(
+            edge["edge_elements"],
+            np.intersect1d(v1["node_elements"], v2["node_elements"]),
+        )
+        flag *= len(edge["edge_elements"]) == edge["weight"]
+    assert flag
+
+
+@pytest.mark.parametrize("min_intersection", [1, 2, 3, 10])
+@given(X=arrays(dtype=np.float, unique=True,
+                elements=floats(allow_nan=False,
+                                allow_infinity=False,
+                                min_value=-1e10,
+                                max_value=1e10),
+                shape=array_shapes(min_dims=2, max_dims=2, min_side=11)))
+def test_min_intersection(X, min_intersection):
+    # TODO: Replace pipe and graph by Nerve transformer
+    # TODO: Improve the Hypothesis strategy to avoid needing to hardcode the
+    # min_side to be greater than n_intervals (10 by default).
+    pipe = make_mapper_pipeline(min_intersection=min_intersection)
+    graph = pipe.fit_transform(X)
+
+    # Check that there are no edges with weight less than min_intersection
+    assert all([x >= min_intersection for x in graph.es["weight"]])

--- a/gtda/mapper/tests/test_visualization.py
+++ b/gtda/mapper/tests/test_visualization.py
@@ -1,13 +1,14 @@
-import plotly.io as pio
-import numpy as np
 import warnings
-
 from unittest import TestCase
 
+import numpy as np
+import plotly.io as pio
+import pytest
+
+from gtda.mapper import FirstSimpleGap
 from gtda.mapper import make_mapper_pipeline
 from gtda.mapper import (plot_interactive_mapper_graph,
                          plot_static_mapper_graph)
-from gtda.mapper import FirstSimpleGap
 
 
 class TestCaseNoTemplate(TestCase):
@@ -42,6 +43,35 @@ colors = np.array([8., 8., 3., 8., 0., 8., 8., 8., 5.,
                    8., 8., 8., 8., 4., 2., 8., 1., 8., 2., 8.])
 
 
+@pytest.mark.parametrize("layout_dim", [2, 3])
+def test_valid_layout_dim(layout_dim):
+    pipe = make_mapper_pipeline()
+    fig = plot_static_mapper_graph(pipe, X, layout_dim=layout_dim)
+    edge_trace = fig.get_state()['_data'][0]
+    assert 'x' in edge_trace.keys()
+    assert 'y' in edge_trace.keys()
+    is_z_present = 'z' in edge_trace.keys()
+    assert is_z_present if layout_dim == 3 else not is_z_present
+
+
+@pytest.mark.parametrize("layout_dim", [1, 4])
+def test_invalid_layout_dim(layout_dim):
+    with pytest.raises(ValueError):
+        pipe = make_mapper_pipeline()
+        _ = plot_static_mapper_graph(pipe, X, layout_dim=layout_dim)
+
+
+def test_invalid_layout_algorithm():
+    with pytest.raises(KeyError):
+        pipe = make_mapper_pipeline()
+        _ = plot_static_mapper_graph(pipe, X, layout="inexistent_layout")
+
+
+def _get_size_from_hovertext(s):
+    size_str = s.split("<br>")[3].split(": ")[1]
+    return int(size_str)
+
+
 class TestStaticPlot(TestCaseNoTemplate):
 
     def test_is_data_present(self):
@@ -64,21 +94,18 @@ class TestStaticPlot(TestCaseNoTemplate):
         assert len(fig_colors) == num_nodes
 
 
+def _get_widget_by_trait(fig, key, val=None):
+    for k, v in fig.widgets.items():
+        try:
+            b = getattr(v, key) == val if val is not None \
+                else getattr(v, key)
+            if b:
+                return fig.widgets[k]
+        except (AttributeError, TypeError):
+            pass
+
+
 class TestInteractivePlot(TestCaseNoTemplate):
-
-    def _get_widget_by_trait(self, fig, key, val=None):
-        for k, v in fig.widgets.items():
-            try:
-                b = getattr(v, key) == val if val is not None \
-                    else getattr(v, key)
-                if b:
-                    return fig.widgets[k]
-            except (AttributeError, TypeError):
-                pass
-
-    def _get_size_from_hovertext(self, s):
-        size_str = s.split("<br>")[3].split(": ")[1]
-        return int(size_str)
 
     def test_cluster_sizes(self):
         """Verify that the total number of calculated clusters is equal to
@@ -86,11 +113,12 @@ class TestInteractivePlot(TestCaseNoTemplate):
         pipe = make_mapper_pipeline(clusterer=FirstSimpleGap())
         warnings.simplefilter("ignore")
         fig = plot_interactive_mapper_graph(pipe, X)
-        w_scatter = self._get_widget_by_trait(fig, 'data')
+        w_scatter = _get_widget_by_trait(fig, 'data')
 
-        node_sizes_vis = [self._get_size_from_hovertext(s_)
-                          for s_ in w_scatter.get_state()
-                          ['_data'][1]['hovertext']]
+        node_sizes_vis = [
+            _get_size_from_hovertext(s_)
+            for s_ in w_scatter.get_state()['_data'][1]['hovertext']
+        ]
 
         g = pipe.fit_transform(X)
         node_size_real = [len(node) for node in g.vs['node_elements']]

--- a/gtda/mapper/tests/test_visualization.py
+++ b/gtda/mapper/tests/test_visualization.py
@@ -39,8 +39,24 @@ X = np.array([[-19.33965799, -284.58638371],
               [-155.54055842, -214.420498],
               [184.6940872,    2.08810678],
               [-184.42012962,   28.8978038]])
+
 colors = np.array([8., 8., 3., 8., 0., 8., 8., 8., 5.,
                    8., 8., 8., 8., 4., 2., 8., 1., 8., 2., 8.])
+
+viridis_colorscale = [[0.0, '#440154'],
+                      [0.1111111111111111, '#482878'],
+                      [0.2222222222222222, '#3e4989'],
+                      [0.3333333333333333, '#31688e'],
+                      [0.4444444444444444, '#26828e'],
+                      [0.5555555555555556, '#1f9e89'],
+                      [0.6666666666666666, '#35b779'],
+                      [0.7777777777777778, '#6ece58'],
+                      [0.8888888888888888, '#b5de2b'],
+                      [1.0, '#fde725']]
+
+hsl_colorscale = ['hsl(19.0, 96.0%, 67.0%)',
+                  'hsl(60.0, 100.0%, 87.0%)',
+                  'hsl(203.0, 51.0%, 71.0%)']
 
 
 @pytest.mark.parametrize("layout_dim", [2, 3])
@@ -64,7 +80,53 @@ def test_invalid_layout_dim(layout_dim):
 def test_invalid_layout_algorithm():
     with pytest.raises(KeyError):
         pipe = make_mapper_pipeline()
-        _ = plot_static_mapper_graph(pipe, X, layout="inexistent_layout")
+        _ = plot_static_mapper_graph(pipe, X, layout="foobar")
+
+
+@pytest.mark.parametrize("layout_dim", [2, 3])
+def test_valid_hoverlabel_bgcolor(layout_dim):
+    pipe = make_mapper_pipeline()
+    fig = plot_static_mapper_graph(
+        pipe, X, layout_dim=layout_dim,
+        plotly_params={"node_trace": {"hoverlabel_bgcolor": "white"}}
+    )
+    assert fig.get_state()["_data"][1]["hoverlabel"]["bgcolor"] == "white"
+
+
+def test_unsuitable_colorscale_for_hoverlabel_3d():
+    pipe = make_mapper_pipeline()
+    with pytest.warns(RuntimeWarning):
+        _ = plot_static_mapper_graph(
+            pipe, X, layout_dim=3,
+            plotly_params={"node_trace": {"marker_colorscale": hsl_colorscale}}
+        )
+
+
+def test_valid_colorscale():
+    pipe = make_mapper_pipeline()
+
+    fig = plot_static_mapper_graph(
+        pipe, X, layout_dim=2,
+        plotly_params={"node_trace": {"marker_colorscale": "blues"}}
+    )
+    fig_3d = plot_static_mapper_graph(
+        pipe, X, layout_dim=3,
+        plotly_params={"node_trace": {"marker_colorscale": "blues"}}
+    )
+
+    # Test that the custom colorscale is correctly applied both in 2d and in 3d
+    marker_colorscale = fig.get_state()["_data"][1]["marker"]["colorscale"]
+    marker_colorscale_3d = \
+        fig_3d.get_state()["_data"][1]["marker"]["colorscale"]
+    assert marker_colorscale == marker_colorscale_3d
+
+    # Test that the default colorscale "viridis" and that the custom one is
+    # different
+    fig_default = plot_static_mapper_graph(pipe, X)
+    marker_colorscale_default = \
+        fig_default.get_state()["_data"][1]["marker"]["colorscale"]
+    assert marker_colorscale_default == viridis_colorscale
+    assert marker_colorscale != marker_colorscale_default
 
 
 def _get_size_from_hovertext(s):

--- a/gtda/mapper/tests/test_visualization.py
+++ b/gtda/mapper/tests/test_visualization.py
@@ -1,3 +1,6 @@
+"""Testing for Mapper plotting functions."""
+# License: GNU AGPLv3
+
 import warnings
 from unittest import TestCase
 

--- a/gtda/mapper/tests/test_visualization.py
+++ b/gtda/mapper/tests/test_visualization.py
@@ -120,7 +120,7 @@ def test_valid_colorscale():
         fig_3d.get_state()["_data"][1]["marker"]["colorscale"]
     assert marker_colorscale == marker_colorscale_3d
 
-    # Test that the default colorscale "viridis" and that the custom one is
+    # Test that the default colorscale is "viridis" and that the custom one is
     # different
     fig_default = plot_static_mapper_graph(pipe, X)
     marker_colorscale_default = \

--- a/gtda/mapper/tests/test_visualization.py
+++ b/gtda/mapper/tests/test_visualization.py
@@ -93,7 +93,6 @@ class TestInteractivePlot(TestCaseNoTemplate):
                           ['_data'][1]['hovertext']]
 
         g = pipe.fit_transform(X)
-        node_size_real = [len(node)
-                          for node in g['node_metadata']['node_elements']]
+        node_size_real = [len(node) for node in g.vs['node_elements']]
 
         assert sum(node_sizes_vis) == sum(node_size_real)

--- a/gtda/mapper/tests/test_visualization.py
+++ b/gtda/mapper/tests/test_visualization.py
@@ -19,40 +19,21 @@ class TestCaseNoTemplate(TestCase):
         pio.templates.default = "plotly"
 
 
-X = np.array([[-19.33965799, -284.58638371],
-              [-290.25710696,  184.31095197],
-              [250.38108853,  134.5112574],
-              [-259.46357187, -172.12937543],
-              [115.72180479,  -69.67624071],
-              [120.12187185,  248.39783826],
-              [234.08476944,  115.54743986],
-              [246.68634685,  119.170029],
-              [-154.27214561, -272.07656956],
-              [225.37435664,  186.3253872],
-              [54.17543392,   76.4066916],
-              [175.28163213, -193.46279193],
-              [228.63910018, -121.16687597],
-              [-101.58902866,   48.86471748],
-              [-185.23421146,  244.14414753],
-              [-275.05799067, -204.99265911],
-              [-170.12180583,  176.10258455],
-              [-155.54055842, -214.420498],
-              [184.6940872,    2.08810678],
-              [-184.42012962,   28.8978038]])
+N = 50
+d = 3
+X = np.random.randn(N, d)
+colors = np.random.randint(0, 10, N)
 
-colors = np.array([8., 8., 3., 8., 0., 8., 8., 8., 5.,
-                   8., 8., 8., 8., 4., 2., 8., 1., 8., 2., 8.])
-
-viridis_colorscale = [[0.0, '#440154'],
-                      [0.1111111111111111, '#482878'],
-                      [0.2222222222222222, '#3e4989'],
-                      [0.3333333333333333, '#31688e'],
-                      [0.4444444444444444, '#26828e'],
-                      [0.5555555555555556, '#1f9e89'],
-                      [0.6666666666666666, '#35b779'],
-                      [0.7777777777777778, '#6ece58'],
-                      [0.8888888888888888, '#b5de2b'],
-                      [1.0, '#fde725']]
+viridis_colorscale = ((0.0, '#440154'),
+                      (0.1111111111111111, '#482878'),
+                      (0.2222222222222222, '#3e4989'),
+                      (0.3333333333333333, '#31688e'),
+                      (0.4444444444444444, '#26828e'),
+                      (0.5555555555555556, '#1f9e89'),
+                      (0.6666666666666666, '#35b779'),
+                      (0.7777777777777778, '#6ece58'),
+                      (0.8888888888888888, '#b5de2b'),
+                      (1.0, '#fde725'))
 
 hsl_colorscale = ['hsl(19.0, 96.0%, 67.0%)',
                   'hsl(60.0, 100.0%, 87.0%)',
@@ -63,10 +44,9 @@ hsl_colorscale = ['hsl(19.0, 96.0%, 67.0%)',
 def test_valid_layout_dim(layout_dim):
     pipe = make_mapper_pipeline()
     fig = plot_static_mapper_graph(pipe, X, layout_dim=layout_dim)
-    edge_trace = fig.get_state()['_data'][0]
-    assert 'x' in edge_trace.keys()
-    assert 'y' in edge_trace.keys()
-    is_z_present = 'z' in edge_trace.keys()
+    edge_trace = fig.data[0]
+    assert hasattr(edge_trace, "x") and hasattr(edge_trace, "y")
+    is_z_present = hasattr(edge_trace, "z")
     assert is_z_present if layout_dim == 3 else not is_z_present
 
 
@@ -90,7 +70,7 @@ def test_valid_hoverlabel_bgcolor(layout_dim):
         pipe, X, layout_dim=layout_dim,
         plotly_params={"node_trace": {"hoverlabel_bgcolor": "white"}}
     )
-    assert fig.get_state()["_data"][1]["hoverlabel"]["bgcolor"] == "white"
+    assert fig.data[1]["hoverlabel"]["bgcolor"] == "white"
 
 
 def test_unsuitable_colorscale_for_hoverlabel_3d():
@@ -105,7 +85,7 @@ def test_unsuitable_colorscale_for_hoverlabel_3d():
 def test_valid_colorscale():
     pipe = make_mapper_pipeline()
 
-    fig = plot_static_mapper_graph(
+    fig_2d = plot_static_mapper_graph(
         pipe, X, layout_dim=2,
         plotly_params={"node_trace": {"marker_colorscale": "blues"}}
     )
@@ -115,18 +95,51 @@ def test_valid_colorscale():
     )
 
     # Test that the custom colorscale is correctly applied both in 2d and in 3d
-    marker_colorscale = fig.get_state()["_data"][1]["marker"]["colorscale"]
-    marker_colorscale_3d = \
-        fig_3d.get_state()["_data"][1]["marker"]["colorscale"]
+    marker_colorscale = fig_2d.data[1]["marker"]["colorscale"]
+    marker_colorscale_3d = fig_3d.data[1]["marker"]["colorscale"]
     assert marker_colorscale == marker_colorscale_3d
 
     # Test that the default colorscale is "viridis" and that the custom one is
     # different
     fig_default = plot_static_mapper_graph(pipe, X)
     marker_colorscale_default = \
-        fig_default.get_state()["_data"][1]["marker"]["colorscale"]
+        fig_default.data[1]["marker"]["colorscale"]
     assert marker_colorscale_default == viridis_colorscale
     assert marker_colorscale != marker_colorscale_default
+
+
+@pytest.mark.parametrize("color_variable", [None, colors])
+@pytest.mark.parametrize("node_color_statistic", [None, np.max])
+def test_colors_same_2d_3d(color_variable, node_color_statistic):
+    pipe = make_mapper_pipeline()
+    fig_2d = plot_static_mapper_graph(
+        pipe, X, layout_dim=2, color_variable=color_variable,
+        node_color_statistic=node_color_statistic
+    )
+    fig_3d = plot_static_mapper_graph(
+        pipe, X, layout_dim=3, color_variable=color_variable,
+        node_color_statistic=node_color_statistic
+    )
+    assert fig_2d.data[1].marker.color == fig_3d.data[1].marker.color
+
+
+@pytest.mark.parametrize("layout_dim", [2, 3])
+def test_color_by_column_dropdown_2d(layout_dim):
+    pipe = make_mapper_pipeline()
+    fig = plot_static_mapper_graph(
+        pipe, X, layout_dim=layout_dim, color_by_columns_dropdown=True
+    )
+    fig_buttons = fig.layout.updatemenus[0].buttons
+
+    assert list(fig.data[1].marker.color) == \
+           list(fig_buttons[0].args[0]["marker.color"][1])
+
+    for i in range(X.shape[1]):
+        fig_col_i = plot_static_mapper_graph(
+            pipe, X, layout_dim=layout_dim, color_variable=i
+        )
+        assert list(fig_col_i.data[1].marker.color) == \
+            list(fig_buttons[i + 1].args[0]["marker.color"][1])
 
 
 def _get_size_from_hovertext(s):
@@ -144,15 +157,15 @@ class TestStaticPlot(TestCaseNoTemplate):
         fig = plot_static_mapper_graph(pipe, X,
                                        color_variable=colors,
                                        clone_pipeline=False)
-        node_trace_x = fig.get_state()['_data'][1]["x"]
-        node_trace_y = fig.get_state()['_data'][1]["y"]
+        node_trace_x = fig.data[1].x
+        node_trace_y = fig.data[1].y
 
-        assert node_trace_x["shape"][0] == node_trace_y["shape"][0]
+        assert node_trace_x.shape[0] == node_trace_y.shape[0]
 
-        num_nodes = node_trace_x["shape"][0]
+        num_nodes = node_trace_x.shape[0]
         assert len(X) >= num_nodes
 
-        fig_colors = fig.get_state()['_data'][1]['marker']['color']
+        fig_colors = fig.data[1].marker.color
         assert len(fig_colors) == num_nodes
 
 
@@ -179,7 +192,7 @@ class TestInteractivePlot(TestCaseNoTemplate):
 
         node_sizes_vis = [
             _get_size_from_hovertext(s_)
-            for s_ in w_scatter.get_state()['_data'][1]['hovertext']
+            for s_ in w_scatter.data[1].hovertext
         ]
 
         g = pipe.fit_transform(X)

--- a/gtda/mapper/utils/_visualization.py
+++ b/gtda/mapper/utils/_visualization.py
@@ -278,20 +278,11 @@ def _calculate_graph_data(
     )
 
     # Compute graph layout
-    is_layout_ndarray = hasattr(layout, "dtype")
-    if is_layout_ndarray:
-        if layout.shape[1] not in [2, 3]:
-            raise ValueError(
-                f"If an ndarray, `layout` must be 2D with 2 or 3 columns. "
-                f"Array with {layout.shape[1]} columns passed."
-            )
-        node_pos = layout
-    else:
-        if layout_dim not in [2, 3]:
-            raise ValueError(
-                f"`layout_dim` must be either 2 or 3. {layout_dim} entered."
-            )
-        node_pos = np.asarray(graph.layout(layout, dim=layout_dim).coords)
+    if layout_dim not in [2, 3]:
+        raise ValueError(
+            f"`layout_dim` must be either 2 or 3. {layout_dim} entered."
+        )
+    node_pos = np.asarray(graph.layout(layout, dim=layout_dim).coords)
 
     # Store x and y coordinates of edge endpoints
     edge_x = list(

--- a/gtda/mapper/utils/_visualization.py
+++ b/gtda/mapper/utils/_visualization.py
@@ -1,7 +1,7 @@
 """Graph layout functions and plotly layout functions."""
 # License: GNU AGPLv3
 
-import operator
+from operator import iconcat
 from copy import deepcopy
 from functools import reduce, partial
 
@@ -232,7 +232,7 @@ def _calculate_graph_data(
         node_color_statistic, n_sig_figs, node_scale
 ):
     graph = pipeline.fit_transform(data)
-    node_elements = graph["node_metadata"]["node_elements"]
+    node_elements = graph.vs["node_elements"]
 
     # Determine whether node_color_statistic is an array of node colors
     is_node_color_statistic_ndarray = hasattr(node_color_statistic, "dtype")
@@ -265,10 +265,10 @@ def _calculate_graph_data(
     })
 
     # Generate hovertext
-    node_ids = graph["node_metadata"]["node_id"]
-    pullback_set_ids = graph["node_metadata"]["pullback_set_label"]
-    partial_cluster_labels = graph["node_metadata"]["partial_cluster_label"]
-    num_node_elements = map(len, graph["node_metadata"]["node_elements"])
+    node_ids = graph.vs.indices
+    pullback_set_ids = graph.vs["pullback_set_label"]
+    partial_cluster_labels = graph.vs["partial_cluster_label"]
+    num_node_elements = map(len, graph.vs["node_elements"])
     node_colors_round = map(
         partial(_round_to_n_sig_figs, n=n_sig_figs), node_colors_color_variable
     )
@@ -296,7 +296,7 @@ def _calculate_graph_data(
     # Store x and y coordinates of edge endpoints
     edge_x = list(
         reduce(
-            operator.iconcat, map(
+            iconcat, map(
                 lambda e: [node_pos[e.source, 0], node_pos[e.target, 0],
                            None],
                 graph.es
@@ -305,7 +305,7 @@ def _calculate_graph_data(
     )
     edge_y = list(
         reduce(
-            operator.iconcat, map(
+            iconcat, map(
                 lambda e: [node_pos[e.source, 1], node_pos[e.target, 1],
                            None],
                 graph.es
@@ -330,7 +330,7 @@ def _calculate_graph_data(
 
         edge_z = list(
             reduce(
-                operator.iconcat, map(
+                iconcat, map(
                     lambda e: [node_pos[e.source][2], node_pos[e.target][2],
                                None],
                     graph.es

--- a/gtda/mapper/visualization.py
+++ b/gtda/mapper/visualization.py
@@ -222,11 +222,13 @@ def plot_static_mapper_graph(
                 if e.args[0] == "This colorscale is not supported.":
                     warn("Data-dependent background hoverlabel colors cannot "
                          "be generated with this choice of colorscale. Please "
-                         "use a standard hex- or RGB-formatted colorscale.")
+                         "use a standard hex- or RGB-formatted colorscale.",
+                         RuntimeWarning)
                 else:
                     warn("Something went wrong in generating data-dependent "
                          "background hoverlabel colors. All background "
-                         "hoverlabel colors will be set to white.")
+                         "hoverlabel colors will be set to white.",
+                         RuntimeWarning)
                 hoverlabel_bgcolor = "white"
                 colorscale_for_hoverlabel = None
             fig.update_traces(

--- a/gtda/mapper/visualization.py
+++ b/gtda/mapper/visualization.py
@@ -131,12 +131,20 @@ def plot_static_mapper_graph(
     Setting a colorscale different from the default one:
 
     >>> import numpy as np
+    >>> np.random.seed(1)
     >>> from gtda.mapper import make_mapper_pipeline, plot_static_mapper_graph
     >>> pipeline = make_mapper_pipeline()
     >>> data = np.random.random((100, 3))
     >>> plotly_params = {"node_trace": {"marker_colorscale": "Blues"}}
     >>> fig = plot_static_mapper_graph(pipeline, data,
     ...                                plotly_params=plotly_params)
+
+    Inspect the composition of a node with "Node ID" displayed as 0 in the
+    hovertext:
+
+    >>> graph = pipeline.fit_transform(data)
+    >>> graph.vs[0]["node_elements"]
+    array([70])
 
     See also
     --------

--- a/gtda/plotting/diagram_representations.py
+++ b/gtda/plotting/diagram_representations.py
@@ -53,7 +53,7 @@ def plot_betti_curves(betti_numbers, samplings, homology_dimensions=None,
             "zeroline": True,
             "showexponent": "all",
             "exponentformat": "e"
-        },
+            },
         "yaxis1": {
             "title": "Betti number",
             "side": "left",
@@ -64,23 +64,24 @@ def plot_betti_curves(betti_numbers, samplings, homology_dimensions=None,
             "zeroline": True,
             "showexponent": "all",
             "exponentformat": "e"
-        },
+            },
         "plot_bgcolor": "white"
-    }
+        }
+
     fig = gobj.Figure(layout=layout)
-    fig.update_xaxes(zeroline=True, linewidth=1, linecolor='black',
+    fig.update_xaxes(zeroline=True, linewidth=1, linecolor="black",
                      mirror=False)
-    fig.update_yaxes(zeroline=True, linewidth=1, linecolor='black',
+    fig.update_yaxes(zeroline=True, linewidth=1, linecolor="black",
                      mirror=False)
 
     for dim in _homology_dimensions:
         fig.add_trace(gobj.Scatter(x=samplings[dim],
                                    y=betti_numbers[dim],
-                                   mode='lines', showlegend=True,
-                                   hoverinfo='none',
-                                   name=f'H{int(dim)}'))
+                                   mode="lines", showlegend=True,
+                                   hoverinfo="none",
+                                   name=f"H{int(dim)}"))
 
-    # Update trace and layout according to user input
+    # Update traces and layout according to user input
     if plotly_params:
         fig.update_traces(plotly_params.get("traces", None))
         fig.update_layout(plotly_params.get("layout", None))
@@ -143,24 +144,27 @@ def plot_betti_surfaces(betti_curves, samplings=None,
             "type": "linear",
             "showexponent": "all",
             "exponentformat": "e"
-        },
+            },
         "yaxis": {
             "title": "Time",
             "type": "linear",
             "showexponent": "all",
             "exponentformat": "e"
-        },
+            },
         "zaxis": {
             "title": "Betti number",
             "type": "linear",
             "showexponent": "all",
             "exponentformat": "e"
+            }
         }
-    }
+
     if betti_curves.shape[0] == 1:
         return plot_betti_curves(
-            betti_curves[0], samplings, homology_dimensions, plotly_params
-        )
+            betti_curves[0], samplings,
+            homology_dimensions=homology_dimensions,
+            plotly_params=plotly_params
+            )
     else:
         figs = []
         for dim in _homology_dimensions:
@@ -171,9 +175,9 @@ def plot_betti_surfaces(betti_curves, samplings=None,
             fig.add_trace(gobj.Surface(x=samplings[dim],
                                        y=np.arange(betti_curves.shape[0]),
                                        z=betti_curves[:, dim],
-                                       connectgaps=True, hoverinfo='none'))
+                                       connectgaps=True, hoverinfo="none"))
 
-            # Update trace and layout according to user input
+            # Update traces and layout according to user input
             if plotly_params:
                 fig.update_traces(plotly_params.get("traces", None))
                 fig.update_layout(plotly_params.get("layout", None))

--- a/gtda/plotting/persistence_diagrams.py
+++ b/gtda/plotting/persistence_diagrams.py
@@ -102,7 +102,7 @@ def plot_diagram(diagram, homology_dimensions=None, plotly_params=None):
         plot_bgcolor='white'
     )
 
-    # Update trace and layout according to user input
+    # Update traces and layout according to user input
     if plotly_params:
         fig.update_traces(plotly_params.get("traces", None))
         fig.update_layout(plotly_params.get("layout", None))

--- a/gtda/plotting/persistence_diagrams.py
+++ b/gtda/plotting/persistence_diagrams.py
@@ -37,70 +37,70 @@ def plot_diagram(diagram, homology_dimensions=None, plotly_params=None):
         homology_dimensions = np.unique(diagram[:, 2])
 
     diagram_no_dims = diagram[:, :2]
-    max_birth, max_death = np.where(
-        np.isposinf(diagram_no_dims), -np.inf, diagram_no_dims
-    ).max(axis=0)
-    min_birth, min_death = np.where(
-        np.isneginf(diagram_no_dims), np.inf, diagram_no_dims
-    ).min(axis=0)
+    max_birth, max_death = np.max(
+        np.where(np.isposinf(diagram_no_dims), -np.inf, diagram_no_dims),
+        axis=0
+        )
+    min_birth, min_death = np.max(
+        np.where(np.isneginf(diagram_no_dims), np.inf, diagram_no_dims),
+        axis=0
+        )
 
     fig = gobj.Figure()
     fig.add_trace(gobj.Scatter(x=[100 * min(-np.abs(max_death), min_birth),
                                   100 * max_death],
                                y=[100 * min(-np.abs(max_death), min_birth),
                                   100 * max_death],
-                               mode='lines',
-                               line=dict(dash='dash', width=1, color='black'),
-                               showlegend=False, hoverinfo='none'))
+                               mode="lines",
+                               line=dict(dash="dash", width=1, color="black"),
+                               showlegend=False, hoverinfo="none"))
 
     for dim in homology_dimensions:
-        name = f'H{int(dim)}' if dim != np.inf else 'Any homology dimension'
+        name = f"H{int(dim)}" if dim != np.inf else "Any homology dimension"
         subdiagram = diagram[diagram[:, 2] == dim]
         diff = (subdiagram[:, 1] != subdiagram[:, 0])
         subdiagram = subdiagram[diff]
         fig.add_trace(gobj.Scatter(x=subdiagram[:, 0], y=subdiagram[:, 1],
-                                   mode='markers', name=name))
+                                   mode="markers", name=name))
 
-    range = max_death - min_birth
-    extra_space = 0.02 * range
+    parameter_range = max_death - min_birth
+    extra_space = 0.02 * parameter_range
 
     fig.update_layout(
         width=500,
         height=500,
-        xaxis1=dict(
-            title='Birth',
-            side='bottom',
-            type='linear',
-            range=[min_birth - extra_space, max_death + extra_space],
-            autorange=False,
-            ticks='outside',
-            showline=True,
-            zeroline=True,
-            linewidth=1,
-            linecolor='black',
-            mirror=False,
-            showexponent='all',
-            exponentformat='e'
-        ),
-        yaxis1=dict(
-            title='Death',
-            side='left',
-            type='linear',
-            range=[min_birth - extra_space, max_death + extra_space],
-            autorange=False,
-            scaleanchor="x",
-            scaleratio=1,
-            ticks='outside',
-            showline=True,
-            zeroline=True,
-            linewidth=1,
-            linecolor='black',
-            mirror=False,
-            showexponent='all',
-            exponentformat='e'
-        ),
-        plot_bgcolor='white'
-    )
+        xaxis1={
+            "title": "Birth",
+            "side": "bottom",
+            "type": "linear",
+            "range": [min_birth - extra_space, max_death + extra_space],
+            "autorange": False,
+            "ticks": "outside",
+            "showline": True,
+            "zeroline": True,
+            "linewidth": 1,
+            "linecolor": "black",
+            "mirror": False,
+            "showexponent": "all",
+            "exponentformat": "e"
+            },
+        yaxis1={
+            "title": "Death",
+            "side": "left",
+            "type": "linear",
+            "range": [min_birth - extra_space, max_death + extra_space],
+            "autorange": False, "scaleanchor": "x", "scaleratio": 1,
+            "ticks": "outside",
+            "showline": True,
+            "zeroline": True,
+            "linewidth": 1,
+            "linecolor": "black",
+            "mirror": False,
+            "showexponent": "all",
+            "exponentformat": "e"
+            },
+        plot_bgcolor="white"
+        )
 
     # Update traces and layout according to user input
     if plotly_params:

--- a/gtda/plotting/tests/test_diagram_representations.py
+++ b/gtda/plotting/tests/test_diagram_representations.py
@@ -1,0 +1,76 @@
+"""Testing for plot_betti_curves and plot_betti_surfaces."""
+# License: GNU AGPLv3
+
+import numpy as np
+import pytest
+
+from gtda.plotting import plot_betti_curves, plot_betti_surfaces
+
+n_samples = 10
+n_homology_dimensions = 3
+n_bins = 20
+
+X = np.random.randint(0, 20, n_samples * n_homology_dimensions * n_bins).\
+    reshape(n_samples, n_homology_dimensions, n_bins)
+samplings = np.vstack([
+    np.linspace(0, 10, num=n_bins),
+    np.linspace(5, 15, num=n_bins),
+    np.linspace(10, 20, num=n_bins)
+    ])
+plotly_params_curves = {"layout": {"xaxis1": {"title": "New title"}}}
+plotly_params_surfaces = {
+    "layout": {"scene": {"xaxis": {"title": "New title"}}}
+    }
+
+
+@pytest.mark.parametrize("homology_dimensions", [None, [0], [0, 1], [0, 1, 2]])
+def test_plot_betti_curves(homology_dimensions):
+    fig = plot_betti_curves(X[0], samplings=samplings,
+                            plotly_params=plotly_params_curves)
+
+    if homology_dimensions is None:
+        _homology_dimensions = list(range(X.shape[1]))
+    else:
+        _homology_dimensions = homology_dimensions
+    traces_xy = all([
+        np.array_equal(fig.data[i].x, samplings[i])
+        and np.array_equal(fig.data[i].y, X[0][i])
+        for i in _homology_dimensions
+        ])
+    assert traces_xy
+
+    assert fig.layout.xaxis1.title.text == "New title"
+
+
+@pytest.mark.parametrize("homology_dimensions", [None, [0], [0, 1], [0, 1, 2]])
+def test_plot_betti_surfaces(homology_dimensions):
+    fig = plot_betti_surfaces(X, samplings=samplings,
+                              plotly_params=plotly_params_surfaces)
+
+    if homology_dimensions is None:
+        _homology_dimensions = list(range(X.shape[1]))
+    else:
+        _homology_dimensions = homology_dimensions
+    traces_xyz = all([
+        np.array_equal(fig[i].data[0].x, samplings[i])
+        and np.array_equal(fig[i].data[0].y, np.arange(X.shape[0]))
+        and np.array_equal(fig[i].data[0].z, X[:, i])
+        for i in _homology_dimensions
+        ])
+    assert traces_xyz
+
+    assert [fig[i].layout.scene.xaxis.title.text == "New title"
+            for i in _homology_dimensions]
+
+
+def test_plot_betti_surfaces_reduces_to_curves():
+    fig = plot_betti_surfaces(X[[0]], samplings=samplings,
+                              plotly_params=plotly_params_curves)
+
+    _homology_dimensions = range(X.shape[1])
+    traces_xy = all([
+        np.array_equal(fig.data[i].x, samplings[i])
+        and np.array_equal(fig.data[i].y, X[0][i])
+        for i in _homology_dimensions
+        ])
+    assert traces_xy

--- a/gtda/plotting/tests/test_diagram_representations.py
+++ b/gtda/plotting/tests/test_diagram_representations.py
@@ -26,6 +26,7 @@ plotly_params_surfaces = {
 @pytest.mark.parametrize("homology_dimensions", [None, [0], [0, 1], [0, 1, 2]])
 def test_plot_betti_curves(homology_dimensions):
     fig = plot_betti_curves(X[0], samplings=samplings,
+                            homology_dimensions=homology_dimensions,
                             plotly_params=plotly_params_curves)
 
     if homology_dimensions is None:
@@ -45,6 +46,7 @@ def test_plot_betti_curves(homology_dimensions):
 @pytest.mark.parametrize("homology_dimensions", [None, [0], [0, 1], [0, 1, 2]])
 def test_plot_betti_surfaces(homology_dimensions):
     fig = plot_betti_surfaces(X, samplings=samplings,
+                              homology_dimensions=homology_dimensions,
                               plotly_params=plotly_params_surfaces)
 
     if homology_dimensions is None:

--- a/gtda/tests/test_common.py
+++ b/gtda/tests/test_common.py
@@ -9,23 +9,21 @@ from gtda.images.preprocessing import Binarizer, Inverter
 
 # mark checks to skip
 SKIP_TESTS = {
-  'Binarizer':  [],
-  'Inverter':  [],
-}
+    'Binarizer':  [],
+    'Inverter':  [],
+    }
 
 # mark tests as a known failure
 # TODO: these should be addressed later.
 # Note with scikit-learn 0.23 these can be moved to estimator tags
 XFAIL_TESTS = {
-  'Binarizer':  ["check_transformer_data_not_an_array",
-                 "check_transformer_general",
-                 "check_transformer_general(readonly_memmap=True)",
-                 ],
-  'Inverter':  ["check_transformer_data_not_an_array",
-                "check_transformer_general",
-                "check_transformer_general(readonly_memmap=True)",
-                ],
-}
+    'Binarizer':  ["check_transformer_data_not_an_array",
+                   "check_transformer_general",
+                   "check_transformer_general(readonly_memmap=True)", ],
+    'Inverter':  ["check_transformer_data_not_an_array",
+                  "check_transformer_general",
+                  "check_transformer_general(readonly_memmap=True)", ],
+    }
 
 
 # adapted from sklearn.utils.estimator_check v0.22
@@ -72,7 +70,7 @@ def _get_estimator_name(estimator):
 
 @parametrize_with_checks(
     [Binarizer, Inverter]
-)
+    )
 def test_sklearn_api(check, estimator, request):
     estimator_name = _get_estimator_name(estimator)
     check_name = _get_callable_name(check)


### PR DESCRIPTION
**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
This PR stemmed from the idea of integrating `giotto-tda` more tightly with our `python-igraph` backend for Mapper graphs. Specifically, I believe that storing all Mapper node attributes as a graph-level dictionary (with key `"node_metadata"`) does not follow the recommended practice for storing vertex attributes in `igraph.Graph` objects, see https://igraph.org/python/doc/tutorial/tutorial.html#setting-and-retrieving-attributes. Instead, it seems to be that one should fully exploit the `VertexSeq` data structure which is accessible via `graph.vs` -- and similarly the `EdgeSeq` data structure which is accessible via `graph.es`.

In this PR:

1. Node metadata is stored as vertex attributes accessible by `graph.vs[attr_name][node_id]` or `graph.vs[node_id][attr_name]` for `attr_name` in `["pullback_set_label", "partial_cluster_label", "node_elements"]`.
2. `"node_id"` is removed from node attributes as it always coincided with the`igraph.Graph` node number anyway.
3. Sizes of intersections are automatically stored as edge weights, accessible by `graph.es["weight"]`.
4. A `"store_intersections"` kwarg has been added to `Nerve` and `make_mapper_pipeline` to allow storing indices of node intersections as edge attributes, accessible via `graph.es["edge_elements"]`.
5. The logic of the `Nerve.fit_transform` code has been simplified.
6. The attributes `nodes_` and `edges_` previously stored by `Nerve.fit` have been removed. Now the entire graph is stored as `graph_` instead.
7. The documentation of `make_mapper_pipeline` has been improved
8. `ParallelClustering` and `Nerve` have been exposed in the `__init__` and in the oline docs. This is because their docstrings might be useful to the user.
9. Two new tests have been added to `test_nerve` to check that the new `store_edge_elements` kwarg works as expected, and that `min_intersection` works as expected.
10. The test coverage for the Mapper visualisation modules has been increased.
11. Tests have been created for `plot_betti_curves` and `plot_betti_surfaces`.
12. `plotly_params` kwargs have been added to the `plot` methods of some transformers in `gtda/diagrams/representations` which had been forgotten in #441.
13. Existing tests, the mapper quickstart notebook, and the mapper plotting functions have been adapted.

**Any other comments?**
The behaviour of the mapper plotting functions is completely unchanged.

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.