### PR TITLE
Fix bug in use of homology_dimension_ix with samplings_, rename homology_dimension_ix

### DIFF
--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -698,7 +698,7 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
         check_is_fitted(self)
         x = self.samplings_[self.homology_dimensions_[homology_dimension_idx]]
         return plot_heatmap(
-            Xt[sample][homology_dimension_idx], x=x, y=x[::-1],
+            Xt[sample][homology_dimension_idx], x=x, y=x,
             colorscale=colorscale, plotly_params=plotly_params
             )
 

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -657,7 +657,7 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
             transpose((1, 0, 2, 3))
         return Xt
 
-    def plot(self, Xt, sample=0, homology_dimension_ix=0, colorscale="blues",
+    def plot(self, Xt, sample=0, homology_dimension_idx=0, colorscale="blues",
              plotly_params=None):
         """Plot a single channel – corresponding to a given homology
         dimension – in a sample from a collection of heat kernel images.
@@ -672,11 +672,11 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
         sample : int, optional, default: ``0``
             Index of the sample in `Xt` to be selected.
 
-        homology_dimension_ix : int, optional, default: ``0``
-            Index of the channel in the selected sample to be plotted. If
-            `Xt` is the result of a call to :meth:`transform` and this
-            index is i, the plot corresponds to the homology dimension given by
-            the i-th entry in :attr:`homology_dimensions_`.
+        homology_dimension_idx : int, optional, default: ``0``
+            Index of the channel in the selected sample to be plotted. If `Xt`
+            is the result of a call to :meth:`transform` and this index is i,
+            the plot corresponds to the homology dimension given by the i-th
+            entry in :attr:`homology_dimensions_`.
 
         colorscale : str, optional, default: ``"blues"``
             Color scale to be used in the heat map. Can be anything allowed by
@@ -696,10 +696,9 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
 
         """
         check_is_fitted(self)
+        x = self.samplings_[self.homology_dimensions_[homology_dimension_idx]]
         return plot_heatmap(
-            Xt[sample][homology_dimension_ix],
-            x=self.samplings_[homology_dimension_ix],
-            y=self.samplings_[homology_dimension_ix],
+            Xt[sample][homology_dimension_idx], x=x, y=x[::-1],
             colorscale=colorscale, plotly_params=plotly_params
             )
 
@@ -891,7 +890,7 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
             transpose((1, 0, 2, 3))
         return Xt
 
-    def plot(self, Xt, sample=0, homology_dimension_ix=0, colorscale="blues",
+    def plot(self, Xt, sample=0, homology_dimension_idx=0, colorscale="blues",
              plotly_params=None):
         """Plot a single channel – corresponding to a given homology
         dimension – in a sample from a collection of persistence images.
@@ -906,11 +905,11 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
         sample : int, optional, default: ``0``
             Index of the sample in `Xt` to be selected.
 
-        homology_dimension_ix : int, optional, default: ``0``
-            Index of the channel in the selected sample to be plotted. If
-            `Xt` is the result of a call to :meth:`transform` and this
-            index is i, the plot corresponds to the homology dimension given by
-            the i-th entry in :attr:`homology_dimensions_`.
+        homology_dimension_idx : int, optional, default: ``0``
+            Index of the channel in the selected sample to be plotted. If `Xt`
+            is the result of a call to :meth:`transform` and this index is i,
+            the plot corresponds to the homology dimension given by the i-th
+            entry in :attr:`homology_dimensions_`.
 
         colorscale : str, optional, default: ``"blues"``
             Color scale to be used in the heat map. Can be anything allowed by
@@ -930,9 +929,10 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
 
         """
         check_is_fitted(self)
-        samplings_x, samplings_y = self.samplings_[homology_dimension_ix]
+        samplings_x, samplings_y = \
+            self.samplings_[self.homology_dimensions_[homology_dimension_idx]]
         return plot_heatmap(
-            Xt[sample][homology_dimension_ix], x=samplings_x, y=samplings_y,
+            Xt[sample][homology_dimension_idx], x=samplings_x, y=samplings_y,
             colorscale=colorscale, plotly_params=plotly_params
             )
 

--- a/gtda/diagrams/tests/test_features_representations.py
+++ b/gtda/diagrams/tests/test_features_representations.py
@@ -38,12 +38,12 @@ def test_not_fitted():
         Silhouette().transform(X)
 
 
-@pytest.mark.parametrize('hom_dim_ix', [0, 1])
-def test_fit_transform_plot_one_hom_dim(hom_dim_ix):
+@pytest.mark.parametrize('hom_dim_idx', [0, 1])
+def test_fit_transform_plot_one_hom_dim(hom_dim_idx):
     HeatKernel().fit_transform_plot(
-        X, sample=0, homology_dimension_ix=hom_dim_ix)
+        X, sample=0, homology_dimension_idx=hom_dim_idx)
     PersistenceImage().fit_transform_plot(
-        X, sample=0, homology_dimension_ix=hom_dim_ix)
+        X, sample=0, homology_dimension_idx=hom_dim_idx)
 
 
 @pytest.mark.parametrize('hom_dims', [None, (0,), (1,), (0, 1)])


### PR DESCRIPTION
**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
The `plot` methods in `HeatKernel` and `PersistenceImage` currently have a kwarg `homology_dimension_ix` which selects the channel to plot, where a channel corresponds to a homology dimension. However, this is incorrectly implemented in e.g.

https://github.com/giotto-ai/giotto-tda/blob/f65f89947240dee62d9071789a8e148effe9d257/gtda/diagrams/representations.py#L701

(and a similar error for `PersistenceImage`) because `self.samplings_` is a dictionary with keys the homology dimensions, not their indices in `self.homology_dimensions_`. This PR:
- fixes this issue;
- renames `homology_dimension_ix` to `homology_dimension_idx` as suggested by @lewtun in a similar context (#447).

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.