### PR TITLE
Add normalization of entropy

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '"ccache-wheels-v2020.05.12" | $(Agent.OS) | "$(python.version)"'
+      key: '"ccache-wheels-v2020.08.7" | $(Agent.OS) | "$(python.version)"'
       path: $(CCACHE_DIR)
     displayName: ccache
 
@@ -136,7 +136,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '"ccache-v2020.05.12" | $(Agent.OS) | "$(python.version)"'
+      key: '"ccache-v2020.08.7" | $(Agent.OS) | "$(python.version)"'
       path: $(CCACHE_DIR)
     displayName: ccache
 
@@ -152,7 +152,7 @@ jobs:
       source .azure-ci/setup_ccache.sh
       python -m pip install -e ".[dev]"
       ccache -s
-    displayName: 'Install dependencies and dev environement'
+    displayName: 'Install dependencies and dev environment'
 
   - script: |
       set -e

--- a/gtda/diagrams/distance.py
+++ b/gtda/diagrams/distance.py
@@ -24,8 +24,8 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
     matrices or a single distance matrix between pairs of diagrams is
     calculated according to the following steps:
 
-    Input collections of persistence diagrams for this transformer must
-    satisfy certain requirements, see e.g. :meth:`fit`.
+    Input collections of persistence diagrams for this transformer must satisfy
+    certain requirements, see e.g. :meth:`fit`.
 
         1. All diagrams are partitioned into subdiagrams corresponding to
            distinct homology dimensions.

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -21,10 +21,10 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
     """:ref:`Persistence entropies <persistence_entropy>` of persistence
     diagrams.
 
-    Given a persistence diagrams consisting of birth-death-dimension triples
+    Given a persistence diagram consisting of birth-death-dimension triples
     [b, d, q], subdiagrams corresponding to distinct homology dimensions are
     considered separately, and their respective persistence entropies are
-    calculated as the (base e) entropies of the collections of differences
+    calculated as the (base 2) entropies of the collections of differences
     d - b, normalized by the sum of all such differences.
 
     Input collections of persistence diagrams for this transformer must
@@ -36,7 +36,7 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
         When ``True``, the persistence entropy of each diagram is normalized by
         the logarithm of the sum of lifetimes of all points in the diagram.
         Can aid comparison between diagrams in an input collection when these
-        have different numbers of (non-trivial) points.
+        have different numbers of (non-trivial) points. [1]_.
 
     n_jobs : int or None, optional, default: ``None``
         The number of jobs to use for the computation. ``None`` means 1 unless
@@ -54,6 +54,13 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
     PersistenceImage, PairwiseDistance, Silhouette, \
     gtda.homology.VietorisRipsPersistence
 
+    References
+    ----------
+    .. [1] A. Myers, E. Munch, and F. A. Khasawneh, “Persistent Homology of
+    Complex Networks for Dynamic State Detection,” Apr. 2019,; doi:
+    `10.1103/PhysRevE.100.022314
+    <https://doi.org/10.1103/PhysRevE.100.022314>`_.
+
     """
 
     def __init__(self, normalize=False, n_jobs=None):
@@ -66,9 +73,9 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
         lifespan_sums = np.sum(X_lifespan, axis=1).reshape(-1, 1)
         X_normalized = X_lifespan / lifespan_sums
         res = - np.sum(np.nan_to_num(
-            X_normalized * np.log(X_normalized)), axis=1).reshape(-1, 1)
+            X_normalized * np.log2(X_normalized)), axis=1).reshape(-1, 1)
         if normalize_nb_pts:
-            return res / np.log(lifespan_sums)
+            return res / np.log2(lifespan_sums)
         else:
             return res
 

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -27,7 +27,7 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
     considered separately, and their respective persistence entropies are
     calculated as the (base 2) Shannon entropies of the collections of
     differences d - b ("lifetimes"), normalized by the sum of all such
-    differences. Optionally, these entropies can be normalized according to a 
+    differences. Optionally, these entropies can be normalized according to a
     simple heuristic, see `normalize`.
 
     Input collections of persistence diagrams for this transformer must satisfy

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -138,13 +138,12 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
         check_is_fitted(self)
         X = check_diagrams(X)
 
