### PR TITLE
Fix y-axis in HeatKernel plots, add default titles to plot methods

### DIFF
--- a/gtda/diagrams/distance.py
+++ b/gtda/diagrams/distance.py
@@ -126,7 +126,8 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
         'metric': {'type': str, 'in': _AVAILABLE_METRICS.keys()},
         'order': {'type': (Real, type(None)),
                   'in': Interval(0, np.inf, closed='right')},
-        'metric_params': {'type': (dict, type(None))}}
+        'metric_params': {'type': (dict, type(None))}
+        }
 
     def __init__(self, metric='landscape', metric_params=None, order=2.,
                  n_jobs=None):

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -232,7 +232,8 @@ class Amplitude(BaseEstimator, TransformerMixin):
         'metric': {'type': str, 'in': _AVAILABLE_AMPLITUDE_METRICS.keys()},
         'order': {'type': (Real, type(None)),
                   'in': Interval(0, np.inf, closed='right')},
-        'metric_params': {'type': (dict, type(None))}}
+        'metric_params': {'type': (dict, type(None))}
+        }
 
     def __init__(self, metric='landscape', metric_params=None, order=2.,
                  n_jobs=None):

--- a/gtda/diagrams/preprocessing.py
+++ b/gtda/diagrams/preprocessing.py
@@ -117,7 +117,7 @@ class ForgetDimension(BaseEstimator, TransformerMixin, PlotterMixin):
         return plot_diagram(
             Xt[sample], homology_dimensions=[np.inf],
             plotly_params=plotly_params
-        )
+            )
 
 
 @adapt_fit_transform_docs
@@ -343,7 +343,7 @@ class Scaler(BaseEstimator, TransformerMixin, PlotterMixin):
         return plot_diagram(
             Xt[sample], homology_dimensions=_homology_dimensions,
             plotly_params=plotly_params
-        )
+            )
 
 
 @adapt_fit_transform_docs
@@ -502,4 +502,4 @@ class Filtering(BaseEstimator, TransformerMixin, PlotterMixin):
         return plot_diagram(
             Xt[sample], homology_dimensions=_homology_dimensions,
             plotly_params=plotly_params
-        )
+            )

--- a/gtda/diagrams/preprocessing.py
+++ b/gtda/diagrams/preprocessing.py
@@ -193,7 +193,7 @@ class Scaler(BaseEstimator, TransformerMixin, PlotterMixin):
         'metric': {'type': str, 'in': _AVAILABLE_AMPLITUDE_METRICS.keys()},
         'metric_params': {'type': (dict, type(None))},
         'function': {'type': (FunctionType, type(None))}
-    }
+        }
 
     def __init__(self, metric='bottleneck', metric_params=None,
                  function=np.max, n_jobs=None):
@@ -387,9 +387,10 @@ class Filtering(BaseEstimator, TransformerMixin, PlotterMixin):
     _hyperparameters = {
         'homology_dimensions': {
             'type': (list, tuple, type(None)),
-            'of': {'type': int, 'in': Interval(0, np.inf, closed='left')}},
+            'of': {'type': int, 'in': Interval(0, np.inf, closed='left')}
+            },
         'epsilon': {'type': Real, 'in': Interval(0, np.inf, closed='left')}
-    }
+        }
 
     def __init__(self, homology_dimensions=None, epsilon=0.01):
         self.homology_dimensions = homology_dimensions

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -231,7 +231,8 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
                 "showexponent": "all",
                 "exponentformat": "e"
                 },
-            "plot_bgcolor": "white"
+            "plot_bgcolor": "white",
+            "title": f"Betti curves from diagram {sample}"
             }
 
         fig = gobj.Figure(layout=layout)
@@ -471,7 +472,8 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
                 "showexponent": "all",
                 "exponentformat": "e"
                 },
-            "plot_bgcolor": "white"
+            "plot_bgcolor": "white",
+            "title": f"Landscape representation of diagram {sample}"
             }
 
         Xt_sample = Xt[sample]