-        with np.errstate(divide='ignore', invalid='ignore'):
-            Xt = Parallel(n_jobs=self.n_jobs)(
-                delayed(self._persistence_entropy)(_subdiagrams(X[s], [dim]),
-                                                   normalize=self.normalize)
-                for dim in self.homology_dimensions_
-                for s in gen_even_slices(len(X), effective_n_jobs(self.n_jobs))
-                )
+        Xt = Parallel(n_jobs=self.n_jobs)(
+            delayed(self._persistence_entropy)(_subdiagrams(X[s], [dim]),
+                                               normalize=self.normalize)
+            for dim in self.homology_dimensions_
+            for s in gen_even_slices(len(X), effective_n_jobs(self.n_jobs))
+            )
         Xt = np.concatenate(Xt).reshape(self._n_dimensions, X.shape[0]).T
         return Xt
 

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -36,7 +36,7 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
         When ``True``, the persistence entropy of each diagram is normalized by
         the logarithm of the sum of lifetimes of all points in the diagram.
         Can aid comparison between diagrams in an input collection when these
-        have different numbers of (non-trivial) points. [1]_.
+        have different numbers of (non-trivial) points. [1]_
 
     n_jobs : int or None, optional, default: ``None``
         The number of jobs to use for the computation. ``None`` means 1 unless
@@ -56,10 +56,10 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
 
     References
     ----------
-    .. [1] A. Myers, E. Munch, and F. A. Khasawneh, “Persistent Homology of
-    Complex Networks for Dynamic State Detection,” Apr. 2019,; doi:
-    `10.1103/PhysRevE.100.022314
-    <https://doi.org/10.1103/PhysRevE.100.022314>`_.
+    .. [1] A. Myers, E. Munch, and F. A. Khasawneh, "Persistent Homology of
+           Complex Networks for Dynamic State Detection"; *Phys. Rev. E*
+           **100**, 022314, 2019; doi: `10.1103/PhysRevE.100.022314
+           <https://doi.org/10.1103/PhysRevE.100.022314>`_.
 
     """
 

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -34,9 +34,9 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
     certain requirements, see e.g. :meth:`fit`.
 
     **Important note**: By default, persistence subdiagrams containing only
-    triples with zero lifetime will have corresponding entropies computed as
-    ``numpy.nan``. To avoid this, set a value of `nan_fill_value` different
-    from ``None``.
+    triples with zero lifetime will have corresponding (normalized) entropies
+    computed as ``numpy.nan``. To avoid this, set a value of `nan_fill_value`
+    different from ``None``.
 
     Parameters
     ----------

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -145,9 +145,8 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
                 delayed(self._persistence_entropy)(_subdiagrams(X[s], [dim]),
                                                    self.normalize)
                 for dim in self.homology_dimensions_
-                for s in gen_even_slices(
-                    len(X), effective_n_jobs(self.n_jobs))
-            )
+                for s in gen_even_slices(len(X), effective_n_jobs(self.n_jobs))
+                )
         Xt = np.concatenate(Xt).reshape(self._n_dimensions, X.shape[0]).T
         return Xt
 

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -68,13 +68,13 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
         self.n_jobs = n_jobs
 
     @staticmethod
-    def _persistence_entropy(X, normalize_nb_pts=False):
+    def _persistence_entropy(X, normalize=False):
         X_lifespan = X[:, :, 1] - X[:, :, 0]
         lifespan_sums = np.sum(X_lifespan, axis=1).reshape(-1, 1)
         X_normalized = X_lifespan / lifespan_sums
         res = - np.sum(np.nan_to_num(
             X_normalized * np.log2(X_normalized)), axis=1).reshape(-1, 1)
-        if normalize_nb_pts:
+        if normalize:
             return res / np.log2(lifespan_sums)
         else:
             return res
@@ -143,7 +143,7 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
         with np.errstate(divide='ignore', invalid='ignore'):
             Xt = Parallel(n_jobs=self.n_jobs)(
                 delayed(self._persistence_entropy)(_subdiagrams(X[s], [dim]),
-                                                   self.normalize)
+                                                   normalize=self.normalize)
                 for dim in self.homology_dimensions_
                 for s in gen_even_slices(len(X), effective_n_jobs(self.n_jobs))
                 )

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -5,6 +5,7 @@ from numbers import Real
 
 import numpy as np
 from joblib import Parallel, delayed, effective_n_jobs
+from scipy.stats import entropy
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import gen_even_slices
 from sklearn.utils.validation import check_is_fitted
@@ -24,14 +25,30 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
     Given a persistence diagrams consisting of birth-death-dimension triples
     [b, d, q], subdiagrams corresponding to distinct homology dimensions are
     considered separately, and their respective persistence entropies are
-    calculated as the (base e) entropies of the collections of differences
-    d - b, normalized by the sum of all such differences.
+    calculated as the (base 2) Shannon entropies of the normalized collections
+    of differences d - b ("lifetimes"). Optionally, the entropies can be
+    further normalized according to a simple heuristic, see `normalize`.
 
-    Input collections of persistence diagrams for this transformer must
-    satisfy certain requirements, see e.g. :meth:`fit`.
+    Input collections of persistence diagrams for this transformer must satisfy
+    certain requirements, see e.g. :meth:`fit`.
+
+    **Important note**: By default, persistence subdiagrams containing only
+    triples with zero lifetime will have corresponding entropies computed as
+    ``numpy.nan``. To avoid this, set a value of `nan_fill_value` different
+    from ``None``.
 
     Parameters
     ----------
+    normalize : bool, optional, default: ``False``
+        When ``True``, the persistence entropy of each diagram is normalized by
+        the logarithm of the sum of lifetimes of all points in the diagram.
+        Can aid comparison between diagrams in an input collection when these
+        have different numbers of (non-trivial) points. [1]_
+
+    nan_fill_value : float or None, optional, default: ``None``
+        If a float, (normalized) persistence entropies initially computed as
+        ``numpy.nan`` are replaced with this value.
+
     n_jobs : int or None, optional, default: ``None``
         The number of jobs to use for the computation. ``None`` means 1 unless
         in a :obj:`joblib.parallel_backend` context. ``-1`` means using all
@@ -48,17 +65,35 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
     PersistenceImage, PairwiseDistance, Silhouette, \
     gtda.homology.VietorisRipsPersistence
 
+    References
+    ----------
+    .. [1] A. Myers, E. Munch, and F. A. Khasawneh, "Persistent Homology of
+           Complex Networks for Dynamic State Detection"; *Phys. Rev. E*
+           **100**, 022314, 2019; doi: `10.1103/PhysRevE.100.022314
+           <https://doi.org/10.1103/PhysRevE.100.022314>`_.
+
     """
 