@@ -696,10 +698,16 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
 
         """
         check_is_fitted(self)
-        x = self.samplings_[self.homology_dimensions_[homology_dimension_idx]]
+        homology_dimension = self.homology_dimensions_[homology_dimension_idx]
+        if homology_dimension != np.inf:
+            homology_dimension = int(homology_dimension)
+        x = self.samplings_[homology_dimension]
         return plot_heatmap(
             Xt[sample][homology_dimension_idx], x=x, y=x[::-1],
             colorscale=colorscale, origin="lower",
+            title=f"Heat kernel representation of diagram {sample} in "
+                  f"homology dimension {homology_dimension}",
+            plotly_params=plotly_params
             )
 
 
@@ -929,11 +937,16 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
 
         """
         check_is_fitted(self)
-        samplings_x, samplings_y = \
-            self.samplings_[self.homology_dimensions_[homology_dimension_idx]]
+        homology_dimension = self.homology_dimensions_[homology_dimension_idx]
+        if homology_dimension != np.inf:
+            homology_dimension = int(homology_dimension)
+        samplings_x, samplings_y = self.samplings_[homology_dimension]
         return plot_heatmap(
             Xt[sample][homology_dimension_idx], x=samplings_x, y=samplings_y,
-            colorscale=colorscale, plotly_params=plotly_params
+            colorscale=colorscale,
+            title=f"Persistence image representation of diagram {sample} in "
+                  f"homology dimension {homology_dimension}",
+            plotly_params=plotly_params
             )
 
 
@@ -1160,7 +1173,8 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
                 "showexponent": "all",
                 "exponentformat": "e"
                 },
-            "plot_bgcolor": "white"
+            "plot_bgcolor": "white",
+            "title": f"Silhouette representation of diagram {sample}"
             }
 
         fig = gobj.Figure(layout=layout)

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -75,7 +75,8 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
     """
 
     _hyperparameters = {
-        "n_bins": {"type": int, "in": Interval(1, np.inf, closed="left")}}
+        "n_bins": {"type": int, "in": Interval(1, np.inf, closed="left")}
+        }
 
     def __init__(self, n_bins=100, n_jobs=None):
         self.n_bins = n_bins
@@ -311,7 +312,8 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
 
     _hyperparameters = {
         "n_bins": {"type": int, "in": Interval(1, np.inf, closed="left")},
-        "n_layers": {"type": int, "in": Interval(1, np.inf, closed="left")}}
+        "n_layers": {"type": int, "in": Interval(1, np.inf, closed="left")}
+        }
 
     def __init__(self, n_layers=1, n_bins=100, n_jobs=None):
         self.n_layers = n_layers
@@ -570,7 +572,8 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
 
     _hyperparameters = {
         "n_bins": {"type": int, "in": Interval(1, np.inf, closed="left")},
-        "sigma": {"type": Real, "in": Interval(0, np.inf, closed="neither")}}
+        "sigma": {"type": Real, "in": Interval(0, np.inf, closed="neither")}
+        }
 
     def __init__(self, sigma=1., n_bins=100, n_jobs=None):
         self.sigma = sigma
@@ -794,7 +797,8 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
     _hyperparameters = {
         "n_bins": {"type": int, "in": Interval(1, np.inf, closed="left")},
         "sigma": {"type": Real, "in": Interval(0, np.inf, closed="neither")},
-        "weight_function": {"type": (types.FunctionType, type(None))}}
+        "weight_function": {"type": (types.FunctionType, type(None))}
+        }
 
     def __init__(self, sigma=1., n_bins=100, weight_function=None,
                  n_jobs=None):
@@ -1016,7 +1020,8 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
 
     _hyperparameters = {
         "n_bins": {"type": int, "in": Interval(1, np.inf, closed="left")},
-        "power": {"type": Real, "in": Interval(0, np.inf, closed="right")}}
+        "power": {"type": Real, "in": Interval(0, np.inf, closed="right")}
+        }
 
     def __init__(self, power=1., n_bins=100, n_jobs=None):
         self.power = power

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -698,8 +698,8 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
         check_is_fitted(self)
         x = self.samplings_[self.homology_dimensions_[homology_dimension_idx]]
         return plot_heatmap(
-            Xt[sample][homology_dimension_idx], x=x, y=x,
-            colorscale=colorscale, plotly_params=plotly_params
+            Xt[sample][homology_dimension_idx], x=x, y=x[::-1],
+            colorscale=colorscale, origin="lower",
             )
 
 

--- a/gtda/graphs/geodesic_distance.py
+++ b/gtda/graphs/geodesic_distance.py
@@ -211,5 +211,7 @@ class GraphGeodesicDistance(BaseEstimator, TransformerMixin, PlotterMixin):
 
         """
         return plot_heatmap(
-            Xt[sample], colorscale=colorscale, plotly_params=plotly_params
-        )
+            Xt[sample], colorscale=colorscale,
+            title=f"{sample}-th geodesic distance matrix",
+            plotly_params=plotly_params
+            )

--- a/gtda/graphs/transition.py
+++ b/gtda/graphs/transition.py
@@ -114,7 +114,7 @@ class TransitionGraph(BaseEstimator, TransformerMixin):
     _hyperparameters = {
         'func': {'type': (FunctionType, type(None))},
         'func_params': {'type': (dict, type(None))}
-    }
+        }
 
     def __init__(self, func=np.argsort, func_params=None, n_jobs=None):
         self.func = func

--- a/gtda/homology/cubical.py
+++ b/gtda/homology/cubical.py
@@ -255,4 +255,4 @@ class CubicalPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         return plot_diagram(
             Xt[sample], homology_dimensions=homology_dimensions,
             plotly_params=plotly_params
-        )
+            )

--- a/gtda/homology/cubical.py
+++ b/gtda/homology/cubical.py
@@ -92,13 +92,14 @@ class CubicalPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
     _hyperparameters = {
         'homology_dimensions': {
-            'type': (list, tuple), 'of': {
-                'type': int, 'in': Interval(0, np.inf, closed='left')}},
+            'type': (list, tuple),
+            'of': {'type': int, 'in': Interval(0, np.inf, closed='left')}
+            },
         'coeff': {'type': int, 'in': Interval(2, np.inf, closed='left')},
-        'periodic_dimensions': {
-            'type': (np.ndarray, type(None)),
-            'of': {'type': np.bool_}},
-        'infinity_values': {'type': (Real, type(None))}}
+        'periodic_dimensions': {'type': (np.ndarray, type(None)),
+                                'of': {'type': np.bool_}},
+        'infinity_values': {'type': (Real, type(None))}
+        }
 
     def __init__(self, homology_dimensions=(0, 1), coeff=2,
                  periodic_dimensions=None, infinity_values=None, n_jobs=None):

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -266,7 +266,7 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         return plot_diagram(
             Xt[sample], homology_dimensions=homology_dimensions,
             plotly_params=plotly_params
-        )
+            )
 
 
 @adapt_fit_transform_docs
@@ -527,7 +527,7 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         return plot_diagram(
             Xt[sample], homology_dimensions=homology_dimensions,
             plotly_params=plotly_params
-        )
+            )
 
 
 @adapt_fit_transform_docs
@@ -744,7 +744,7 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         return plot_diagram(
             Xt[sample], homology_dimensions=homology_dimensions,
             plotly_params=plotly_params
-        )
+            )
 
 
 @adapt_fit_transform_docs
@@ -1022,4 +1022,4 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         return plot_diagram(
             Xt[sample], homology_dimensions=homology_dimensions,
             plotly_params=plotly_params
-        )
+            )

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -112,12 +112,13 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
     _hyperparameters = {
         'metric': {'type': (str, FunctionType)},
         'homology_dimensions': {
-            'type': (list, tuple), 'of': {
-                'type': int, 'in': Interval(0, np.inf, closed='left')}},
+            'type': (list, tuple),
+            'of': {'type': int, 'in': Interval(0, np.inf, closed='left')}
+            },
         'coeff': {'type': int, 'in': Interval(2, np.inf, closed='left')},
         'max_edge_length': {'type': Real},
         'infinity_values': {'type': (Real, type(None))}