-    def __init__(self, n_jobs=None):
+    _hyperparameters = {
+        'normalize': {'type': bool},
+        'nan_fill_value': {'type': (Real, type(None))}}
+
+    def __init__(self, normalize=False, nan_fill_value=None, n_jobs=None):
+        self.normalize = normalize
+        self.nan_fill_value = nan_fill_value
         self.n_jobs = n_jobs
 
     @staticmethod
-    def _persistence_entropy(X):
+    def _persistence_entropy(X, normalize=False, nan_fill_value=None):
         X_lifespan = X[:, :, 1] - X[:, :, 0]
-        X_normalized = X_lifespan / np.sum(X_lifespan, axis=1).reshape(-1, 1)
-        return - np.sum(np.nan_to_num(
-            X_normalized * np.log(X_normalized)), axis=1).reshape(-1, 1)
+        X_entropy = entropy(X_lifespan, base=2, axis=1)
+        if normalize:
+            lifespan_sums = np.sum(X_lifespan, axis=1)
+            X_entropy /= np.log2(lifespan_sums)
+        if nan_fill_value is not None:
+            np.nan_to_num(X_entropy, nan=nan_fill_value, copy=False)
+        X_entropy = X_entropy[:, None]
+        return X_entropy
 
     def fit(self, X, y=None):
         """Store all observed homology dimensions in
@@ -87,6 +122,8 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
 
         """
         X = check_diagrams(X)