-    }
+        }
 
     def __init__(self, metric='euclidean', homology_dimensions=(0, 1),
                  coeff=2, max_edge_length=np.inf, infinity_values=None,
@@ -363,13 +364,14 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
     _hyperparameters = {
         'metric': {'type': (str, FunctionType)},
         'homology_dimensions': {
-            'type': (list, tuple), 'of': {
-                'type': int, 'in': Interval(0, np.inf, closed='left')}},
+            'type': (list, tuple),
+            'of': {'type': int, 'in': Interval(0, np.inf, closed='left')}
+            },
         'coeff': {'type': int, 'in': Interval(2, np.inf, closed='left')},
         'epsilon': {'type': Real, 'in': Interval(0, 1, closed='both')},
         'max_edge_length': {'type': Real},
         'infinity_values': {'type': (Real, type(None))}
-    }
+        }
 
     def __init__(self, metric='euclidean', homology_dimensions=(0, 1),
                  coeff=2, epsilon=0.1, max_edge_length=np.inf,
@@ -598,15 +600,15 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
     _hyperparameters = {
         'homology_dimensions': {
-            'type': (list, tuple), 'of': {
-                'type': int, 'in': Interval(0, np.inf, closed='left')}},
+            'type': (list, tuple),
+            'of': {'type': int, 'in': Interval(0, np.inf, closed='left')}
+            },
         'coeff': {'type': int, 'in': Interval(2, np.inf, closed='left')},
-        'max_edge_length': {
-            'type': Real, 'in': Interval(0, np.inf, closed='right')},
-        'infinity_values': {
-            'type': (Real, type(None)),
-            'in': Interval(0, np.inf, closed='neither')},
-    }
+        'max_edge_length': {'type': Real,
+                            'in': Interval(0, np.inf, closed='right')},
+        'infinity_values': {'type': (Real, type(None)),
+                            'in': Interval(0, np.inf, closed='neither')},
+        }
 
     def __init__(self, homology_dimensions=(0, 1), coeff=2,
                  max_edge_length=np.inf, infinity_values=None, n_jobs=None):
@@ -850,14 +852,15 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
     _hyperparameters = {
         'homology_dimensions': {
-            'type': (list, tuple), 'of': {
-                'type': int, 'in': Interval(0, np.inf, closed='left')}},
+            'type': (list, tuple),
+            'of': {'type': int, 'in': Interval(0, np.inf, closed='left')}
+            },
         'directed': {'type': bool},
         'coeff': {'type': int, 'in': Interval(2, np.inf, closed='left')},
         'max_edge_weight': {'type': Real},
         'infinity_values': {'type': (Real, type(None))},
         'max_entries': {'type': int}
-    }
+        }
 
     def __init__(self, homology_dimensions=(0, 1), directed=True,
                  filtration='max', coeff=2, max_edge_weight=np.inf,

--- a/gtda/images/filtrations.py
+++ b/gtda/images/filtrations.py
@@ -75,9 +75,8 @@ class HeightFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
     """
 
     _hyperparameters = {
-        'direction': {
-            'type': (np.ndarray, type(None)), 'of': {'type': Real}}
-    }
+        'direction': {'type': (np.ndarray, type(None)), 'of': {'type': Real}}
+        }
 
     def __init__(self, direction=None, n_jobs=None):
         self.direction = direction
@@ -305,12 +304,11 @@ class RadialFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
     """
 
     _hyperparameters = {
-        'center': {
-            'type': (np.ndarray, type(None)), 'of': {'type': int}},
+        'center': {'type': (np.ndarray, type(None)), 'of': {'type': int}},
         'radius': {'type': Real, 'in': Interval(0, np.inf, closed='right')},
         'metric': {'type': (str, FunctionType)},
         'metric_params': {'type': (dict, type(None))}
-    }
+        }
 
     def __init__(self, center=None, radius=np.inf, metric='euclidean',
                  metric_params=None, n_jobs=None):
@@ -521,10 +519,9 @@ class DilationFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
     """
 
     _hyperparameters = {
-        'n_iterations': {
-            'type': (int, type(None)),
-            'in': Interval(1, np.inf, closed='left')}
-    }
+        'n_iterations': {'type': (int, type(None)),
+                         'in': Interval(1, np.inf, closed='left')}
+        }
 
     def __init__(self, n_iterations=None, n_jobs=None):
         self.n_iterations = n_iterations
@@ -711,10 +708,9 @@ class ErosionFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
     """
 
     _hyperparameters = {
-        'n_iterations': {
-            'type': (int, type(None)),
-            'in': Interval(1, np.inf, closed='left')}
-    }
+        'n_iterations': {'type': (int, type(None)),
+                         'in': Interval(1, np.inf, closed='left')}
+        }
 
     def __init__(self, n_iterations=None, n_jobs=None):
         self.n_iterations = n_iterations
@@ -903,10 +899,9 @@ class SignedDistanceFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
     """
 
     _hyperparameters = {
-        'n_iterations': {
-            'type': (int, type(None)),
-            'in': Interval(1, np.inf, closed='left')}
-    }
+        'n_iterations': {'type': (int, type(None)),
+                         'in': Interval(1, np.inf, closed='left')}
+        }
 
     def __init__(self, n_iterations=None, n_jobs=None):
         self.n_iterations = n_iterations

--- a/gtda/images/filtrations.py
+++ b/gtda/images/filtrations.py
@@ -217,8 +217,9 @@ class HeightFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
         """
         return plot_heatmap(
             Xt[sample], colorscale=colorscale, origin=origin,
+            title=f"Height filtration of image {sample}",
             plotly_params=plotly_params
-        )
+            )
 
 
 @adapt_fit_transform_docs
@@ -459,8 +460,9 @@ class RadialFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
         """
         return plot_heatmap(
             Xt[sample], colorscale=colorscale, origin=origin,
+            title=f"Radial filtration of image {sample}",
             plotly_params=plotly_params
-        )
+            )
 
 
 @adapt_fit_transform_docs
@@ -648,8 +650,9 @@ class DilationFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
         """
         return plot_heatmap(
             Xt[sample], colorscale=colorscale, origin=origin,
+            title=f"Dilation filtration of image {sample}",
             plotly_params=plotly_params
-        )
+            )
 
 
 @adapt_fit_transform_docs
@@ -836,8 +839,9 @@ class ErosionFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
         """
         return plot_heatmap(
             Xt[sample], colorscale=colorscale, origin=origin,
+            title=f"Erosion filtration of image {sample}",
             plotly_params=plotly_params
-        )
+            )
 
 
 @adapt_fit_transform_docs
@@ -1034,5 +1038,6 @@ class SignedDistanceFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
         """
         return plot_heatmap(
             Xt[sample], colorscale=colorscale, origin=origin,
+            title=f"Signed-distance filtration of image {sample}",
             plotly_params=plotly_params
-        )
+            )

--- a/gtda/images/preprocessing.py
+++ b/gtda/images/preprocessing.py
@@ -178,8 +178,9 @@ class Binarizer(BaseEstimator, TransformerMixin, PlotterMixin):
         """
         return plot_heatmap(
             Xt[sample] * 1, colorscale=colorscale, origin=origin,
+            title=f"Binarization of image {sample}",
             plotly_params=plotly_params
-        )
+            )
 
 
 @adapt_fit_transform_docs
@@ -301,8 +302,9 @@ class Inverter(BaseEstimator, TransformerMixin, PlotterMixin):
         """
         return plot_heatmap(
             Xt[sample] * 1, colorscale=colorscale, origin=origin,
+            title=f"Inversion of image {sample}",
             plotly_params=plotly_params
-        )
+            )
 
 
 @adapt_fit_transform_docs
@@ -468,8 +470,9 @@ class Padder(BaseEstimator, TransformerMixin, PlotterMixin):
         """
         return plot_heatmap(
             Xt[sample] * 1, colorscale=colorscale, origin=origin,
+            title=f"Padded version of image {sample}",
             plotly_params=plotly_params
-        )
+            )
 
 
 @adapt_fit_transform_docs

--- a/gtda/images/preprocessing.py
+++ b/gtda/images/preprocessing.py
@@ -58,7 +58,7 @@ class Binarizer(BaseEstimator, TransformerMixin, PlotterMixin):
 
     _hyperparameters = {
         'threshold': {'type': Real, 'in': Interval(0, 1, closed='right')}
-    }
+        }
 
     def __init__(self, threshold=0.5, n_jobs=None):
         self.threshold = threshold
@@ -343,11 +343,9 @@ class Padder(BaseEstimator, TransformerMixin, PlotterMixin):
     """
 
     _hyperparameters = {
-        'paddings': {
-            'type': (np.ndarray, type(None)),
-            'of': {'type': int}},
+        'paddings': {'type': (np.ndarray, type(None)), 'of': {'type': int}},
         'activated': {'type': bool}
-    }
+        }
 
     def __init__(self, paddings=None, activated=False, n_jobs=None):
         self.paddings = paddings