+        validate_params(
+            self.get_params(), self._hyperparameters, exclude=['n_jobs'])
 
         self.homology_dimensions_ = sorted(set(X[0, :, 2]))
         self._n_dimensions = len(self.homology_dimensions_)
@@ -123,11 +160,15 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
 
         with np.errstate(divide='ignore', invalid='ignore'):
             Xt = Parallel(n_jobs=self.n_jobs)(
-                delayed(self._persistence_entropy)(_subdiagrams(X[s], [dim]))
+                delayed(self._persistence_entropy)(
+                    _subdiagrams(X[s], [dim]),
+                    normalize=self.normalize,
+                    nan_fill_value=self.nan_fill_value
+                )
                 for dim in self.homology_dimensions_
                 for s in gen_even_slices(len(X), effective_n_jobs(self.n_jobs))
-            )
-        Xt = np.concatenate(Xt).reshape(self._n_dimensions, X.shape[0]).T
+                )
+        Xt = np.concatenate(Xt).reshape(self._n_dimensions, len(X)).T
         return Xt
 
 
@@ -147,8 +188,8 @@ class Amplitude(BaseEstimator, TransformerMixin):
         3. The final result is either :math:`\\mathbf{a}` itself or
            a norm of :math:`\\mathbf{a}`, specified by the parameter `order`.
 
-    Input collections of persistence diagrams for this transformer must
-    satisfy certain requirements, see e.g. :meth:`fit`.
+    Input collections of persistence diagrams for this transformer must satisfy
+    certain requirements, see e.g. :meth:`fit`.
 
     Parameters
     ----------

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -5,6 +5,7 @@ from numbers import Real
 
 import numpy as np
 from joblib import Parallel, delayed, effective_n_jobs
+from scipy.stats import entropy
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import gen_even_slices
 from sklearn.utils.validation import check_is_fitted
@@ -71,9 +72,7 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
     def _persistence_entropy(X, normalize=False):
         X_lifespan = X[:, :, 1] - X[:, :, 0]
         lifespan_sums = np.sum(X_lifespan, axis=1).reshape(-1, 1)
-        X_normalized = X_lifespan / lifespan_sums
-        res = - np.sum(np.nan_to_num(
-            X_normalized * np.log2(X_normalized)), axis=1).reshape(-1, 1)
+        res = entropy(X_lifespan, base=2, axis=1).reshape(-1, 1)
         if normalize:
             return res / np.log2(lifespan_sums)
         else:

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -22,11 +22,11 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
     """:ref:`Persistence entropies <persistence_entropy>` of persistence
     diagrams.
 
-    Given a persistence diagram consisting of birth-death-dimension triples
+    Given a persistence diagrams consisting of birth-death-dimension triples
     [b, d, q], subdiagrams corresponding to distinct homology dimensions are
     considered separately, and their respective persistence entropies are
-    calculated as the (base 2) entropies of the collections of differences
-    d - b, normalized by the sum of all such differences.
+    calculated as the (base 2) Shannon entropies of the collections of
+    differences d - b, normalized by the sum of all such differences.
 
     Input collections of persistence diagrams for this transformer must
     satisfy certain requirements, see e.g. :meth:`fit`.
@@ -71,12 +71,11 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
     @staticmethod
     def _persistence_entropy(X, normalize=False):
         X_lifespan = X[:, :, 1] - X[:, :, 0]
-        lifespan_sums = np.sum(X_lifespan, axis=1).reshape(-1, 1)
-        res = entropy(X_lifespan, base=2, axis=1).reshape(-1, 1)
+        X_entropy = entropy(X_lifespan, base=2, axis=1).reshape(-1, 1)
         if normalize:
-            return res / np.log2(lifespan_sums)
-        else:
-            return res
+            lifespan_sums = np.sum(X_lifespan, axis=1).reshape(-1, 1)
+            X_entropy /= np.log2(lifespan_sums)
+        return X_entropy
 
     def fit(self, X, y=None):
         """Store all observed homology dimensions in