--- a/gtda/mapper/cluster.py
+++ b/gtda/mapper/cluster.py
@@ -401,13 +401,13 @@ class FirstSimpleGap(ClusterMixin, BaseEstimator, Agglomerative):
     """
 
     _hyperparameters = {
-        'relative_gap_size': {
-            'type': Real, 'in': Interval(0, 1, closed='right')},
-        'max_fraction': {
-            'type': (Real, type(None)), 'in': Interval(0, 1, closed='right')},
+        'relative_gap_size': {'type': Real,
+                              'in': Interval(0, 1, closed='right')},
+        'max_fraction': {'type': (Real, type(None)),
+                         'in': Interval(0, 1, closed='right')},
         'affinity': {'type': str},
         'linkage': {'type': str}
-    }
+        }
 
     def __init__(self, relative_gap_size=0.3, max_fraction=None,
                  affinity='euclidean', memory=None, linkage='single'):
@@ -554,15 +554,15 @@ class FirstHistogramGap(ClusterMixin, BaseEstimator, Agglomerative):
     """
 
     _hyperparameters = {
-        'freq_threshold': {
-            'type': int, 'in': Interval(0, np.inf, closed='left')},
-        'max_fraction': {
-            'type': (Real, type(None)), 'in': Interval(0, 1, closed='right')},
-        'n_bins_start': {
-            'type': int, 'in': Interval(1, np.inf, closed='left')},
+        'freq_threshold': {'type': int,
+                           'in': Interval(0, np.inf, closed='left')},
+        'max_fraction': {'type': (Real, type(None)),
+                         'in': Interval(0, 1, closed='right')},
+        'n_bins_start': {'type': int,
+                         'in': Interval(1, np.inf, closed='left')},
         'affinity': {'type': str},
         'linkage': {'type': str}
-    }
+        }
 
     def __init__(self, freq_threshold=0, max_fraction=None, n_bins_start=5,
                  affinity='euclidean', memory=None, linkage='single'):

--- a/gtda/mapper/cover.py
+++ b/gtda/mapper/cover.py
@@ -88,7 +88,7 @@ class OneDimensionalCover(BaseEstimator, TransformerMixin):
         'kind': {'type': str, 'in': ['uniform', 'balanced']},
         'n_intervals': {'type': int, 'in': Interval(1, np.inf, closed='left')},
         'overlap_frac': {'type': float, 'in': Interval(0, 1, closed='neither')}
-    }
+        }
 
     def __init__(self, kind='uniform', n_intervals=10, overlap_frac=0.1):
         self.kind = kind
@@ -384,7 +384,7 @@ class CubicalCover(BaseEstimator, TransformerMixin):
         'kind': {'type': str, 'in': ['uniform', 'balanced']},
         'n_intervals': {'type': int, 'in': Interval(1, np.inf, closed='left')},
         'overlap_frac': {'type': float, 'in': Interval(0, 1, closed='neither')}
-    }
+        }
 
     def __init__(self, kind='uniform', n_intervals=10, overlap_frac=0.1):
         self.kind = kind

--- a/gtda/plotting/images.py
+++ b/gtda/plotting/images.py
@@ -1,10 +1,10 @@
 """Image-related plotting functions and classes."""
 # License: GNU AGPLv3
 