--- a/gtda/diagrams/preprocessing.py
+++ b/gtda/diagrams/preprocessing.py
@@ -139,8 +139,8 @@ class Scaler(BaseEstimator, TransformerMixin, PlotterMixin):
           two-dimensional array of amplitudes (one per diagram and homology
           dimension) to obtain :attr:`scale_`.
 
-    Input collections of persistence diagrams for this transformer must
-    satisfy certain requirements, see e.g. :meth:`fit`.
+    Input collections of persistence diagrams for this transformer must satisfy
+    certain requirements, see e.g. :meth:`fit`.
 
     Parameters
     ----------
@@ -356,8 +356,8 @@ class Filtering(BaseEstimator, TransformerMixin, PlotterMixin):
     are equal) may still appear in the output for padding purposes, but carry
     no information.
 
-    Input collections of persistence diagrams for this transformer must
-    satisfy certain requirements, see e.g. :meth:`fit`.
+    Input collections of persistence diagrams for this transformer must satisfy
+    certain requirements, see e.g. :meth:`fit`.
 
     Parameters
     ----------

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -35,8 +35,8 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
     considered separately, and their respective Betti curves are obtained by
     evenly sampling the :ref:`filtration parameter <filtered_complex>`.
 
-    Input collections of persistence diagrams for this transformer must
-    satisfy certain requirements, see e.g. :meth:`fit`.
+    Input collections of persistence diagrams for this transformer must satisfy
+    certain requirements, see e.g. :meth:`fit`.
 
     Parameters
     ----------
@@ -265,8 +265,8 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
     landscapes are obtained by evenly sampling the :ref:`filtration parameter
     <filtered_complex>`.
 
-    Input collections of persistence diagrams for this transformer must
-    satisfy certain requirements, see e.g. :meth:`fit`.
+    Input collections of persistence diagrams for this transformer must satisfy
+    certain requirements, see e.g. :meth:`fit`.
 
     Parameters
     ----------
@@ -515,8 +515,8 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
     diagonal, and the difference between the results of the two convolutions is
     computed. The result can be thought of as a (multi-channel) raster image.
 
-    Input collections of persistence diagrams for this transformer must
-    satisfy certain requirements, see e.g. :meth:`fit`.
+    Input collections of persistence diagrams for this transformer must satisfy
+    certain requirements, see e.g. :meth:`fit`.
 
     Parameters
     ----------
@@ -719,8 +719,8 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
     <filtered_complex>`. The result can be thought of as a (multi-channel)
     raster image.
 
-    Input collections of persistence diagrams for this transformer must
-    satisfy certain requirements, see e.g. :meth:`fit`.
+    Input collections of persistence diagrams for this transformer must satisfy
+    certain requirements, see e.g. :meth:`fit`.
 
     Parameters
     ----------
@@ -949,8 +949,8 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
     spaced locations from appropriate ranges of the :ref:`filtration parameter
     <filtered_complex>`.
 
-    Input collections of persistence diagrams for this transformer must
-    satisfy certain requirements, see e.g. :meth:`fit`.
+    Input collections of persistence diagrams for this transformer must satisfy
+    certain requirements, see e.g. :meth:`fit`.
 
     Parameters
     ----------

--- a/gtda/diagrams/tests/test_features_representations.py
+++ b/gtda/diagrams/tests/test_features_representations.py
@@ -58,9 +58,9 @@ def test_fit_transform_plot_many_hom_dims(hom_dims):
 
 def test_pe_transform():
     pe = PersistenceEntropy()
-    diagram_res = np.array([[0.69314718, 0.63651417]])
+    diagram_res = np.array([[1., 0.91829583405]])
 
-    assert_almost_equal(pe.fit_transform(X), diagram_res)
+    assert_almost_equal(pe.fit_transform(X), diagram_res, )
 
 
 @pytest.mark.parametrize('n_bins', range(10, 51, 10))

--- a/gtda/diagrams/tests/test_features_representations.py
+++ b/gtda/diagrams/tests/test_features_representations.py
@@ -60,11 +60,11 @@ def test_pe_transform():
     pe = PersistenceEntropy()
     diagram_res = np.array([[1., 0.91829583405]])
 
-    assert_almost_equal(pe.fit_transform(X), diagram_res, )
+    assert_almost_equal(pe.fit_transform(X), diagram_res)
 
     pe_normalize = PersistenceEntropy(normalize=True)
     diagram_res = np.array([[1., 0.355245321276]])
-    assert_almost_equal(pe_normalize.fit_transform(X), diagram_res, )
+    assert_almost_equal(pe_normalize.fit_transform(X), diagram_res)
 
 
 @pytest.mark.parametrize('n_bins', range(10, 51, 10))

--- a/gtda/diagrams/tests/test_features_representations.py
+++ b/gtda/diagrams/tests/test_features_representations.py
@@ -62,6 +62,10 @@ def test_pe_transform():
 
     assert_almost_equal(pe.fit_transform(X), diagram_res, )
 
+    pe_normalize = PersistenceEntropy(normalize=True)
+    diagram_res = np.array([[1., 0.355245321276]])
+    assert_almost_equal(pe_normalize.fit_transform(X), diagram_res, )
+
 
 @pytest.mark.parametrize('n_bins', range(10, 51, 10))
 def test_bc_transform_shape(n_bins):

--- a/gtda/mapper/filter.py
+++ b/gtda/mapper/filter.py
@@ -5,7 +5,7 @@ import warnings
 
 import numpy as np
 from scipy.spatial.distance import pdist, squareform
-from scipy.special import entr
+from scipy.stats import entropy
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_array, check_is_fitted
 
@@ -111,9 +111,9 @@ class Eccentricity(BaseEstimator, TransformerMixin):
 class Entropy(BaseEstimator, TransformerMixin):
     """Entropy of rows in a two-dimensional array.
 
-    The rows of the array are interpreted as probability vectors,
-    after taking absolute values if necessary and normalizing. Then,
-    their Shannon entropies are computed and returned.
+    The rows of the array are interpreted as probability vectors, after taking
+    absolute values if necessary and normalizing. Then, their (base 2) Shannon
+    entropies are computed and returned.
 
     """
 
@@ -175,8 +175,7 @@ class Entropy(BaseEstimator, TransformerMixin):
                           "value to calculate probabilities.")
             Xt = np.abs(Xt)
 
-        Xt = Xt / Xt.sum(axis=1, keepdims=True)
-        Xt = entr(Xt).sum(axis=1, keepdims=True) / np.log(2)
+        Xt = entropy(Xt, base=2, axis=1)
         return Xt
 
 

--- a/gtda/mapper/filter.py
+++ b/gtda/mapper/filter.py
@@ -175,7 +175,7 @@ class Entropy(BaseEstimator, TransformerMixin):
                           "value to calculate probabilities.")
             Xt = np.abs(Xt)
 
-        Xt = entropy(Xt, base=2, axis=1)
+        Xt = entropy(Xt, base=2, axis=1)[:, None]
         return Xt
 
 

--- a/gtda/mapper/tests/test_visualization.py
+++ b/gtda/mapper/tests/test_visualization.py
@@ -135,7 +135,7 @@ def test_color_by_column_dropdown_2d(layout_dim):
     fig_buttons = fig.layout.updatemenus[0].buttons
 
     assert list(fig.data[1].marker.color) == \
-           list(fig_buttons[0].args[0]["marker.color"][1])
+        list(fig_buttons[0].args[0]["marker.color"][1])
 
     for i in range(X.shape[1]):
         fig_col_i = plot_static_mapper_graph(

--- a/gtda/tests/test_pipeline.py
+++ b/gtda/tests/test_pipeline.py
@@ -38,7 +38,7 @@ def get_steps():
         ('diagram', hl.VietorisRipsPersistence()),
         ('rescaler', diag.Scaler()),
         ('filter', diag.Filtering(epsilon=0.1)),
-        ('entropy', diag.PersistenceEntropy()),
+        ('entropy', diag.PersistenceEntropy(nan_fill_value=0.)),
         ('scaling', skprep.MinMaxScaler(copy=True))
     ]
     return steps

--- a/gtda/time_series/features.py
+++ b/gtda/time_series/features.py
@@ -17,8 +17,8 @@ class PermutationEntropy(BaseEstimator, TransformerMixin):
 
     Given a two-dimensional array `A`, another array `A'` of the same size is
     computed by arg-sorting each row in `A`. The permutation entropy [1]_ of