-import plotly.graph_objects as gobj
+from plotly.express import imshow
 
 
-def plot_heatmap(data, x=None, y=None, colorscale='greys', origin='upper',
+def plot_heatmap(data, x=None, y=None, colorscale="greys", origin="upper",
                  title=None, plotly_params=None):
     """Plot a 2D single-channel image, as a heat map from 2D array data.
 
@@ -19,13 +19,13 @@ def plot_heatmap(data, x=None, y=None, colorscale='greys', origin='upper',
     y : ndarray of shape (n_pixels_y,) or None, optional, default: ``None``
         Vertical coordinates of the pixels in `data`.
 
-    colorscale : str, optional, default: ``'greys'``
+    colorscale : str, optional, default: ``"greys"``
         Color scale to be used in the heat map. Can be anything allowed by
         :class:`plotly.graph_objects.Heatmap`.
 
-    origin : ``'upper'`` | ``'lower'``, optional, default: ``'upper'``
+    origin : ``"upper"`` | ``"lower"``, optional, default: ``"upper"``
         Position of the [0, 0] pixel of `data`, in the upper left or lower
-        left corner. The convention ``'upper'`` is typically used for
+        left corner. The convention ``"upper"`` is typically used for
         matrices and images.
 
     title : str or None, optional, default: ``None``
@@ -44,15 +44,10 @@ def plot_heatmap(data, x=None, y=None, colorscale='greys', origin='upper',
         Figure representing the 2D single-channel image.
 
     """
-    autorange = True if origin == 'lower' else 'reversed'
-    layout = dict(
-        xaxis=dict(scaleanchor='y', constrain='domain'),
-        yaxis=dict(autorange=autorange, constrain='domain'),
-        plot_bgcolor='white',
-        title=title
-    )
-    fig = gobj.Figure(layout=layout)
-    fig.add_trace(gobj.Heatmap(z=data * 1, x=x, y=y, colorscale=colorscale))
+    fig = imshow(
+        data * 1, x=x, y=y,
+        color_continuous_scale=colorscale, origin=origin, title=title
+        )
 
     # Update trace and layout according to user input
     if plotly_params:

--- a/gtda/plotting/images.py
+++ b/gtda/plotting/images.py
@@ -1,7 +1,7 @@
 """Image-related plotting functions and classes."""
 # License: GNU AGPLv3
 
-from plotly.express import imshow
+import plotly.graph_objects as gobj
 
 
 def plot_heatmap(data, x=None, y=None, colorscale="greys", origin="upper",
@@ -44,10 +44,15 @@ def plot_heatmap(data, x=None, y=None, colorscale="greys", origin="upper",
         Figure representing the 2D single-channel image.
 
     """
-    fig = imshow(
-        data * 1, x=x, y=y,
-        color_continuous_scale=colorscale, origin=origin, title=title
-        )
+    autorange = True if origin == "lower" else "reversed"
+    layout = {
+        "xaxis": {"scaleanchor": "y", "constrain": "domain"},
+        "yaxis": {"autorange": autorange, "constrain": "domain"},
+        "plot_bgcolor": "white",
+        "title": title
+        }
+    fig = gobj.Figure(layout=layout)
+    fig.add_trace(gobj.Heatmap(z=data * 1, x=x, y=y, colorscale=colorscale))
 
     # Update trace and layout according to user input
     if plotly_params:

--- a/gtda/point_clouds/rescaling.py
+++ b/gtda/point_clouds/rescaling.py
@@ -222,8 +222,10 @@ class ConsistentRescaling(BaseEstimator, TransformerMixin, PlotterMixin):
 
         """
         return plot_heatmap(
-            Xt[sample], colorscale=colorscale, plotly_params=plotly_params
-        )
+            Xt[sample], colorscale=colorscale,
+            title=f"{sample}-th distance matrix after consistent rescaling",
+            plotly_params=plotly_params
+            )
 
 
 @adapt_fit_transform_docs
@@ -415,5 +417,7 @@ class ConsecutiveRescaling(BaseEstimator, TransformerMixin, PlotterMixin):
 
         """
         return plot_heatmap(
-            Xt[sample], colorscale=colorscale, plotly_params=plotly_params
-        )
+            Xt[sample], colorscale=colorscale,
+            title=f"{sample}-th distance matrix after consecutive rescaling",
+            plotly_params=plotly_params
+            )

--- a/gtda/point_clouds/rescaling.py
+++ b/gtda/point_clouds/rescaling.py
@@ -94,9 +94,9 @@ class ConsistentRescaling(BaseEstimator, TransformerMixin, PlotterMixin):
     _hyperparameters = {
         'metric': {'type': (str, FunctionType)},
         'metric_params': {'type': (dict, type(None))},
-        'neighbor_rank': {
-            'type': int, 'in': Interval(1, np.inf, closed='left')}
-    }
+        'neighbor_rank': {'type': int,
+                          'in': Interval(1, np.inf, closed='left')}
+        }
 
     def __init__(self, metric='euclidean', metric_params=None, neighbor_rank=1,
                  n_jobs=None):
@@ -295,8 +295,7 @@ class ConsecutiveRescaling(BaseEstimator, TransformerMixin, PlotterMixin):
     _hyperparameters = {
         'metric': {'type': (str, FunctionType)},
         'metric_params': {'type': (dict, type(None))},
-        'factor': {
-            'type': Real, 'in': Interval(0, np.inf, closed='both')}
+        'factor': {'type': Real, 'in': Interval(0, np.inf, closed='both')}
     }
 
     def __init__(self, metric='euclidean', metric_params=None, factor=0.,

--- a/gtda/time_series/multivariate.py
+++ b/gtda/time_series/multivariate.py
@@ -45,8 +45,7 @@ class PearsonDissimilarity(BaseEstimator, TransformerMixin):
 
     """
 
-    _hyperparameters = {
-        'absolute_value': {'type': bool}}
+    _hyperparameters = {'absolute_value': {'type': bool}}
 
     def __init__(self, absolute_value=False, n_jobs=None):
         self.absolute_value = absolute_value

--- a/gtda/time_series/preprocessing.py
+++ b/gtda/time_series/preprocessing.py
@@ -39,7 +39,8 @@ class Resampler(BaseEstimator, TransformerResamplerMixin):
     """
 
     _hyperparameters = {
-        'period': {'type': int, 'in': Interval(1, np.inf, closed='left')}}
+        'period': {'type': int, 'in': Interval(1, np.inf, closed='left')}
+        }
 
     def __init__(self, period=2):
         self.period = period
@@ -160,7 +161,8 @@ class Stationarizer(BaseEstimator, TransformerResamplerMixin):
     """
 
     _hyperparameters = {
-        'operation': {'type': str, 'in': ['return', 'log-return']}}
+        'operation': {'type': str, 'in': ['return', 'log-return']}
+        }
 
     def __init__(self, operation='return'):
         self.operation = operation

--- a/gtda/time_series/target.py
+++ b/gtda/time_series/target.py
@@ -80,10 +80,11 @@ class Labeller(BaseEstimator, TransformerResamplerMixin):
         'func_params': {'type': (dict, type(None))},
         'percentiles': {
             'type': (list, type(None)),
-            'of': {'type': Real, 'in': Interval(0, 100, closed='both')}},
-        'n_steps_future': {
-            'type': int, 'in': Interval(1, np.inf, closed='left')}
-    }
+            'of': {'type': Real, 'in': Interval(0, 100, closed='both')}
+            },
+        'n_steps_future': {'type': int,
+                           'in': Interval(1, np.inf, closed='left')}
+        }
 
     def __init__(self, width=10, func=np.std,
                  func_params=None, percentiles=None, n_steps_future=1):


### PR DESCRIPTION
**Reference issues/PRs**
#442 during whose review this was discovered.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
While reviewing #442, I noticed that the y-axes of plots produced by `HeatKernel.plot` have labels which are reversed relative to what they should be. High values of the filtration parameter appear at the top and low values at the bottom. This is due to the quirks of the behaviour of the `"autorange"` option in `plotly` layouts.

This PR started as a fix to this problem, achieved by *simultaneously* using a flipped version of `y` and by telling `plotly` that the origin should be the bottom-left hand corner (instead of top-left) by passing `origin="lower"` to `plot_heatmap` which in turn sets `autorange` to `"reversed"` for the y-axis. I must admit that I don't fully understand exactly why this works.

Finally, the opportunity was taken to add default titles to all `plot` class methods which make use of `plot_heatmap`. This e.g. reminds the user about which sample is being plotted, or in which homology dimension (when relevant).

**Screenshots**
Before:
![plot_hk_before](https://user-images.githubusercontent.com/46537483/89776102-7d347580-db09-11ea-8b17-d5ffd3e13b35.png)
After:
![plot_hk_after](https://user-images.githubusercontent.com/46537483/89776118-832a5680-db09-11ea-88aa-21890c7b1b59.png)

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.