-    `A` is the (base 2) Shannon entropy of the probability distribution given by
-    the relative frequencies of each arg-sorting permutation in `A'`.
+    `A` is the (base 2) Shannon entropy of the probability distribution given
+    by the relative frequencies of each arg-sorting permutation in `A'`.
 
     Parameters
     ----------

--- a/gtda/time_series/features.py
+++ b/gtda/time_series/features.py
@@ -43,14 +43,17 @@ class PermutationEntropy(BaseEstimator, TransformerMixin):
     def __init__(self, n_jobs=None):
         self.n_jobs = n_jobs
 
-    def _entropy(self, X):
-        Xo = np.unique(X, axis=0, return_counts=True)[1].reshape(-1, 1)
-        return entropy(Xo, base=2, axis=0)
+    @staticmethod
+    def _entropy_2d(x):
+        unique_row_counts = np.unique(x, axis=0, return_counts=True)[1]
+        return entropy(unique_row_counts, base=2)
 
     def _permutation_entropy(self, X):
-        Xo = np.argsort(X, axis=2)
-        Xo = np.stack([self._entropy(x) for x in Xo])
-        return Xo.reshape(-1, 1)
+        X_permutations = np.argsort(X, axis=2)
+        X_permutation_entropy = np.asarray(
+            [self._entropy_2d(x) for x in X_permutations]
+            )[:, None]
+        return X_permutation_entropy
 
     def fit(self, X, y=None):
         """Do nothing and return the estimator unchanged.

--- a/gtda/time_series/features.py
+++ b/gtda/time_series/features.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 from joblib import Parallel, delayed, effective_n_jobs
+from scipy.stats import entropy
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import gen_even_slices
 from sklearn.utils.validation import check_is_fitted, check_array
@@ -16,7 +17,7 @@ class PermutationEntropy(BaseEstimator, TransformerMixin):
 
     Given a two-dimensional array `A`, another array `A'` of the same size is
     computed by arg-sorting each row in `A`. The permutation entropy [1]_ of
-    `A` is the Shannon entropy of the probability distribution given by
+    `A` is the Shannon entropy (base 2) of the probability distribution given by
     the relative frequencies of each arg-sorting permutation in `A'`.
 
     Parameters
@@ -44,8 +45,7 @@ class PermutationEntropy(BaseEstimator, TransformerMixin):
 
     def _entropy(self, X):
         Xo = np.unique(X, axis=0, return_counts=True)[1].reshape(-1, 1)
-        Xo = Xo / np.sum(Xo, axis=0).reshape(-1, 1)
-        return -np.sum(np.nan_to_num(Xo * np.log2(Xo)), axis=0).reshape(-1, 1)
+        return entropy(Xo, base=2, axis=0)
 
     def _permutation_entropy(self, X):
         Xo = np.argsort(X, axis=2)

--- a/gtda/time_series/features.py
+++ b/gtda/time_series/features.py
@@ -17,7 +17,7 @@ class PermutationEntropy(BaseEstimator, TransformerMixin):
 
     Given a two-dimensional array `A`, another array `A'` of the same size is
     computed by arg-sorting each row in `A`. The permutation entropy [1]_ of
-    `A` is the Shannon entropy (base 2) of the probability distribution given by
+    `A` is the (base 2) Shannon entropy of the probability distribution given by
     the relative frequencies of each arg-sorting permutation in `A'`.
 
     Parameters


### PR DESCRIPTION
**Reference issues/PRs**
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.

Pull requests which are not related to open issues may be rejected!
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

**Types of changes**
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
Add the option to normalize the entropy returned by `PersistenceEntropy`, according to the heuristic proposed by [Myers et Al. (2019) in eq. 4](https://arxiv.org/abs/1904.07403v2). Up to now, the calculated entropy wass the one in eq. 3.

**Screenshots (if appropriate)**

**Any other comments?**
Fix indentation in mapper visualization test.

**Checklist**
<!--
Go over all the following points, and put an `x` in all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [X] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [X] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.

<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
