### PR TITLE
Refactor gtda/diagrams

### DIFF
--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -84,11 +84,13 @@ def landscapes(diagrams, sampling, n_layers):
 
 def _heat(image, sampled_diag, sigma):
     _sample_image(image, sampled_diag)
-    image[:] = gaussian_filter(image, sigma, mode="reflect")
+    gaussian_filter(image, sigma, mode="reflect", output=image)
 
 
 def heats(diagrams, sampling, step_size, sigma):
-    heats_ = np.zeros((len(diagrams), len(sampling), len(sampling)))
+    heats_ = np.zeros(
+        (len(diagrams), len(sampling), len(sampling)), dtype=float
+        )
 
     diagrams[diagrams < sampling[0, 0]] = sampling[0, 0]
     diagrams[diagrams > sampling[-1, 0]] = sampling[-1, 0]
@@ -104,7 +106,7 @@ def heats(diagrams, sampling, step_size, sigma):
 
 def persistence_images(diagrams, sampling, step_size, weights, sigma):
     persistence_images_ = np.zeros(
-        (len(diagrams), len(sampling), len(sampling))
+        (len(diagrams), len(sampling), len(sampling)), dtype=float
         )
     # Transform diagrams from (birth, death, dim) to (birth, persistence, dim)
     diagrams[:, :, 1] = diagrams[:, :, 1] - diagrams[:, :, 0]
@@ -128,8 +130,8 @@ def persistence_images(diagrams, sampling, step_size, weights, sigma):
     persistence_images_ *= weights
 
     # Smoothen the weighted-image
-    for i, image in enumerate(persistence_images_):
-        persistence_images_[i] = gaussian_filter(image, sigma, mode="reflect")
+    for image in persistence_images_:
+        gaussian_filter(image, sigma, mode="reflect", output=image)
 
     persistence_images_ = np.rot90(persistence_images_, k=1, axes=(1, 2))
     return persistence_images_

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -10,7 +10,7 @@ from scipy.spatial.distance import cdist, pdist, squareform
 from sklearn.utils import gen_even_slices
 from sklearn.utils.validation import _num_samples
 
-from ._utils import identity, _subdiagrams, _sample_image
+from ._utils import _subdiagrams, _sample_image
 from ..externals.modules.gtda_bottleneck import bottleneck_distance
 from ..externals.modules.gtda_wasserstein import wasserstein_distance
 from ..utils.intervals import Interval

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -86,7 +86,7 @@ def heats(diagrams, sampling, step_size, sigma):
     # WARNING: modifies `diagrams` in place
     heats_ = \
         np.zeros((len(diagrams), len(sampling), len(sampling)), dtype=float)
-    # If the step size is zero, we return a trivial diagram
+    # If the step size is zero, we return a trivial image
     if step_size == 0:
         return heats_
 
@@ -120,7 +120,7 @@ def persistence_images(diagrams, sampling, step_size, sigma, weights):
     # WARNING: modifies `diagrams` in place
     persistence_images_ = \
         np.zeros((len(diagrams), len(sampling), len(sampling)), dtype=float)
-    # If both step sizes are zero, we return a trivial diagram
+    # If both step sizes are zero, we return a trivial image
     if (step_size == 0).all():
         return persistence_images_
 

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -131,10 +131,6 @@ def persistence_images(diagrams, sampling, step_size, sigma, weights):
         # Calculate the value of the component of `sigma` in pixel units
         sigma_pixel.append(sigma / step_size[ax])
 
-    # diagrams_ax[...] = (diagrams_ax - first_sampling) / step_size[ax]
-    #
-    # diagrams = diagrams.astype(int)
-
     # Sample the image, apply the weights, smoothen
     for i, diagram in enumerate(diagrams):
         nontrivial_points_idx = np.flatnonzero(diagram[:, 1])

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -82,22 +82,21 @@ def landscapes(diagrams, sampling, n_layers):
     return fibers
 
 
-def _heat(image, sampled_diag, sigma):
-    _sample_image(image, sampled_diag)
+def _heat(image, sampled_diagram, sigma):
+    _sample_image(image, sampled_diagram)
     gaussian_filter(image, sigma, mode="reflect", output=image)
 
 
 def heats(diagrams, sampling, step_size, sigma):
-    heats_ = np.zeros(
-        (len(diagrams), len(sampling), len(sampling)), dtype=float
-        )
+    heats_ = \
+        np.zeros((len(diagrams), len(sampling), len(sampling)), dtype=float)
 
     diagrams[diagrams < sampling[0, 0]] = sampling[0, 0]
     diagrams[diagrams > sampling[-1, 0]] = sampling[-1, 0]
     diagrams = np.array((diagrams - sampling[0, 0]) / step_size, dtype=int)
 
-    [_heat(heats_[i], sampled_diag, sigma)
-     for i, sampled_diag in enumerate(diagrams)]
+    [_heat(heats_[i], sampled_diagram, sigma)
+     for i, sampled_diagram in enumerate(diagrams)]
 
     heats_ = heats_ - np.transpose(heats_, (0, 2, 1))
     heats_ = np.rot90(heats_, k=1, axes=(1, 2))
@@ -105,11 +104,10 @@ def heats(diagrams, sampling, step_size, sigma):
 
 
 def persistence_images(diagrams, sampling, step_size, weights, sigma):
-    persistence_images_ = np.zeros(
-        (len(diagrams), len(sampling), len(sampling)), dtype=float
-        )
+    persistence_images_ = \
+        np.zeros((len(diagrams), len(sampling), len(sampling)), dtype=float)
     # Transform diagrams from (birth, death, dim) to (birth, persistence, dim)
-    diagrams[:, :, 1] = diagrams[:, :, 1] - diagrams[:, :, 0]
+    diagrams[:, :, 1] -= diagrams[:, :, 0]
 
     for axis in [0, 1]:
         # Set the values outside of the sampling range to be the sampling range
@@ -123,8 +121,8 @@ def persistence_images(diagrams, sampling, step_size, weights, sigma):
             dtype=int
             )
     # Sample the image
-    [_sample_image(persistence_images_[i], sampled_diag)
-     for i, sampled_diag in enumerate(diagrams)]
+    [_sample_image(persistence_images_[i], sampled_diagram)
+     for i, sampled_diagram in enumerate(diagrams)]
 
     # Apply the weights
     persistence_images_ *= weights

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -190,27 +190,32 @@ def wasserstein_distances(diagrams_1, diagrams_2, p=2, delta=0.01, **kwargs):
 def betti_distances(
         diagrams_1, diagrams_2, sampling, step_size, p=2., **kwargs
         ):
+    step_size_factor = step_size ** (1 / p)
     are_arrays_equal = np.array_equal(diagrams_1, diagrams_2)
     betti_curves_1 = betti_curves(diagrams_1, sampling)
     if are_arrays_equal:
-        unnorm_dist = squareform(pdist(betti_curves_1, "minkowski", p=p))
-        return (step_size ** (1 / p)) * unnorm_dist
+        distances = pdist(betti_curves_1, "minkowski", p=p)
+        distances *= step_size_factor
+        return squareform(distances)
     betti_curves_2 = betti_curves(diagrams_2, sampling)
-    unnorm_dist = cdist(betti_curves_1, betti_curves_2, "minkowski", p=p)
-    return (step_size ** (1 / p)) * unnorm_dist
+    distances = cdist(betti_curves_1, betti_curves_2, "minkowski", p=p)
+    distances *= step_size_factor
+    return distances
 
 
 def landscape_distances(
         diagrams_1, diagrams_2, sampling, step_size, p=2., n_layers=1,
         **kwargs
         ):
+    step_size_factor = step_size ** (1 / p)
     n_samples_1, n_points_1 = diagrams_1.shape[:2]
     n_layers_1 = min(n_layers, n_points_1)
     if np.array_equal(diagrams_1, diagrams_2):
         ls_1 = landscapes(diagrams_1, sampling, n_layers_1).\
             reshape(n_samples_1, -1)
-        unnorm_dist = squareform(pdist(ls_1, "minkowski", p=p))
-        return (step_size ** (1 / p)) * unnorm_dist
+        distances = pdist(ls_1, "minkowski", p=p)
+        distances *= step_size_factor
+        return squareform(distances)
     n_samples_2, n_points_2 = diagrams_2.shape[:2]
     n_layers_2 = min(n_layers, n_points_2)
     n_layers = max(n_layers_1, n_layers_2)
@@ -218,8 +223,9 @@ def landscape_distances(
         reshape(n_samples_1, -1)
     ls_2 = landscapes(diagrams_2, sampling, n_layers).\
         reshape(n_samples_2, -1)
-    unnorm_dist = cdist(ls_1, ls_2, "minkowski", p=p)
-    return (step_size ** (1 / p)) * unnorm_dist
+    distances = cdist(ls_1, ls_2, "minkowski", p=p)
+    distances *= step_size_factor
+    return distances
 
 
 def heat_distances(
@@ -272,14 +278,17 @@ def persistence_image_distances(
 def silhouette_distances(
         diagrams_1, diagrams_2, sampling, step_size, power=1., p=2., **kwargs
         ):
+    step_size_factor = step_size ** (1 / p)
     are_arrays_equal = np.array_equal(diagrams_1, diagrams_2)
     silhouettes_1 = silhouettes(diagrams_1, sampling, power)
     if are_arrays_equal:
-        unnorm_dist = squareform(pdist(silhouettes_1, 'minkowski', p=p))
-    else:
-        silhouettes_2 = silhouettes(diagrams_2, sampling, power)
-        unnorm_dist = cdist(silhouettes_1, silhouettes_2, 'minkowski', p=p)
-    return (step_size ** (1 / p)) * unnorm_dist
+        distances = pdist(silhouettes_1, 'minkowski', p=p)
+        distances *= step_size_factor
+        return squareform(distances)
+    silhouettes_2 = silhouettes(diagrams_2, sampling, power)
+    distances = cdist(silhouettes_1, silhouettes_2, 'minkowski', p=p)
+    distances *= step_size_factor
+    return distances
 
 
 implemented_metric_recipes = {
@@ -289,7 +298,7 @@ implemented_metric_recipes = {
     "betti": betti_distances,
     "heat": heat_distances,
     "persistence_image": persistence_image_distances,
-    'silhouette': silhouette_distances,
+    'silhouette': silhouette_distances
     }
 
 
@@ -334,16 +343,22 @@ def wasserstein_amplitudes(diagrams, p=2., **kwargs):
 
 
 def betti_amplitudes(diagrams, sampling, step_size, p=2., **kwargs):
+    step_size_factor = step_size ** (1 / p)
     bcs = betti_curves(diagrams, sampling)
-    return (step_size ** (1 / p)) * np.linalg.norm(bcs, axis=1, ord=p)
+    amplitudes = np.linalg.norm(bcs, axis=1, ord=p)
+    amplitudes *= step_size_factor
+    return amplitudes
 
 
 def landscape_amplitudes(
         diagrams, sampling, step_size, p=2., n_layers=1, **kwargs
         ):
+    step_size_factor = step_size ** (1 / p)
     ls = landscapes(diagrams, sampling, n_layers).\
         reshape(len(diagrams), -1)
-    return (step_size ** (1 / p)) * np.linalg.norm(ls, axis=1, ord=p)
+    amplitudes = np.linalg.norm(ls, axis=1, ord=p)
+    amplitudes *= step_size_factor
+    return amplitudes
 
 
 def heat_amplitudes(diagrams, sampling, step_size, sigma=0.1, p=2., **kwargs):
@@ -377,8 +392,11 @@ def persistence_image_amplitudes(
 def silhouette_amplitudes(
         diagrams, sampling, step_size, power=1., p=2., **kwargs
         ):
+    step_size_factor = step_size ** (1 / p)
     silhouettes_ = silhouettes(diagrams, sampling, power)
-    return (step_size ** (1 / p)) * np.linalg.norm(silhouettes_, axis=1, ord=p)
+    amplitudes = np.linalg.norm(silhouettes_, axis=1, ord=p)
+    amplitudes *= step_size_factor
+    return amplitudes
 
 
 implemented_amplitude_recipes = {
@@ -388,7 +406,7 @@ implemented_amplitude_recipes = {
     "betti": betti_amplitudes,
     "heat": heat_amplitudes,
     "persistence_image": persistence_image_amplitudes,
-    'silhouette': silhouette_amplitudes,
+    'silhouette': silhouette_amplitudes
     }
 
 

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -142,10 +142,6 @@ def persistence_images(diagrams, sampling, step_size, sigma, weights):
         image *= weights
         gaussian_filter(image, sigma_pixel, mode="constant", output=image)
 
-    # Smoothen the weighted image
-    for image in persistence_images_:
-        gaussian_filter(image, sigma_pixel, mode="constant", output=image)
-
     persistence_images_ = np.rot90(persistence_images_, k=1, axes=(1, 2))
     persistence_images_ /= np.product(step_size)
     return persistence_images_

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -93,7 +93,8 @@ def heats(diagrams, sampling, step_size, sigma):
 
     diagrams[diagrams < sampling[0, 0]] = sampling[0, 0]
     diagrams[diagrams > sampling[-1, 0]] = sampling[-1, 0]
-    diagrams = np.array((diagrams - sampling[0, 0]) / step_size, dtype=int)
+    diagrams[...] = (diagrams - sampling[0, 0]) / step_size
+    diagrams = diagrams.astype(int)
 
     [_heat(heats_[i], sampled_diagram, sigma)
      for i, sampled_diagram in enumerate(diagrams)]
@@ -109,17 +110,15 @@ def persistence_images(diagrams, sampling, step_size, weights, sigma):
     # Transform diagrams from (birth, death, dim) to (birth, persistence, dim)
     diagrams[:, :, 1] -= diagrams[:, :, 0]
 
-    for axis in [0, 1]:
-        # Set the values outside of the sampling range to be the sampling range
-        diagrams[:, :, axis][diagrams[:, :, axis] < sampling[0, axis]] = \
-            sampling[0, axis]
-        diagrams[:, :, axis][diagrams[:, :, axis] > sampling[-1, axis]] = \
-            sampling[-1, axis]
+    for ax in [0, 1]:
+        diagrams_ax = diagrams[:, :, ax]
+        # Set the values outside of the sampling range
+        diagrams_ax[diagrams_ax < sampling[0, ax]] = sampling[0, ax]
+        diagrams_ax[diagrams_ax > sampling[-1, ax]] = sampling[-1, ax]
         # Convert into pixel
-        diagrams[:, :, axis] = np.array(
-            (diagrams[:, :, axis] - sampling[0, axis]) / step_size[axis],
-            dtype=int
-            )
+        diagrams_ax[...] = (diagrams_ax - sampling[0, ax]) / step_size[ax]
+    diagrams = diagrams.astype(int)
+
     # Sample the image
     [_sample_image(persistence_images_[i], sampled_diagram)
      for i, sampled_diagram in enumerate(diagrams)]
@@ -127,7 +126,7 @@ def persistence_images(diagrams, sampling, step_size, weights, sigma):
     # Apply the weights
     persistence_images_ *= weights
 
-    # Smoothen the weighted-image
+    # Smoothen the weighted image
     for image in persistence_images_:
         gaussian_filter(image, sigma, mode="reflect", output=image)
 

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -294,12 +294,6 @@ implemented_metric_recipes = {
     }
 
 
-def _matrix_wrapper(
-        distance_func, distance_matrices, slice_, dim, *args, **kwargs
-        ):
-    distance_matrices[:, slice_, int(dim)] = distance_func(*args, **kwargs)
-
-
 def _parallel_pairwise(
         X1, X2, metric, metric_params, homology_dimensions, n_jobs
         ):
@@ -397,12 +391,6 @@ implemented_amplitude_recipes = {
     "persistence_image": persistence_image_amplitudes,
     'silhouette': silhouette_amplitudes,
     }
-
-
-def _arrays_wrapper(
-        amplitude_func, amplitude_arrays, slice_, dim, *args, **kwargs
-        ):
-    amplitude_arrays[slice_, int(dim)] = amplitude_func(*args, **kwargs)
 
 
 def _parallel_amplitude(X, metric, metric_params, homology_dimensions, n_jobs):

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -86,6 +86,9 @@ def heats(diagrams, sampling, step_size, sigma):
     # WARNING: modifies `diagrams` in place
     heats_ = \
         np.zeros((len(diagrams), len(sampling), len(sampling)), dtype=float)
+    # If the step size is zero, we return a trivial diagram
+    if step_size == 0:
+        return heats_
 
     # Set the values outside of the sampling range
     first_sampling, last_sampling = sampling[0, 0, 0], sampling[-1, 0, 0]
@@ -117,6 +120,10 @@ def persistence_images(diagrams, sampling, step_size, sigma, weights):
     # WARNING: modifies `diagrams` in place
     persistence_images_ = \
         np.zeros((len(diagrams), len(sampling), len(sampling)), dtype=float)
+    # If both step sizes are zero, we return a trivial diagram
+    if (step_size == 0).all():
+        return persistence_images_
+
     # Transform diagrams from (birth, death, dim) to (birth, persistence, dim)
     diagrams[:, :, 1] -= diagrams[:, :, 0]
 

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -41,7 +41,7 @@ _AVAILABLE_METRICS = {
         'p': {'type': Real, 'in': Interval(1, np.inf, closed='both')},
         'n_bins': {'type': int, 'in': Interval(1, np.inf, closed='left')},
         'sigma': {'type': Real, 'in': Interval(0, np.inf, closed='neither')},
-        'weight_function': {'type': FunctionType, 'in': None}
+        'weight_function': {'type': (FunctionType, type(None))}
         },
     'silhouette': {
         'power': {'type': Real, 'in': Interval(0, np.inf, closed='right')},

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -84,7 +84,7 @@ def landscapes(diagrams, sampling, n_layers):
 
 def _heat(image, sampled_diagram, sigma):
     _sample_image(image, sampled_diagram)
-    gaussian_filter(image, sigma, mode="reflect", output=image)
+    gaussian_filter(image, sigma, mode="constant", output=image)
 
 
 def heats(diagrams, sampling, step_size, sigma):
@@ -128,7 +128,7 @@ def persistence_images(diagrams, sampling, step_size, weights, sigma):
 
     # Smoothen the weighted image
     for image in persistence_images_:
-        gaussian_filter(image, sigma, mode="reflect", output=image)
+        gaussian_filter(image, sigma, mode="constant", output=image)
 
     persistence_images_ = np.rot90(persistence_images_, k=1, axes=(1, 2))
     return persistence_images_

--- a/gtda/diagrams/_utils.py
+++ b/gtda/diagrams/_utils.py
@@ -135,3 +135,23 @@ def _bin(X, metric, n_bins=100, homology_dimensions=None, **kw_args):
             samplings[dim] = samplings[dim][:, [0], None]
             step_sizes[dim] = step_sizes[dim][0]
     return samplings, step_sizes
+
+
+def _make_homology_dimensions_mapping(
+        homology_dimensions, homology_dimensions_ref
+    ):
+    """`homology_dimensions_ref` is assumed to be a sorted tuple as is e.g.
+    :attr:`homology_dimensions_` for several transformers."""
+    if homology_dimensions is None:
+        homology_dimensions_mapping = list(enumerate(homology_dimensions_ref))
+    else:
+        homology_dimensions_mapping = []
+        for dim in homology_dimensions:
+            if dim not in homology_dimensions_ref:
+                raise ValueError(f"All homology dimensions must be in "
+                                 f"{homology_dimensions_ref}; {dim} is not.")
+            else:
+                homology_dimensions_arr = np.array(homology_dimensions_ref)
+                inv_idx = np.flatnonzero(homology_dimensions_arr == dim)[0]
+                homology_dimensions_mapping.append((inv_idx, dim))
+    return homology_dimensions_mapping

--- a/gtda/diagrams/_utils.py
+++ b/gtda/diagrams/_utils.py
@@ -20,18 +20,6 @@ def _subdiagrams(X, homology_dimensions, remove_dim=False):
     return Xs
 
 
-def _pad(X, max_diagram_sizes):
-    X_padded = {
-        dim: np.pad(
-            Xdim,
-            ((0, 0), (0, max_diagram_sizes[dim] - Xdim.shape[1]), (0, 0)),
-            "constant"
-            )
-        for dim, Xdim in X.items()
-        }
-    return X_padded
-
-
 def _sample_image(image, diagram_pixel_coords):
     # WARNING: Modifies `image` in-place
     unique, counts = \

--- a/gtda/diagrams/_utils.py
+++ b/gtda/diagrams/_utils.py
@@ -9,6 +9,8 @@ def _homology_dimensions_to_sorted_ints(homology_dimensions):
         sorted([int(dim) if dim != np.inf else dim
                 for dim in homology_dimensions])
         )
+
+
 def _subdiagrams(X, homology_dimensions, remove_dim=False):
     """For each diagram in a collection, extract the subdiagrams in a given
     list of homology dimensions. It is assumed that all diagrams in X contain

--- a/gtda/diagrams/_utils.py
+++ b/gtda/diagrams/_utils.py
@@ -90,8 +90,9 @@ def _filter(X, filtered_homology_dimensions, cutoff):
     return Xf
 
 
-def _bin(X, metric, n_bins=100, **kw_args):
-    homology_dimensions = sorted(set(X[0, :, 2]))
+def _bin(X, metric, n_bins=100, homology_dimensions=None, **kw_args):
+    if homology_dimensions is None:
+        homology_dimensions = sorted(set(X[0, :, 2]))
     # For some vectorizations, we force the values to be the same + widest
     sub_diags = {dim: _subdiagrams(X, [dim], remove_dim=True)
                  for dim in homology_dimensions}

--- a/gtda/diagrams/_utils.py
+++ b/gtda/diagrams/_utils.py
@@ -47,7 +47,7 @@ def _multirange(counts):
 
 def _filter(X, filtered_homology_dimensions, cutoff):
     n = len(X)
-    homology_dimensions = sorted(list(set(X[0, :, 2])))
+    homology_dimensions = sorted(set(X[0, :, 2]))
     unfiltered_homology_dimensions = [dim for dim in homology_dimensions if
                                       dim not in filtered_homology_dimensions]
 
@@ -91,7 +91,7 @@ def _filter(X, filtered_homology_dimensions, cutoff):
 
 
 def _bin(X, metric, n_bins=100, **kw_args):
-    homology_dimensions = sorted(list(set(X[0, :, 2])))
+    homology_dimensions = sorted(set(X[0, :, 2]))
     # For some vectorizations, we force the values to be the same + widest
     sub_diags = {dim: _subdiagrams(X, [dim], remove_dim=True)
                  for dim in homology_dimensions}

--- a/gtda/diagrams/_utils.py
+++ b/gtda/diagrams/_utils.py
@@ -4,6 +4,11 @@
 import numpy as np
 
 
+def identity(x):
+    """The identity function."""
+    return x
+
+
 def _subdiagrams(X, homology_dimensions, remove_dim=False):
     """For each diagram in a collection, extract the subdiagrams in a given
     list of homology dimensions. It is assumed that all diagrams in X contain
@@ -131,18 +136,11 @@ def _bin(X, metric, n_bins=100, **kw_args):
     samplings = {}
     step_sizes = {}
     for dim in homology_dimensions:
-        samplings[dim], step_sizes[dim] = np.linspace(min_vals[dim],
-                                                      max_vals[dim],
-                                                      retstep=True,
-                                                      num=n_bins)
+        samplings[dim], step_sizes[dim] = np.linspace(
+            min_vals[dim], max_vals[dim], retstep=True, num=n_bins
+            )
     if metric in ['landscape', 'betti', 'heat', 'silhouette']:
         for dim in homology_dimensions:
             samplings[dim] = samplings[dim][:, [0], None]
             step_sizes[dim] = step_sizes[dim][0]
     return samplings, step_sizes
-
-
-def _calculate_weights(X, weight_function, samplings, **kw_args):
-    weights = {dim: weight_function(samplings[dim][:, 1])
-               for dim in samplings.keys()}
-    return weights

--- a/gtda/diagrams/_utils.py
+++ b/gtda/diagrams/_utils.py
@@ -15,15 +15,38 @@ def _subdiagrams(X, homology_dimensions, remove_dim=False):
     """For each diagram in a collection, extract the subdiagrams in a given
     list of homology dimensions. It is assumed that all diagrams in X contain
     the same number of points in each homology dimension."""
-    n = len(X)
+    n_samples = len(X)
+    X_0 = X[0]
+
+    def _subdiagrams_single_homology_dimension(homology_dimension):
+        n_features_in_dim = np.sum(X_0[:, 2] == homology_dimension)
+        try:
+            # In this case, reshape ensures copy
+            Xs = X[X[:, :, 2] == homology_dimension].\
+                reshape(n_samples, n_features_in_dim, 3)
+            return Xs
+        except ValueError as e:
+            if e.args[0].lower().startswith("cannot reshape array"):
+                raise ValueError(
+                    f"All persistence diagrams in the collection must have "
+                    f"the same number of birth-death-dimension triples in any "
+                    f"given homology dimension. This is not true in homology "
+                    f"dimension {dim}. Trivial triples for which birth = "
+                    f"death may be added or removed to fulfill this "
+                    f"requirement."
+                )
+            else:
+                raise e
+
     if len(homology_dimensions) == 1:
-        # Reshape ensures copy
-        Xs = X[X[:, :, 2] == homology_dimensions[0]].reshape(n, -1, 3)
+        Xs = _subdiagrams_single_homology_dimension(homology_dimensions[0])
     else:
         # np.concatenate will also create a copy
-        Xs = np.concatenate([X[X[:, :, 2] == dim].reshape(n, -1, 3)
-                             for dim in homology_dimensions],
-                            axis=1)
+        Xs = np.concatenate(
+            [_subdiagrams_single_homology_dimension(dim)
+             for dim in homology_dimensions],
+            axis=1
+            )
     if remove_dim:
         Xs = Xs[:, :, :2]
     return Xs

--- a/gtda/diagrams/_utils.py
+++ b/gtda/diagrams/_utils.py
@@ -137,9 +137,8 @@ def _bin(X, metric, n_bins=100, homology_dimensions=None, **kw_args):
     return samplings, step_sizes
 
 
-def _make_homology_dimensions_mapping(
-        homology_dimensions, homology_dimensions_ref
-    ):
+def _make_homology_dimensions_mapping(homology_dimensions,
+                                      homology_dimensions_ref):
     """`homology_dimensions_ref` is assumed to be a sorted tuple as is e.g.
     :attr:`homology_dimensions_` for several transformers."""
     if homology_dimensions is None:

--- a/gtda/diagrams/_utils.py
+++ b/gtda/diagrams/_utils.py
@@ -26,10 +26,14 @@ def _subdiagrams(X, homology_dimensions, remove_dim=False):
 
 
 def _pad(X, max_diagram_sizes):
-    X_padded = {dim: np.pad(
-        X[dim],
-        ((0, 0), (0, max_diagram_sizes[dim] - X[dim].shape[1]),
-         (0, 0)), 'constant') for dim in X.keys()}
+    X_padded = {
+        dim: np.pad(
+            Xdim,
+            ((0, 0), (0, max_diagram_sizes[dim] - Xdim.shape[1]), (0, 0)),
+            "constant"
+            )
+        for dim, Xdim in X.items()
+        }
     return X_padded
 
 

--- a/gtda/diagrams/_utils.py
+++ b/gtda/diagrams/_utils.py
@@ -10,8 +10,10 @@ def _subdiagrams(X, homology_dimensions, remove_dim=False):
     the same number of points in each homology dimension."""
     n = len(X)
     if len(homology_dimensions) == 1:
+        # Reshape ensures copy
         Xs = X[X[:, :, 2] == homology_dimensions[0]].reshape(n, -1, 3)
     else:
+        # np.concatenate will also create a copy
         Xs = np.concatenate([X[X[:, :, 2] == dim].reshape(n, -1, 3)
                              for dim in homology_dimensions],
                             axis=1)

--- a/gtda/diagrams/_utils.py
+++ b/gtda/diagrams/_utils.py
@@ -4,11 +4,6 @@
 import numpy as np
 
 
-def identity(x):
-    """The identity function."""
-    return x
-
-
 def _subdiagrams(X, homology_dimensions, remove_dim=False):
     """For each diagram in a collection, extract the subdiagrams in a given
     list of homology dimensions. It is assumed that all diagrams in X contain
@@ -37,9 +32,10 @@ def _pad(X, max_diagram_sizes):
     return X_padded
 
 
-def _sample_image(image, sampled_diag):
-    # NOTE: Modifies `image` in-place
-    unique, counts = np.unique(sampled_diag, axis=0, return_counts=True)
+def _sample_image(image, diagram_pixel_coords):
+    # WARNING: Modifies `image` in-place
+    unique, counts = \
+        np.unique(diagram_pixel_coords, axis=0, return_counts=True)
     unique = tuple(tuple(row) for row in unique.astype(np.int).T)
     image[unique] = counts
 

--- a/gtda/diagrams/_utils.py
+++ b/gtda/diagrams/_utils.py
@@ -4,6 +4,11 @@
 import numpy as np
 
 
+def _homology_dimensions_to_sorted_ints(homology_dimensions):
+    return tuple(
+        sorted([int(dim) if dim != np.inf else dim
+                for dim in homology_dimensions])
+        )
 def _subdiagrams(X, homology_dimensions, remove_dim=False):
     """For each diagram in a collection, extract the subdiagrams in a given
     list of homology dimensions. It is assumed that all diagrams in X contain
@@ -49,7 +54,7 @@ def _multirange(counts):
 
 def _filter(X, filtered_homology_dimensions, cutoff):
     n = len(X)
-    homology_dimensions = sorted(set(X[0, :, 2]))
+    homology_dimensions = sorted(np.unique(X[0, :, 2]))
     unfiltered_homology_dimensions = [dim for dim in homology_dimensions if
                                       dim not in filtered_homology_dimensions]
 
@@ -94,7 +99,7 @@ def _filter(X, filtered_homology_dimensions, cutoff):
 
 def _bin(X, metric, n_bins=100, homology_dimensions=None, **kw_args):
     if homology_dimensions is None:
-        homology_dimensions = sorted(set(X[0, :, 2]))
+        homology_dimensions = sorted(np.unique(X[0, :, 2]))
     # For some vectorizations, we force the values to be the same + widest
     sub_diags = {dim: _subdiagrams(X, [dim], remove_dim=True)
                  for dim in homology_dimensions}

--- a/gtda/diagrams/_utils.py
+++ b/gtda/diagrams/_utils.py
@@ -31,9 +31,9 @@ def _subdiagrams(X, homology_dimensions, remove_dim=False):
                     f"All persistence diagrams in the collection must have "
                     f"the same number of birth-death-dimension triples in any "
                     f"given homology dimension. This is not true in homology "
-                    f"dimension {dim}. Trivial triples for which birth = "
-                    f"death may be added or removed to fulfill this "
-                    f"requirement."
+                    f"dimension {homology_dimension}. Trivial triples for "
+                    f"which birth = death may be added or removed to fulfill "
+                    f"this requirement."
                 )
             else:
                 raise e

--- a/gtda/diagrams/distance.py
+++ b/gtda/diagrams/distance.py
@@ -24,9 +24,6 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
     matrices or a single distance matrix between pairs of diagrams is
     calculated according to the following steps:
 
-    Input collections of persistence diagrams for this transformer must satisfy
-    certain requirements, see e.g. :meth:`fit`.
-
         1. All diagrams are partitioned into subdiagrams corresponding to
            distinct homology dimensions.
         2. Pairwise distances between subdiagrams of equal homology
@@ -37,22 +34,29 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
            three-dimensional array, or a single distance matrix constructed
            by taking norms of the vectors of distances between diagram pairs.
 
+    **Important notes**:
+
+        - Input collections of persistence diagrams for this transformer must
+          satisfy certain requirements, see e.g. :meth:`fit`.
+        - The shape of outputs of :meth:`transform` depends on the value of the
+          `order` parameter.
+
     Parameters
     ----------
-    metric : ``'bottleneck'`` | ``'wasserstein'`` | ``'landscape'`` | \
-        ``'betti'`` | ``'heat'`` | ``'persistence_image'``, | \
-        ``'silhouette'``, optional, default: ``'landscape'``
+    metric : ``'bottleneck'`` | ``'wasserstein'`` | ``'betti'`` | \
+        ``'landscape'`` | ``'silhouette'`` | ``'heat'`` | \
+        ``'persistence_image'``, optional, default: ``'landscape'``
         Distance or dissimilarity function between subdiagrams:
 
         - ``'bottleneck'`` and ``'wasserstein'`` refer to the identically named
           perfect-matching--based notions of distance.
+        - ``'betti'`` refers to the :math:`L^p` distance between Betti curves.
         - ``'landscape'`` refers to the :math:`L^p` distance between
           persistence landscapes.
-        - ``'betti'`` refers to the :math:`L^p` distance between Betti curves.
-        - ``'heat'`` refers to the :math:`L^p` distance between
-          Gaussian-smoothed diagrams.
         - ``'silhouette'`` refers to the :math:`L^p` distance between
           silhouettes.
+        - ``'heat'`` refers to the :math:`L^p` distance between
+          Gaussian-smoothed diagrams.
         - ``'persistence_image'`` refers to the :math:`L^p` distance between
           Gaussian-smoothed diagrams represented on birth-persistence axes.
 
@@ -61,27 +65,27 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
         ``None`` is equivalent to passing the defaults described below):
 
         - If ``metric == 'bottleneck'`` the only argument is `delta` (float,
-          default: ``0.01``). When equal to ``0.``, an exact algorithm is
-          used; otherwise, a faster approximate algorithm is used.
+          default: ``0.01``). When equal to ``0.``, an exact algorithm is used;
+          otherwise, a faster approximate algorithm is used.
         - If ``metric == 'wasserstein'`` the available arguments are `p`
           (float, default: ``2.``) and `delta` (float, default: ``0.01``).
-          Unlike the case of ``'bottleneck'``, `delta` cannot be set to
-          ``0.`` and an exact algorithm is not available.
+          Unlike the case of ``'bottleneck'``, `delta` cannot be set to ``0.``
+          and an exact algorithm is not available.
         - If ``metric == 'betti'`` the available arguments are `p` (float,
           default: ``2.``) and `n_bins` (int, default: ``100``).
-        - If ``metric == 'landscape'`` the available arguments are `p`
-          (float, default: ``2.``), `n_bins` (int, default: ``100``) and
-          `n_layers` (int, default: ``1``).
-        - If ``metric == 'heat'`` the available arguments are `p`
-          (float, default: ``2.``), `sigma` (float, default: ``1.``) and
-          `n_bins` (int, default: ``100``).
-        - If ``metric == 'silhouette'`` the available arguments are `p`
-          (float, default: ``2.``), `order` (float, default: ``1.``) and
-          `n_bins` (int, default: ``100``).
+        - If ``metric == 'landscape'`` the available arguments are `p` (float,
+          default: ``2.``), `n_bins` (int, default: ``100``) and `n_layers`
+          (int, default: ``1``).
+        - If ``metric == 'silhouette'`` the available arguments are `p` (float,
+          default: ``2.``), `power` (float, default: ``1.``) and `n_bins` (int,
+          default: ``100``).
+        - If ``metric == 'heat'`` the available arguments are `p` (float,
+          default: ``2.``), `sigma` (float, default: ``1.``) and `n_bins` (int,
+          default: ``100``).
         - If ``metric == 'persistence_image'`` the available arguments are `p`
-          (float, default: ``2.``), `sigma` (float, default: ``1.``),
-          `n_bins` (int, default: ``100``) and `weight_function`
-          (callable or None, default: ``None``).
+          (float, default: ``2.``), `sigma` (float, default: ``1.``), `n_bins`
+          (int, default: ``100``) and `weight_function` (callable or None,
+          default: ``None``).
 
     order : float or None, optional, default: ``2.``
         If ``None``, :meth:`transform` returns for each pair of diagrams a
@@ -98,7 +102,7 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
     ----------
     effective_metric_params_ : dict
         Dictionary containing all information present in `metric_params` as
-        well as on any relevant quantities computed in :meth:`fit`.
+        well as relevant quantities computed in :meth:`fit`.
 
     homology_dimensions_ : list
         Homology dimensions seen in :meth:`fit`, sorted in ascending order.

--- a/gtda/diagrams/distance.py
+++ b/gtda/diagrams/distance.py
@@ -104,7 +104,7 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
         Dictionary containing all information present in `metric_params` as
         well as relevant quantities computed in :meth:`fit`.
 
-    homology_dimensions_ : list
+    homology_dimensions_ : tuple
         Homology dimensions seen in :meth:`fit`, sorted in ascending order.
 
     See also
@@ -178,7 +178,10 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
         validate_params(
             self.effective_metric_params_, _AVAILABLE_METRICS[self.metric])
 
-        self.homology_dimensions_ = sorted(set(X[0, :, 2]))
+        self.homology_dimensions_ = tuple(
+            sorted([int(dim) if dim != np.inf else dim
+                    for dim in set(X[0, :, 2])])
+            )
 
         self.effective_metric_params_['samplings'], \
             self.effective_metric_params_['step_sizes'] = \

--- a/gtda/diagrams/distance.py
+++ b/gtda/diagrams/distance.py
@@ -8,7 +8,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
 from ._metrics import _AVAILABLE_METRICS, _parallel_pairwise
-from ._utils import _bin, _calculate_weights
+from ._utils import _bin
 from ..utils._docs import adapt_fit_transform_docs
 from ..utils.intervals import Interval
 from ..utils.validation import check_diagrams, validate_params
@@ -177,11 +177,14 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
 
         self.effective_metric_params_['samplings'], \
             self.effective_metric_params_['step_sizes'] = \
-            _bin(X, metric=self.metric, **self.effective_metric_params_)
+            _bin(X, self.metric, **self.effective_metric_params_)
 
         if self.metric == 'persistence_image':
-            self.effective_metric_params_['weights'] = \
-                _calculate_weights(X, **self.effective_metric_params_)
+            weight_function = self.effective_metric_params_['weight_function']
+            samplings = self.effective_metric_params_['samplings']
+            weights = {dim: weight_function(samplings_dim[:, 1])
+                       for dim, samplings_dim in samplings.items()}
+            self.effective_metric_params_['weights'] = weights
 
         self._X = X
         return self

--- a/gtda/diagrams/distance.py
+++ b/gtda/diagrams/distance.py
@@ -192,8 +192,9 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
             weight_function = self.effective_metric_params_.get(
                 'weight_function', None
                 )
-            if weight_function is None:
-                self.effective_metric_params_['weight_function'] = np.ones_like
+            weight_function = \
+                np.ones_like if weight_function is None else weight_function
+            self.effective_metric_params_['weight_function'] = weight_function
 
         self._X = X
         return self

--- a/gtda/diagrams/distance.py
+++ b/gtda/diagrams/distance.py
@@ -8,7 +8,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
 from ._metrics import _AVAILABLE_METRICS, _parallel_pairwise
-from ._utils import _bin, _calculate_weights
+from ._utils import _bin
 from ..utils._docs import adapt_fit_transform_docs
 from ..utils.intervals import Interval
 from ..utils.validation import check_diagrams, validate_params
@@ -178,11 +178,14 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
 
         self.effective_metric_params_['samplings'], \
             self.effective_metric_params_['step_sizes'] = \
-            _bin(X, metric=self.metric, **self.effective_metric_params_)
+            _bin(X, self.metric, **self.effective_metric_params_)
 
         if self.metric == 'persistence_image':
-            self.effective_metric_params_['weights'] = \
-                _calculate_weights(X, **self.effective_metric_params_)
+            weight_function = self.effective_metric_params_['weight_function']
+            samplings = self.effective_metric_params_['samplings']
+            weights = {dim: weight_function(samplings_dim[:, 1])
+                       for dim, samplings_dim in samplings.items()}
+            self.effective_metric_params_['weights'] = weights
 
         self._X = X
         return self

--- a/gtda/diagrams/distance.py
+++ b/gtda/diagrams/distance.py
@@ -80,10 +80,10 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
           default: ``2.``), `power` (float, default: ``1.``) and `n_bins` (int,
           default: ``100``).
         - If ``metric == 'heat'`` the available arguments are `p` (float,
-          default: ``2.``), `sigma` (float, default: ``1.``) and `n_bins` (int,
-          default: ``100``).
+          default: ``2.``), `sigma` (float, default: ``0.1``) and `n_bins`
+          (int, default: ``100``).
         - If ``metric == 'persistence_image'`` the available arguments are `p`
-          (float, default: ``2.``), `sigma` (float, default: ``1.``), `n_bins`
+          (float, default: ``2.``), `sigma` (float, default: ``0.1``), `n_bins`
           (int, default: ``100``) and `weight_function` (callable or None,
           default: ``None``).
 
@@ -185,11 +185,11 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
             _bin(X, self.metric, **self.effective_metric_params_)
 
         if self.metric == 'persistence_image':
-            weight_function = self.effective_metric_params_['weight_function']
-            samplings = self.effective_metric_params_['samplings']
-            weights = {dim: weight_function(samplings_dim[:, 1])
-                       for dim, samplings_dim in samplings.items()}
-            self.effective_metric_params_['weights'] = weights
+            weight_function = self.effective_metric_params_.get(
+                'weight_function', None
+                )
+            if weight_function is None:
+                self.effective_metric_params_['weight_function'] = np.ones_like
 
         self._X = X
         return self

--- a/gtda/diagrams/distance.py
+++ b/gtda/diagrams/distance.py
@@ -8,7 +8,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
 from ._metrics import _AVAILABLE_METRICS, _parallel_pairwise
-from ._utils import _bin
+from ._utils import _bin, _homology_dimensions_to_sorted_ints
 from ..utils._docs import adapt_fit_transform_docs
 from ..utils.intervals import Interval
 from ..utils.validation import check_diagrams, validate_params
@@ -178,10 +178,11 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
         validate_params(
             self.effective_metric_params_, _AVAILABLE_METRICS[self.metric])
 
-        self.homology_dimensions_ = tuple(
-            sorted([int(dim) if dim != np.inf else dim
-                    for dim in set(X[0, :, 2])])
-            )
+        # Find the unique homology dimensions in the 3D array X passed to `fit`
+        # assuming that they can all be found in its zero-th entry
+        homology_dimensions_fit = np.unique(X[0, :, 2])
+        self.homology_dimensions_ = \
+            _homology_dimensions_to_sorted_ints(homology_dimensions_fit)
 
         self.effective_metric_params_['samplings'], \
             self.effective_metric_params_['step_sizes'] = \

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -233,10 +233,10 @@ class Amplitude(BaseEstimator, TransformerMixin):
           default: ``2.``), `power` (float, default: ``1.``) and `n_bins` (int,
           default: ``100``).
         - If ``metric == 'heat'`` the available arguments are `p` (float,
-          default: ``2.``), `sigma` (float, default: ``1.``) and `n_bins` (int,
-          default: ``100``).
+          default: ``2.``), `sigma` (float, default: ``0.1``) and `n_bins`
+          (int, default: ``100``).
         - If ``metric == 'persistence_image'`` the available arguments are `p`
-          (float, default: ``2.``), `sigma` (float, default: ``1.``), `n_bins`
+          (float, default: ``2.``), `sigma` (float, default: ``0.1``), `n_bins`
           (int, default: ``100``) and `weight_function` (callable or None,
           default: ``None``).
 
@@ -334,11 +334,11 @@ class Amplitude(BaseEstimator, TransformerMixin):
             _bin(X, self.metric, **self.effective_metric_params_)
 
         if self.metric == 'persistence_image':
-            weight_function = self.effective_metric_params_['weight_function']
-            samplings = self.effective_metric_params_['samplings']
-            weights = {dim: weight_function(samplings_dim[:, 1])
-                       for dim, samplings_dim in samplings.items()}
-            self.effective_metric_params_['weights'] = weights
+            weight_function = self.effective_metric_params_.get(
+                'weight_function', None
+                )
+            if weight_function is None:
+                self.effective_metric_params_['weight_function'] = np.ones_like
 
         return self
 

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -11,7 +11,7 @@ from sklearn.utils import gen_even_slices
 from sklearn.utils.validation import check_is_fitted
 
 from ._metrics import _AVAILABLE_AMPLITUDE_METRICS, _parallel_amplitude
-from ._utils import _subdiagrams, _bin
+from ._utils import _subdiagrams, _bin, _homology_dimensions_to_sorted_ints
 from ..utils._docs import adapt_fit_transform_docs
 from ..utils.intervals import Interval
 from ..utils.validation import validate_params, check_diagrams
@@ -127,10 +127,11 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
         validate_params(
             self.get_params(), self._hyperparameters, exclude=['n_jobs'])
 
-        self.homology_dimensions_ = tuple(
-            sorted([int(dim) if dim != np.inf else dim
-                    for dim in set(X[0, :, 2])])
-            )
+        # Find the unique homology dimensions in the 3D array X passed to `fit`
+        # assuming that they can all be found in its zero-th entry
+        homology_dimensions_fit = np.unique(X[0, :, 2])
+        self.homology_dimensions_ = \
+            _homology_dimensions_to_sorted_ints(homology_dimensions_fit)
         self._n_dimensions = len(self.homology_dimensions_)
 
         return self
@@ -330,10 +331,11 @@ class Amplitude(BaseEstimator, TransformerMixin):
         validate_params(self.effective_metric_params_,
                         _AVAILABLE_AMPLITUDE_METRICS[self.metric])
 
-        self.homology_dimensions_ = tuple(
-            sorted([int(dim) if dim != np.inf else dim
-                    for dim in set(X[0, :, 2])])
-            )
+        # Find the unique homology dimensions in the 3D array X passed to `fit`
+        # assuming that they can all be found in its zero-th entry
+        homology_dimensions_fit = np.unique(X[0, :, 2])
+        self.homology_dimensions_ = \
+            _homology_dimensions_to_sorted_ints(homology_dimensions_fit)
 
         self.effective_metric_params_['samplings'], \
             self.effective_metric_params_['step_sizes'] = \

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -11,7 +11,7 @@ from sklearn.utils import gen_even_slices
 from sklearn.utils.validation import check_is_fitted
 
 from ._metrics import _AVAILABLE_AMPLITUDE_METRICS, _parallel_amplitude
-from ._utils import _subdiagrams, _bin, _calculate_weights
+from ._utils import _subdiagrams, _bin
 from ..utils._docs import adapt_fit_transform_docs
 from ..utils.intervals import Interval
 from ..utils.validation import validate_params, check_diagrams
@@ -326,11 +326,14 @@ class Amplitude(BaseEstimator, TransformerMixin):
 
         self.effective_metric_params_['samplings'], \
             self.effective_metric_params_['step_sizes'] = \
-            _bin(X, metric=self.metric, **self.effective_metric_params_)
+            _bin(X, self.metric, **self.effective_metric_params_)
 
         if self.metric == 'persistence_image':
-            self.effective_metric_params_['weights'] = \
-                _calculate_weights(X, **self.effective_metric_params_)
+            weight_function = self.effective_metric_params_['weight_function']
+            samplings = self.effective_metric_params_['samplings']
+            weights = {dim: weight_function(samplings_dim[:, 1])
+                       for dim, samplings_dim in samplings.items()}
+            self.effective_metric_params_['weights'] = weights
 
         return self
 

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -345,8 +345,9 @@ class Amplitude(BaseEstimator, TransformerMixin):
             weight_function = self.effective_metric_params_.get(
                 'weight_function', None
                 )
-            if weight_function is None:
-                self.effective_metric_params_['weight_function'] = np.ones_like
+            weight_function = \
+                np.ones_like if weight_function is None else weight_function
+            self.effective_metric_params_['weight_function'] = weight_function
 
         return self
 

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -240,7 +240,7 @@ class Amplitude(BaseEstimator, TransformerMixin):
           (int, default: ``100``) and `weight_function` (callable or None,
           default: ``None``).
 
-    order : float or None, optional, default: ``2.``
+    order : float or None, optional, default: ``None``
         If ``None``, :meth:`transform` returns for each diagram a vector of
         amplitudes corresponding to the dimensions in
         :attr:`homology_dimensions_`. Otherwise, the :math:`p`-norm of
@@ -282,7 +282,7 @@ class Amplitude(BaseEstimator, TransformerMixin):
         'metric_params': {'type': (dict, type(None))}
         }
 
-    def __init__(self, metric='landscape', metric_params=None, order=2.,
+    def __init__(self, metric='landscape', metric_params=None, order=None,
                  n_jobs=None):
         self.metric = metric
         self.metric_params = metric_params

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -58,7 +58,7 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
 
     Attributes
     ----------
-    homology_dimensions_ : list
+    homology_dimensions_ : tuple
         Homology dimensions seen in :meth:`fit`, sorted in ascending order.
 
     See also
@@ -127,7 +127,10 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
         validate_params(
             self.get_params(), self._hyperparameters, exclude=['n_jobs'])
 
-        self.homology_dimensions_ = sorted(set(X[0, :, 2]))
+        self.homology_dimensions_ = tuple(
+            sorted([int(dim) if dim != np.inf else dim
+                    for dim in set(X[0, :, 2])])
+            )
         self._n_dimensions = len(self.homology_dimensions_)
 
         return self
@@ -257,7 +260,7 @@ class Amplitude(BaseEstimator, TransformerMixin):
         Dictionary containing all information present in `metric_params` as
         well as relevant quantities computed in :meth:`fit`.
 
-    homology_dimensions_ : list
+    homology_dimensions_ : tuple
         Homology dimensions seen in :meth:`fit`, sorted in ascending order.
 
     See also
@@ -327,7 +330,10 @@ class Amplitude(BaseEstimator, TransformerMixin):
         validate_params(self.effective_metric_params_,
                         _AVAILABLE_AMPLITUDE_METRICS[self.metric])
 
-        self.homology_dimensions_ = sorted(set(X[0, :, 2]))
+        self.homology_dimensions_ = tuple(
+            sorted([int(dim) if dim != np.inf else dim
+                    for dim in set(X[0, :, 2])])
+            )
 
         self.effective_metric_params_['samplings'], \
             self.effective_metric_params_['step_sizes'] = \

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -30,13 +30,14 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
     differences. Optionally, these entropies can be normalized according to a
     simple heuristic, see `normalize`.
 
-    Input collections of persistence diagrams for this transformer must satisfy
-    certain requirements, see e.g. :meth:`fit`.
+    **Important notes**:
 
-    **Important note**: By default, persistence subdiagrams containing only
-    triples with zero lifetime will have corresponding (normalized) entropies
-    computed as ``numpy.nan``. To avoid this, set a value of `nan_fill_value`
-    different from ``None``.
+        - Input collections of persistence diagrams for this transformer must
+          satisfy certain requirements, see e.g. :meth:`fit`.
+        - By default, persistence subdiagrams containing only triples with zero
+          lifetime will have corresponding (normalized) entropies computed as
+          ``numpy.nan``. To avoid this, set a value of `nan_fill_value`
+          different from ``None``.
 
     Parameters
     ----------
@@ -189,26 +190,30 @@ class Amplitude(BaseEstimator, TransformerMixin):
         3. The final result is either :math:`\\mathbf{a}` itself or
            a norm of :math:`\\mathbf{a}`, specified by the parameter `order`.
 
-    Input collections of persistence diagrams for this transformer must satisfy
-    certain requirements, see e.g. :meth:`fit`.
+    **Important notes**:
+
+        - Input collections of persistence diagrams for this transformer must
+          satisfy certain requirements, see e.g. :meth:`fit`.
+        - The shape of outputs of :meth:`transform` depends on the value of the
+          `order` parameter.
 
     Parameters
     ----------
-    metric : ``'bottleneck'`` | ``'wasserstein'`` | ``'landscape'`` | \
-        ``'betti'`` | ``'heat'`` | ``'silhouette'`` | \
+    metric : ``'bottleneck'`` | ``'wasserstein'`` | ``'betti'`` | \
+        ``'landscape'`` | ``'silhouette'`` | ``'heat'`` | \
         ``'persistence_image'``, optional, default: ``'landscape'``
         Distance or dissimilarity function used to define the amplitude of
         a subdiagram as its distance from the (trivial) diagonal diagram:
 
         - ``'bottleneck'`` and ``'wasserstein'`` refer to the identically named
           perfect-matching--based notions of distance.
+        - ``'betti'`` refers to the :math:`L^p` distance between Betti curves.
         - ``'landscape'`` refers to the :math:`L^p` distance between
           persistence landscapes.
-        - ``'betti'`` refers to the :math:`L^p` distance between Betti curves.
-        - ``'heat'`` refers to the :math:`L^p` distance between
-          Gaussian-smoothed diagrams.
         - ``'silhouette'`` refers to the :math:`L^p` distance between
           silhouettes.
+        - ``'heat'`` refers to the :math:`L^p` distance between
+          Gaussian-smoothed diagrams.
         - ``'persistence_image'`` refers to the :math:`L^p` distance between
           Gaussian-smoothed diagrams represented on birth-persistence axes.
 
@@ -219,21 +224,21 @@ class Amplitude(BaseEstimator, TransformerMixin):
         - If ``metric == 'bottleneck'`` there are no available arguments.
         - If ``metric == 'wasserstein'`` the only argument is `p` (float,
           default: ``2.``).
-        - If ``metric == 'landscape'`` the available arguments are `p`
-          (float, default: ``2.``), `n_bins` (int, default: ``100``) and
-          `n_layers` (int, default: ``1``).
         - If ``metric == 'betti'`` the available arguments are `p` (float,
           default: ``2.``) and `n_bins` (int, default: ``100``).
+        - If ``metric == 'landscape'`` the available arguments are `p` (float,
+          default: ``2.``), `n_bins` (int, default: ``100``) and `n_layers`
+          (int, default: ``1``).
+        - If ``metric == 'silhouette'`` the available arguments are `p` (float,
+          default: ``2.``), `power` (float, default: ``1.``) and `n_bins` (int,
+          default: ``100``).
         - If ``metric == 'heat'`` the available arguments are `p` (float,
-          default: ``2.``), `sigma` (float, default: ``1.``) and `n_bins`
-          (int, default: ``100``).
-        - If ``metric == 'silhouette'`` the available arguments are `p`
-          (float, default: ``2.``), `order` (float, default: ``1.``) and
-          `n_bins` (int, default: ``100``).
+          default: ``2.``), `sigma` (float, default: ``1.``) and `n_bins` (int,
+          default: ``100``).
         - If ``metric == 'persistence_image'`` the available arguments are `p`
-          (float, default: ``2.``), `sigma` (float, default: ``1.``),
-          `n_bins` (int, default: ``100``) and `weight_function`
-          (callable or None, default: ``None``).
+          (float, default: ``2.``), `sigma` (float, default: ``1.``), `n_bins`
+          (int, default: ``100``) and `weight_function` (callable or None,
+          default: ``None``).
 
     order : float or None, optional, default: ``2.``
         If ``None``, :meth:`transform` returns for each diagram a vector of
@@ -250,7 +255,7 @@ class Amplitude(BaseEstimator, TransformerMixin):
     ----------
     effective_metric_params_ : dict
         Dictionary containing all information present in `metric_params` as
-        well as on any relevant quantities computed in :meth:`fit`.
+        well as relevant quantities computed in :meth:`fit`.
 
     homology_dimensions_ : list
         Homology dimensions seen in :meth:`fit`, sorted in ascending order.

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -11,7 +11,7 @@ from sklearn.utils import gen_even_slices
 from sklearn.utils.validation import check_is_fitted
 
 from ._metrics import _AVAILABLE_AMPLITUDE_METRICS, _parallel_amplitude
-from ._utils import _subdiagrams, _bin, _calculate_weights
+from ._utils import _subdiagrams, _bin
 from ..utils._docs import adapt_fit_transform_docs
 from ..utils.intervals import Interval
 from ..utils.validation import validate_params, check_diagrams
@@ -325,11 +325,14 @@ class Amplitude(BaseEstimator, TransformerMixin):
 
         self.effective_metric_params_['samplings'], \
             self.effective_metric_params_['step_sizes'] = \
-            _bin(X, metric=self.metric, **self.effective_metric_params_)
+            _bin(X, self.metric, **self.effective_metric_params_)
 
         if self.metric == 'persistence_image':
-            self.effective_metric_params_['weights'] = \
-                _calculate_weights(X, **self.effective_metric_params_)
+            weight_function = self.effective_metric_params_['weight_function']
+            samplings = self.effective_metric_params_['samplings']
+            weights = {dim: weight_function(samplings_dim[:, 1])
+                       for dim, samplings_dim in samplings.items()}
+            self.effective_metric_params_['weights'] = weights
 
         return self
 

--- a/gtda/diagrams/preprocessing.py
+++ b/gtda/diagrams/preprocessing.py
@@ -169,7 +169,7 @@ class Scaler(BaseEstimator, TransformerMixin, PlotterMixin):
         Dictionary containing all information present in `metric_params` as
         well as relevant quantities computed in :meth:`fit`.
 
-    homology_dimensions_ : list
+    homology_dimensions_ : tuple
         Homology dimensions seen in :meth:`fit`, sorted in ascending order.
 
     scale_ : float
@@ -239,7 +239,10 @@ class Scaler(BaseEstimator, TransformerMixin, PlotterMixin):
         validate_params(self.effective_metric_params_,
                         _AVAILABLE_AMPLITUDE_METRICS[self.metric])
 
-        self.homology_dimensions_ = sorted(set(X[0, :, 2]))
+        self.homology_dimensions_ = tuple(
+            sorted([int(dim) if dim != np.inf else dim
+                    for dim in set(X[0, :, 2])])
+            )
 
         self.effective_metric_params_['samplings'], \
             self.effective_metric_params_['step_sizes'] = \
@@ -356,10 +359,10 @@ class Filtering(BaseEstimator, TransformerMixin, PlotterMixin):
     """Filtering of persistence diagrams.
 
     Filtering a diagram means discarding all points [b, d, q] representing
-    non-trivial topological features whose lifetime d - b is less than or
-    equal to a cutoff value. Points on the diagonal (i.e. for which b and d
-    are equal) may still appear in the output for padding purposes, but carry
-    no information.
+    non-trivial topological features whose lifetime d - b is less than or equal
+    to a cutoff value. Points on the diagonal (i.e. for which b and d are
+    equal) may still appear in the output for padding purposes, but carry no
+    information.
 
     **Important note**:
 
@@ -379,11 +382,10 @@ class Filtering(BaseEstimator, TransformerMixin, PlotterMixin):
 
     Attributes
     ----------
-    homology_dimensions_ : list
-        If `homology_dimensions` is set to ``None``, then this is the list
-        of homology dimensions seen in :meth:`fit`, sorted in ascending
-        order. Otherwise, it is a similarly sorted version of
-        `homology_dimensions`.
+    homology_dimensions_ : tuple
+        If `homology_dimensions` is set to ``None``, contains the homology
+        dimensions seen in :meth:`fit`, sorted in ascending order. Otherwise,
+        it is a similarly sorted version of `homology_dimensions`.
 
     See also
     --------
@@ -434,10 +436,15 @@ class Filtering(BaseEstimator, TransformerMixin, PlotterMixin):
             self.get_params(), self._hyperparameters)
 
         if self.homology_dimensions is None:
-            self.homology_dimensions_ = [int(dim) for dim in set(X[0, :, 2])]
+            self.homology_dimensions_ = [
+                int(dim) if dim != np.inf else dim for dim in set(X[0, :, 2])
+                ]
         else:
             self.homology_dimensions_ = self.homology_dimensions
-        self.homology_dimensions_ = sorted(self.homology_dimensions_)
+        self.homology_dimensions_ = tuple(
+            sorted([int(dim) if dim != np.inf else dim
+                    for dim in set(X[0, :, 2])])
+            )
 
         return self
 

--- a/gtda/diagrams/preprocessing.py
+++ b/gtda/diagrams/preprocessing.py
@@ -9,7 +9,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
 from ._metrics import _AVAILABLE_AMPLITUDE_METRICS, _parallel_amplitude
-from ._utils import _filter, _bin, _calculate_weights
+from ._utils import _filter, _bin
 from ..base import PlotterMixin
 from ..plotting.persistence_diagrams import plot_diagram
 from ..utils._docs import adapt_fit_transform_docs
@@ -241,11 +241,14 @@ class Scaler(BaseEstimator, TransformerMixin, PlotterMixin):
 
         self.effective_metric_params_['samplings'], \
             self.effective_metric_params_['step_sizes'] = \
-            _bin(X, metric=self.metric, **self.effective_metric_params_)
+            _bin(X, self.metric, **self.effective_metric_params_)
 
         if self.metric == 'persistence_image':
-            self.effective_metric_params_['weights'] = \
-                _calculate_weights(X, **self.effective_metric_params_)
+            weight_function = self.effective_metric_params_['weight_function']
+            samplings = self.effective_metric_params_['samplings']
+            weights = {dim: weight_function(samplings_dim[:, 1])
+                       for dim, samplings_dim in samplings.items()}
+            self.effective_metric_params_['weights'] = weights
 
         amplitude_array = _parallel_amplitude(X, self.metric,
                                               self.effective_metric_params_,

--- a/gtda/diagrams/preprocessing.py
+++ b/gtda/diagrams/preprocessing.py
@@ -441,10 +441,7 @@ class Filtering(BaseEstimator, TransformerMixin, PlotterMixin):
                 ]
         else:
             self.homology_dimensions_ = self.homology_dimensions
-        self.homology_dimensions_ = tuple(
-            sorted([int(dim) if dim != np.inf else dim
-                    for dim in set(X[0, :, 2])])
-            )
+        self.homology_dimensions_ = tuple(sorted(self.homology_dimensions_))
 
         return self
 

--- a/gtda/diagrams/preprocessing.py
+++ b/gtda/diagrams/preprocessing.py
@@ -285,7 +285,7 @@ class Scaler(BaseEstimator, TransformerMixin, PlotterMixin):
         """
         check_is_fitted(self)
 
-        Xs = check_diagrams(X)
+        Xs = check_diagrams(X, copy=True)
         Xs[:, :, :2] /= self.scale_
         return Xs
 
@@ -306,7 +306,7 @@ class Scaler(BaseEstimator, TransformerMixin, PlotterMixin):
         """
         check_is_fitted(self)
 
-        Xs = check_diagrams(X)
+        Xs = check_diagrams(X, copy=True)
         Xs[:, :, :2] *= self.scale_
         return Xs
 

--- a/gtda/diagrams/preprocessing.py
+++ b/gtda/diagrams/preprocessing.py
@@ -253,8 +253,9 @@ class Scaler(BaseEstimator, TransformerMixin, PlotterMixin):
             weight_function = self.effective_metric_params_.get(
                 'weight_function', None
                 )
-            if weight_function is None:
-                self.effective_metric_params_['weight_function'] = np.ones_like
+            weight_function = \
+                np.ones_like if weight_function is None else weight_function
+            self.effective_metric_params_['weight_function'] = weight_function
 
         amplitude_array = _parallel_amplitude(X, self.metric,
                                               self.effective_metric_params_,

--- a/gtda/diagrams/preprocessing.py
+++ b/gtda/diagrams/preprocessing.py
@@ -147,8 +147,8 @@ class Scaler(BaseEstimator, TransformerMixin, PlotterMixin):
     Parameters
     ----------
     metric : ``'bottleneck'`` | ``'wasserstein'`` | ``'betti'`` | \
-        ``'landscape'`` | ``'heat'`` | ``'persistence_image'`` | \
-        ``'silhouette'``, optional, default: ``'bottleneck'``
+        ``'landscape'`` |``'silhouette'`` |  ``'heat'`` | \
+        ``'persistence_image'``, optional, default: ``'bottleneck'``
         See the corresponding parameter in :class:`Amplitude`.
 
     metric_params : dict or None, optional, default: ``None``
@@ -246,11 +246,11 @@ class Scaler(BaseEstimator, TransformerMixin, PlotterMixin):
             _bin(X, self.metric, **self.effective_metric_params_)
 
         if self.metric == 'persistence_image':
-            weight_function = self.effective_metric_params_['weight_function']
-            samplings = self.effective_metric_params_['samplings']
-            weights = {dim: weight_function(samplings_dim[:, 1])
-                       for dim, samplings_dim in samplings.items()}
-            self.effective_metric_params_['weights'] = weights
+            weight_function = self.effective_metric_params_.get(
+                'weight_function', None
+                )
+            if weight_function is None:
+                self.effective_metric_params_['weight_function'] = np.ones_like
 
         amplitude_array = _parallel_amplitude(X, self.metric,
                                               self.effective_metric_params_,

--- a/gtda/diagrams/preprocessing.py
+++ b/gtda/diagrams/preprocessing.py
@@ -139,8 +139,10 @@ class Scaler(BaseEstimator, TransformerMixin, PlotterMixin):
           two-dimensional array of amplitudes (one per diagram and homology
           dimension) to obtain :attr:`scale_`.
 
-    Input collections of persistence diagrams for this transformer must satisfy
-    certain requirements, see e.g. :meth:`fit`.
+    **Important note**:
+
+        - Input collections of persistence diagrams for this transformer must
+          satisfy certain requirements, see e.g. :meth:`fit`.
 
     Parameters
     ----------
@@ -157,15 +159,15 @@ class Scaler(BaseEstimator, TransformerMixin, PlotterMixin):
         amplitude vectors in :meth:`fit`. Must map 2D arrays to scalars.
 
     n_jobs : int or None, optional, default: ``None``
-        The number of jobs to use for the computation. ``None`` means 1
-        unless in a :obj:`joblib.parallel_backend` context. ``-1`` means
-        using all processors.
+        The number of jobs to use for the computation. ``None`` means 1 unless
+        in a :obj:`joblib.parallel_backend` context. ``-1`` means using all
+        processors.
 
     Attributes
     ----------
     effective_metric_params_ : dict
         Dictionary containing all information present in `metric_params` as
-        well as on any relevant quantities computed in :meth:`fit`.
+        well as relevant quantities computed in :meth:`fit`.
 
     homology_dimensions_ : list
         Homology dimensions seen in :meth:`fit`, sorted in ascending order.
@@ -359,8 +361,10 @@ class Filtering(BaseEstimator, TransformerMixin, PlotterMixin):
     are equal) may still appear in the output for padding purposes, but carry
     no information.
 
-    Input collections of persistence diagrams for this transformer must satisfy
-    certain requirements, see e.g. :meth:`fit`.
+    **Important note**:
+
+        - Input collections of persistence diagrams for this transformer must
+          satisfy certain requirements, see e.g. :meth:`fit`.
 
     Parameters
     ----------

--- a/gtda/diagrams/preprocessing.py
+++ b/gtda/diagrams/preprocessing.py
@@ -9,7 +9,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
 from ._metrics import _AVAILABLE_AMPLITUDE_METRICS, _parallel_amplitude
-from ._utils import _filter, _bin
+from ._utils import _filter, _bin, _homology_dimensions_to_sorted_ints
 from ..base import PlotterMixin
 from ..plotting.persistence_diagrams import plot_diagram
 from ..utils._docs import adapt_fit_transform_docs
@@ -239,10 +239,11 @@ class Scaler(BaseEstimator, TransformerMixin, PlotterMixin):
         validate_params(self.effective_metric_params_,
                         _AVAILABLE_AMPLITUDE_METRICS[self.metric])
 
-        self.homology_dimensions_ = tuple(
-            sorted([int(dim) if dim != np.inf else dim
-                    for dim in set(X[0, :, 2])])
-            )
+        # Find the unique homology dimensions in the 3D array X passed to `fit`
+        # assuming that they can all be found in its zero-th entry
+        homology_dimensions_fit = np.unique(X[0, :, 2])
+        self.homology_dimensions_ = \
+            _homology_dimensions_to_sorted_ints(homology_dimensions_fit)
 
         self.effective_metric_params_['samplings'], \
             self.effective_metric_params_['step_sizes'] = \
@@ -436,12 +437,13 @@ class Filtering(BaseEstimator, TransformerMixin, PlotterMixin):
             self.get_params(), self._hyperparameters)
 
         if self.homology_dimensions is None:
-            self.homology_dimensions_ = [
-                int(dim) if dim != np.inf else dim for dim in set(X[0, :, 2])
-                ]
+            # Find the unique homology dimensions in the 3D array X passed to
+            # `fit` assuming that they can all be found in its zero-th entry
+            homology_dimensions = np.unique(X[0, :, 2])
         else:
-            self.homology_dimensions_ = self.homology_dimensions
-        self.homology_dimensions_ = tuple(sorted(self.homology_dimensions_))
+            homology_dimensions = self.homology_dimensions
+        self.homology_dimensions_ = \
+            _homology_dimensions_to_sorted_ints(homology_dimensions)
 
         return self
 

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -237,11 +237,12 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
         fig = Figure(layout=layout)
 
         for ix, dim in _homology_dimensions:
+            name = f"H{int(dim) if dim != np.inf else np.inf}"
             fig.add_trace(Scatter(x=self.samplings_[dim],
                                   y=Xt[sample][ix],
                                   mode="lines",
                                   showlegend=True,
-                                  name=f"H{int(dim)}"))
+                                  name=name))
 
         # Update traces and layout according to user input
         if plotly_params:
@@ -1200,12 +1201,13 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
         fig = Figure(layout=layout)
 
         for ix, dim in _homology_dimensions:
+            name = f"H{int(dim) if dim != np.inf else np.inf}"
             fig.add_trace(Scatter(x=self.samplings_[dim],
                                   y=Xt[sample][ix],
                                   mode="lines",
                                   showlegend=True,
                                   hoverinfo="none",
-                                  name=f"H{int(dim)}"))
+                                  name=name))
 
         # Update traces and layout according to user input
         if plotly_params:

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -14,7 +14,7 @@ from sklearn.utils.validation import check_is_fitted
 
 from ._metrics import betti_curves, landscapes, heats, \
     persistence_images, silhouettes
-from ._utils import _subdiagrams, _bin
+from ._utils import _subdiagrams, _bin, _make_homology_dimensions_mapping
 from ..base import PlotterMixin
 from ..plotting import plot_heatmap
 from ..utils._docs import adapt_fit_transform_docs
@@ -196,21 +196,9 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
         """
         check_is_fitted(self)
 
-        if homology_dimensions is None:
-            _homology_dimensions = list(enumerate(self.homology_dimensions_))
-        else:
-            _homology_dimensions = []
-            for dim in homology_dimensions:
-                if dim not in self.homology_dimensions_:
-                    raise ValueError(
-                        f"All homology dimensions must be in "
-                        f"self.homology_dimensions_ which is "
-                        f"{self.homology_dimensions_}. {dim} is not.")
-                else:
-                    homology_dimensions_arr = np.array(
-                        self.homology_dimensions_)
-                    ix = np.flatnonzero(homology_dimensions_arr == dim)[0]
-                    _homology_dimensions.append((ix, dim))
+        homology_dimensions_mapping = _make_homology_dimensions_mapping(
+            homology_dimensions, self.homology_dimensions_
+            )
 
         layout_axes_common = {
             "type": "linear",
@@ -242,7 +230,7 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
 
         fig = Figure(layout=layout)
 
-        for ix, dim in _homology_dimensions:
+        for ix, dim in homology_dimensions_mapping:
             fig.add_trace(Scatter(x=self.samplings_[dim],
                                   y=Xt[sample][ix],
                                   mode="lines",
@@ -446,21 +434,9 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
         """
         check_is_fitted(self)
 
-        if homology_dimensions is None:
-            _homology_dimensions = list(enumerate(self.homology_dimensions_))
-        else:
-            _homology_dimensions = []
-            for dim in homology_dimensions:
-                if dim not in self.homology_dimensions_:
-                    raise ValueError(
-                        f"All homology dimensions must be in "
-                        f"self.homology_dimensions_ which is "
-                        f"{self.homology_dimensions_}. {dim} is not.")
-                else:
-                    homology_dimensions_arr = np.array(
-                        self.homology_dimensions_)
-                    inv_idx = np.flatnonzero(homology_dimensions_arr == dim)[0]
-                    _homology_dimensions.append((inv_idx, dim))
+        homology_dimensions_mapping = _make_homology_dimensions_mapping(
+            homology_dimensions, self.homology_dimensions_
+            )
 
         layout_axes_common = {
             "type": "linear",
@@ -489,11 +465,11 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
 
         Xt_sample = Xt[sample]
         n_layers = Xt_sample.shape[1]
-        subplot_titles = [f"H{dim} for _, dim in _homology_dimensions"]
-        fig = make_subplots(rows=len(_homology_dimensions), cols=1,
+        subplot_titles = [f"H{dim}" for _, dim in homology_dimensions_mapping]
+        fig = make_subplots(rows=len(homology_dimensions_mapping), cols=1,
                             subplot_titles=subplot_titles)
-        has_many_homology_dim = len(_homology_dimensions) - 1
-        for i, (inv_idx, dim) in enumerate(_homology_dimensions):
+        has_many_homology_dim = len(homology_dimensions_mapping) - 1
+        for i, (inv_idx, dim) in enumerate(homology_dimensions_mapping):
             hom_dim_str = \
                 f" ({subplot_titles[i]})" if has_many_homology_dim else ""
             for layer in range(n_layers):
@@ -1182,21 +1158,9 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
         """
         check_is_fitted(self)
 
-        if homology_dimensions is None:
-            _homology_dimensions = list(enumerate(self.homology_dimensions_))
-        else:
-            _homology_dimensions = []
-            for dim in homology_dimensions:
-                if dim not in self.homology_dimensions_:
-                    raise ValueError(
-                        f"All homology dimensions must be in "
-                        f"self.homology_dimensions_ which is "
-                        f"{self.homology_dimensions_}. {dim} is not.")
-                else:
-                    homology_dimensions_arr = np.array(
-                        self.homology_dimensions_)
-                    ix = np.flatnonzero(homology_dimensions_arr == dim)[0]
-                    _homology_dimensions.append((ix, dim))
+        homology_dimensions_mapping = _make_homology_dimension_mapping(
+            homology_dimensions, self.homology_dimensions_
+            )
 
         layout_axes_common = {
             "type": "linear",
@@ -1227,7 +1191,7 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
 
         fig = Figure(layout=layout)
 
-        for ix, dim in _homology_dimensions:
+        for ix, dim in homology_dimensions_mapping:
             fig.add_trace(Scatter(x=self.samplings_[dim],
                                   y=Xt[sample][ix],
                                   mode="lines",

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -942,8 +942,11 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
             homology_dimension = int(homology_dimension)
         samplings_x, samplings_y = self.samplings_[homology_dimension]
         return plot_heatmap(
-            Xt[sample][homology_dimension_idx], x=samplings_x, y=samplings_y,
+            Xt[sample][homology_dimension_idx],
+            x=samplings_x,
+            y=samplings_y[::-1],
             colorscale=colorscale,
+            origin="lower",
             title=f"Persistence image representation of diagram {sample} in "
                   f"homology dimension {homology_dimension}",
             plotly_params=plotly_params

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -13,17 +13,12 @@ from sklearn.utils.validation import check_is_fitted
 
 from ._metrics import betti_curves, landscapes, heats, \
     persistence_images, silhouettes
-from ._utils import _subdiagrams, _bin, _calculate_weights
+from ._utils import identity, _subdiagrams, _bin
 from ..base import PlotterMixin
 from ..plotting import plot_heatmap
 from ..utils._docs import adapt_fit_transform_docs
 from ..utils.intervals import Interval
 from ..utils.validation import validate_params, check_diagrams
-
-
-def identity(x):
-    """The identity function."""
-    return x
 
 
 @adapt_fit_transform_docs
@@ -116,7 +111,7 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
 
         self.homology_dimensions_ = sorted(list(set(X[0, :, 2])))
         self._n_dimensions = len(self.homology_dimensions_)
-        self._samplings, _ = _bin(X, metric="betti", n_bins=self.n_bins)
+        self._samplings, _ = _bin(X, "betti", n_bins=self.n_bins)
         self.samplings_ = {dim: s.flatten()
                            for dim, s in self._samplings.items()}
 
@@ -354,7 +349,7 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
 
         self.homology_dimensions_ = sorted(list(set(X[0, :, 2])))
         self._n_dimensions = len(self.homology_dimensions_)
-        self._samplings, _ = _bin(X, metric="landscape", n_bins=self.n_bins)
+        self._samplings, _ = _bin(X, "landscape", n_bins=self.n_bins)
         self.samplings_ = {dim: s.flatten()
                            for dim, s in self._samplings.items()}
 
@@ -614,8 +609,7 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
 
         self.homology_dimensions_ = sorted(list(set(X[0, :, 2])))
         self._n_dimensions = len(self.homology_dimensions_)
-        self._samplings, self._step_size = _bin(
-            X, metric="heat", n_bins=self.n_bins)
+        self._samplings, self._step_size = _bin(X, "heat", n_bins=self.n_bins)
         self.samplings_ = {dim: s.flatten()
                            for dim, s in self._samplings.items()}
 
@@ -846,12 +840,14 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
 
         self.homology_dimensions_ = sorted(list(set(X[0, :, 2])))
         self._n_dimensions = len(self.homology_dimensions_)
-        self._samplings, self._step_size = _bin(
-            X, metric="persistence_image", n_bins=self.n_bins)
-        self.samplings_ = {dim: s.transpose()
-                           for dim, s in self._samplings.items()}
-        self.weights_ = _calculate_weights(X, self.effective_weight_function_,
-                                           self._samplings)
+        self._samplings, self._step_size = _bin(X, "persistence_image",
+                                                n_bins=self.n_bins)
+        self.weights_ = {
+            dim: self.effective_weight_function_(samplings_dim[:, 1])
+            for dim, samplings_dim in self._samplings.items()
+            }
+        self.samplings_ = {dim: s.T for dim, s in self._samplings.items()}
+
 
         return self
 
@@ -876,7 +872,7 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
         Returns
         -------
         Xt : ndarray of shape (n_samples, n_homology_dimensions, n_bins, \
-             n_bins)
+            n_bins)
             Multi-channel raster images: one image per sample and one channel
             per homology dimension seen in :meth:`fit`. Index i along axis 1
             corresponds to the i-th homology dimension in
@@ -1062,7 +1058,7 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
 
         self.homology_dimensions_ = sorted(list(set(X[0, :, 2])))
         self._n_dimensions = len(self.homology_dimensions_)
-        self._samplings, _ = _bin(X, metric="silhouette", n_bins=self.n_bins)
+        self._samplings, _ = _bin(X, "silhouette", n_bins=self.n_bins)
         self.samplings_ = {dim: s.flatten()
                            for dim, s in self._samplings.items()}
 

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -31,8 +31,10 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
     considered separately, and their respective Betti curves are obtained by
     evenly sampling the :ref:`filtration parameter <filtered_complex>`.
 
-    Input collections of persistence diagrams for this transformer must satisfy
-    certain requirements, see e.g. :meth:`fit`.
+    **Important note**:
+
+        - Input collections of persistence diagrams for this transformer must
+          satisfy certain requirements, see e.g. :meth:`fit`.
 
     Parameters
     ----------
@@ -41,9 +43,9 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
         dimension, to sample during :meth:`fit`.
 
     n_jobs : int or None, optional, default: ``None``
-        The number of jobs to use for the computation. ``None`` means 1
-        unless in a :obj:`joblib.parallel_backend` context. ``-1`` means
-        using all processors.
+        The number of jobs to use for the computation. ``None`` means 1 unless
+        in a :obj:`joblib.parallel_backend` context. ``-1`` means using all
+        processors.
 
     Attributes
     ----------
@@ -158,9 +160,8 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
         return Xt
 
     def plot(self, Xt, sample=0, homology_dimensions=None, plotly_params=None):
-        """Plot a sample from a collection of Betti curves arranged as in
-        the output of :meth:`transform`. Include homology in multiple
-        dimensions.
+        """Plot a sample from a collection of Betti curves arranged as in the
+        output of :meth:`transform`. Include homology in multiple dimensions.
 
         Parameters
         ----------
@@ -263,8 +264,10 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
     landscapes are obtained by evenly sampling the :ref:`filtration parameter
     <filtered_complex>`.
 
-    Input collections of persistence diagrams for this transformer must satisfy
-    certain requirements, see e.g. :meth:`fit`.
+    **Important note**:
+
+        - Input collections of persistence diagrams for this transformer must
+          satisfy certain requirements, see e.g. :meth:`fit`.
 
     Parameters
     ----------
@@ -523,8 +526,10 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
     diagonal, and the difference between the results of the two convolutions is
     computed. The result can be thought of as a (multi-channel) raster image.
 
-    Input collections of persistence diagrams for this transformer must satisfy
-    certain requirements, see e.g. :meth:`fit`.
+    **Important note**:
+
+        - Input collections of persistence diagrams for this transformer must
+          satisfy certain requirements, see e.g. :meth:`fit`.
 
     Parameters
     ----------
@@ -667,8 +672,8 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
 
     def plot(self, Xt, sample=0, homology_dimension_idx=0, colorscale="blues",
              plotly_params=None):
-        """Plot a single channel – corresponding to a given homology
-        dimension – in a sample from a collection of heat kernel images.
+        """Plot a single channel –- corresponding to a given homology
+        dimension -- in a sample from a collection of heat kernel images.
 
         Parameters
         ----------
@@ -732,8 +737,10 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
     <filtered_complex>`. The result can be thought of as a (multi-channel)
     raster image.
 
-    Input collections of persistence diagrams for this transformer must satisfy
-    certain requirements, see e.g. :meth:`fit`.
+    **Important note**:
+
+        - Input collections of persistence diagrams for this transformer must
+          satisfy certain requirements, see e.g. :meth:`fit`.
 
     Parameters
     ----------
@@ -764,9 +771,10 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
         Homology dimensions seen in :meth:`fit`.
 
     samplings_ : dict
-        For each number in `homology_dimensions_`, a discrete sampling of
-        filtration parameters, calculated during :meth:`fit` according to the
-        minimum birth and maximum death values observed across all samples.
+        For each dimension in `homology_dimensions_`, a discrete sampling of
+        birth parameters and one of persistence values, calculated during
+        :meth:`fit` according to the minimum birth and maximum death values
+        observed across all samples.
 
     weights_ : dict
         For each number in `homology_dimensions_`, an array of weights
@@ -857,7 +865,6 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
             }
         self.samplings_ = {dim: s.T for dim, s in self._samplings.items()}
 
-
         return self
 
     def transform(self, X, y=None):
@@ -909,8 +916,8 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
 
     def plot(self, Xt, sample=0, homology_dimension_idx=0, colorscale="blues",
              plotly_params=None):
-        """Plot a single channel – corresponding to a given homology
-        dimension – in a sample from a collection of persistence images.
+        """Plot a single channel -– corresponding to a given homology
+        dimension -– in a sample from a collection of persistence images.
 
         Parameters
         ----------
@@ -970,12 +977,14 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
     Based on ideas in [1]_. Given a persistence diagram consisting of
     birth-death-dimension triples [b, d, q], subdiagrams corresponding to
     distinct homology dimensions are considered separately, and their
-    respective silhouette by sampling the silhouette function over evenly
-    spaced locations from appropriate ranges of the :ref:`filtration parameter
-    <filtered_complex>`.
+    respective silhouettes are obtained by sampling the silhouette function
+    over evenly spaced locations from appropriate ranges of the
+    :ref:`filtration parameter <filtered_complex>`.
 
-    Input collections of persistence diagrams for this transformer must satisfy
-    certain requirements, see e.g. :meth:`fit`.
+    **Important note**:
+
+        - Input collections of persistence diagrams for this transformer must
+          satisfy certain requirements, see e.g. :meth:`fit`.
 
     Parameters
     ----------
@@ -988,9 +997,9 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
         dimension, to sample during :meth:`fit`.
 
     n_jobs : int or None, optional, default: ``None``
-        The number of jobs to use for the computation. ``None`` means 1
-        unless in a :obj:`joblib.parallel_backend` context. ``-1`` means
-        using all processors.
+        The number of jobs to use for the computation. ``None`` means 1 unless
+        in a :obj:`joblib.parallel_backend` context. ``-1`` means using all
+        processors.
 
     Attributes
     ----------
@@ -1010,10 +1019,9 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
     Notes
     -----
     The samplings in :attr:`samplings_` are in general different between
-    different homology dimensions. This means that the j-th entry of
-    a silhouette in homology dimension q typically arises from
-    a different parameter values to the j-th entry of a curve
-    in dimension q'.
+    different homology dimensions. This means that the j-th entry of a
+    silhouette in homology dimension q typically arises from a different
+    parameter values to the j-th entry of a curve in dimension q'.
 
     References
     ----------
@@ -1027,8 +1035,8 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
     """
 
     _hyperparameters = {
-        "n_bins": {"type": int, "in": Interval(1, np.inf, closed="left")},
-        "power": {"type": Real, "in": Interval(0, np.inf, closed="right")}
+        "power": {"type": Real, "in": Interval(0, np.inf, closed="right")},
+        "n_bins": {"type": int, "in": Interval(1, np.inf, closed="left")}
         }
 
     def __init__(self, power=1., n_bins=100, n_jobs=None):
@@ -1117,9 +1125,8 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
         return Xt
 
     def plot(self, Xt, sample=0, homology_dimensions=None, plotly_params=None):
-        """Plot a sample from a collection of silhouettes arranged as in
-        the output of :meth:`transform`. Include homology in multiple
-        dimensions.
+        """Plot a sample from a collection of silhouettes arranged as in the
+        output of :meth:`transform`. Include homology in multiple dimensions.
 
         Parameters
         ----------

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -14,7 +14,8 @@ from sklearn.utils.validation import check_is_fitted
 
 from ._metrics import betti_curves, landscapes, heats, \
     persistence_images, silhouettes
-from ._utils import _subdiagrams, _bin, _make_homology_dimensions_mapping
+from ._utils import _subdiagrams, _bin, _make_homology_dimensions_mapping, \
+    _homology_dimensions_to_sorted_ints
 from ..base import PlotterMixin
 from ..plotting import plot_heatmap
 from ..utils._docs import adapt_fit_transform_docs
@@ -112,11 +113,13 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
         validate_params(
             self.get_params(), self._hyperparameters, exclude=["n_jobs"])
 
-        self.homology_dimensions_ = tuple(
-            sorted([int(dim) if dim != np.inf else dim
-                    for dim in set(X[0, :, 2])])
-            )
+        # Find the unique homology dimensions in the 3D array X passed to `fit`
+        # assuming that they can all be found in its zero-th entry
+        homology_dimensions_fit = np.unique(X[0, :, 2])
+        self.homology_dimensions_ = \
+            _homology_dimensions_to_sorted_ints(homology_dimensions_fit)
         self._n_dimensions = len(self.homology_dimensions_)
+
         self._samplings, _ = _bin(
             X, "betti", n_bins=self.n_bins,
             homology_dimensions=self.homology_dimensions_
@@ -343,11 +346,13 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
         validate_params(
             self.get_params(), self._hyperparameters, exclude=["n_jobs"])
 
-        self.homology_dimensions_ = tuple(
-            sorted([int(dim) if dim != np.inf else dim
-                    for dim in set(X[0, :, 2])])
-            )
+        # Find the unique homology dimensions in the 3D array X passed to `fit`
+        # assuming that they can all be found in its zero-th entry
+        homology_dimensions_fit = np.unique(X[0, :, 2])
+        self.homology_dimensions_ = \
+            _homology_dimensions_to_sorted_ints(homology_dimensions_fit)
         self._n_dimensions = len(self.homology_dimensions_)
+
         self._samplings, _ = _bin(
             X, "landscape", n_bins=self.n_bins,
             homology_dimensions=self.homology_dimensions_
@@ -606,11 +611,13 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
         validate_params(
             self.get_params(), self._hyperparameters, exclude=["n_jobs"])
 
-        self.homology_dimensions_ = tuple(
-            sorted([int(dim) if dim != np.inf else dim
-                    for dim in set(X[0, :, 2])])
-            )
+        # Find the unique homology dimensions in the 3D array X passed to `fit`
+        # assuming that they can all be found in its zero-th entry
+        homology_dimensions_fit = np.unique(X[0, :, 2])
+        self.homology_dimensions_ = \
+            _homology_dimensions_to_sorted_ints(homology_dimensions_fit)
         self._n_dimensions = len(self.homology_dimensions_)
+
         self._samplings, self._step_size = _bin(
             X, "heat", n_bins=self.n_bins,
             homology_dimensions=self.homology_dimensions_
@@ -847,11 +854,13 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
         else:
             self.effective_weight_function_ = self.weight_function
 
-        self.homology_dimensions_ = tuple(
-            sorted([int(dim) if dim != np.inf else dim
-                    for dim in set(X[0, :, 2])])
-            )
+        # Find the unique homology dimensions in the 3D array X passed to `fit`
+        # assuming that they can all be found in its zero-th entry
+        homology_dimensions_fit = np.unique(X[0, :, 2])
+        self.homology_dimensions_ = \
+            _homology_dimensions_to_sorted_ints(homology_dimensions_fit)
         self._n_dimensions = len(self.homology_dimensions_)
+
         self._samplings, self._step_size = _bin(
             X, "persistence_image",  n_bins=self.n_bins,
             homology_dimensions=self.homology_dimensions_
@@ -1073,11 +1082,12 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
         validate_params(
             self.get_params(), self._hyperparameters, exclude=["n_jobs"])
 
-        self.homology_dimensions_ = tuple(
-            sorted([int(dim) if dim != np.inf else dim
-                    for dim in set(X[0, :, 2])])
-            )
-        self._n_dimensions = len(self.homology_dimensions_)
+        # Find the unique homology dimensions in the 3D array X passed to `fit`
+        # assuming that they can all be found in its zero-th entry
+        homology_dimensions_fit = np.unique(X[0, :, 2])
+        self.homology_dimensions_ = \
+            _homology_dimensions_to_sorted_ints(homology_dimensions_fit)
+
         self._samplings, _ = _bin(
             X, "silhouette", n_bins=self.n_bins,
             homology_dimensions=self.homology_dimensions_

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -14,7 +14,7 @@ from sklearn.utils.validation import check_is_fitted
 
 from ._metrics import betti_curves, landscapes, heats, \
     persistence_images, silhouettes
-from ._utils import identity, _subdiagrams, _bin
+from ._utils import _subdiagrams, _bin
 from ..base import PlotterMixin
 from ..plotting import plot_heatmap
 from ..utils._docs import adapt_fit_transform_docs
@@ -752,9 +752,10 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
         dimension, to sample during :meth:`fit`.
 
     weight_function : callable or None, default: ``None``
-        Function mapping the 1D array of persistence values of the points of an
-        input diagram to a 1D array of weights. ``None`` is equivalent to
-        passing the identity function.
+        Function mapping the 1D array of sampled persistence values (see
+        :attr:`samplings_`) to a 1D array of weights. ``None`` is equivalent to
+        passing ``numpy.ones_like``. More weight can be given to regions of
+        high persistence by passing a monotonic function, e.g. the identity.
 
     n_jobs : int or None, optional, default: ``None``
         The number of jobs to use for the computation. ``None`` means 1 unless
@@ -851,7 +852,7 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
             self.get_params(), self._hyperparameters, exclude=["n_jobs"])
 
         if self.weight_function is None:
-            self.effective_weight_function_ = identity
+            self.effective_weight_function_ = np.ones_like
         else:
             self.effective_weight_function_ = self.weight_function
 

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -243,12 +243,11 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
         fig = Figure(layout=layout)
 
         for ix, dim in _homology_dimensions:
-            name = f"H{int(dim) if dim != np.inf else np.inf}"
             fig.add_trace(Scatter(x=self.samplings_[dim],
                                   y=Xt[sample][ix],
                                   mode="lines",
                                   showlegend=True,
-                                  name=name))
+                                  name=f"H{dim}"))
 
         # Update traces and layout according to user input
         if plotly_params:
@@ -490,8 +489,7 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
 
         Xt_sample = Xt[sample]
         n_layers = Xt_sample.shape[1]
-        subplot_titles = [f"H{int(dim) if dim != np.inf else np.inf}"
-                          for _, dim in _homology_dimensions]
+        subplot_titles = [f"H{dim} for _, dim in _homology_dimensions"]
         fig = make_subplots(rows=len(_homology_dimensions), cols=1,
                             subplot_titles=subplot_titles)
         has_many_homology_dim = len(_homology_dimensions) - 1
@@ -1230,13 +1228,12 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
         fig = Figure(layout=layout)
 
         for ix, dim in _homology_dimensions:
-            name = f"H{int(dim) if dim != np.inf else np.inf}"
             fig.add_trace(Scatter(x=self.samplings_[dim],
                                   y=Xt[sample][ix],
                                   mode="lines",
                                   showlegend=True,
                                   hoverinfo="none",
-                                  name=name))
+                                  name=f"H{dim}"))
 
         # Update traces and layout according to user input
         if plotly_params:

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -1087,6 +1087,7 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
         homology_dimensions_fit = np.unique(X[0, :, 2])
         self.homology_dimensions_ = \
             _homology_dimensions_to_sorted_ints(homology_dimensions_fit)
+        self._n_dimensions = len(self.homology_dimensions_)
 
         self._samplings, _ = _bin(
             X, "silhouette", n_bins=self.n_bins,

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -531,7 +531,7 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
 
     Parameters
     ----------
-    sigma : float, optional default ``1.``
+    sigma : float, optional default ``0.1``
         Standard deviation for Gaussian kernel.
 
     n_bins : int, optional, default: ``100``
@@ -582,7 +582,7 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
         "sigma": {"type": Real, "in": Interval(0, np.inf, closed="neither")}
         }
 
-    def __init__(self, sigma=1., n_bins=100, n_jobs=None):
+    def __init__(self, sigma=0.1, n_bins=100, n_jobs=None):
         self.sigma = sigma
         self.n_bins = n_bins
         self.n_jobs = n_jobs
@@ -742,7 +742,7 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
 
     Parameters
     ----------
-    sigma : float, optional default ``1.``
+    sigma : float, optional default ``0.1``
         Standard deviation for Gaussian kernel.
 
     n_bins : int, optional, default: ``100``
@@ -810,7 +810,7 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
         "weight_function": {"type": (types.FunctionType, type(None))}
         }
 
-    def __init__(self, sigma=1., n_bins=100, weight_function=None,
+    def __init__(self, sigma=0.1, n_bins=100, weight_function=None,
                  n_jobs=None):
         self.sigma = sigma
         self.n_bins = n_bins
@@ -902,8 +902,8 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
                 _subdiagrams(X[s], [dim], remove_dim=True),
                 self._samplings[dim],
                 self._step_size[dim],
-                self.weights_[dim],
-                self.sigma
+                self.sigma,
+                self.weights_[dim]
                 )
             for dim in self.homology_dimensions_
             for s in gen_even_slices(len(X), effective_n_jobs(self.n_jobs))

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -482,10 +482,10 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
                           for _, dim in _homology_dimensions]
         fig = make_subplots(rows=len(_homology_dimensions), cols=1,
                             subplot_titles=subplot_titles)
-        many_homology_dim = len(_homology_dimensions) - 1
+        has_many_homology_dim = len(_homology_dimensions) - 1
         for i, (inv_idx, dim) in enumerate(_homology_dimensions):
             hom_dim_str = \
-                f" ({subplot_titles[i]})" if many_homology_dim else ""
+                f" ({subplot_titles[i]})" if has_many_homology_dim else ""
             for layer in range(n_layers):
                 fig.add_trace(
                     Scatter(x=self.samplings_[dim],

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -117,7 +117,10 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
                     for dim in set(X[0, :, 2])])
             )
         self._n_dimensions = len(self.homology_dimensions_)
-        self._samplings, _ = _bin(X, "betti", n_bins=self.n_bins)
+        self._samplings, _ = _bin(
+            X, "betti", n_bins=self.n_bins,
+            homology_dimensions=self.homology_dimensions_
+            )
         self.samplings_ = {dim: s.flatten()
                            for dim, s in self._samplings.items()}
 
@@ -358,7 +361,10 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
                     for dim in set(X[0, :, 2])])
             )
         self._n_dimensions = len(self.homology_dimensions_)
-        self._samplings, _ = _bin(X, "landscape", n_bins=self.n_bins)
+        self._samplings, _ = _bin(
+            X, "landscape", n_bins=self.n_bins,
+            homology_dimensions=self.homology_dimensions_
+            )
         self.samplings_ = {dim: s.flatten()
                            for dim, s in self._samplings.items()}
 
@@ -631,7 +637,10 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
                     for dim in set(X[0, :, 2])])
             )
         self._n_dimensions = len(self.homology_dimensions_)
-        self._samplings, self._step_size = _bin(X, "heat", n_bins=self.n_bins)
+        self._samplings, self._step_size = _bin(
+            X, "heat", n_bins=self.n_bins,
+            homology_dimensions=self.homology_dimensions_
+            )
         self.samplings_ = {dim: s.flatten()
                            for dim, s in self._samplings.items()}
 
@@ -869,8 +878,10 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
                     for dim in set(X[0, :, 2])])
             )
         self._n_dimensions = len(self.homology_dimensions_)
-        self._samplings, self._step_size = _bin(X, "persistence_image",
-                                                n_bins=self.n_bins)
+        self._samplings, self._step_size = _bin(
+            X, "persistence_image",  n_bins=self.n_bins,
+            homology_dimensions=self.homology_dimensions_
+            )
         self.weights_ = {
             dim: self.effective_weight_function_(samplings_dim[:, 1])
             for dim, samplings_dim in self._samplings.items()
@@ -1093,7 +1104,10 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
                     for dim in set(X[0, :, 2])])
             )
         self._n_dimensions = len(self.homology_dimensions_)
-        self._samplings, _ = _bin(X, "silhouette", n_bins=self.n_bins)
+        self._samplings, _ = _bin(
+            X, "silhouette", n_bins=self.n_bins,
+            homology_dimensions=self.homology_dimensions_
+            )
         self.samplings_ = {dim: s.flatten()
                            for dim, s in self._samplings.items()}
 

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -1158,7 +1158,7 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
         """
         check_is_fitted(self)
 
-        homology_dimensions_mapping = _make_homology_dimension_mapping(
+        homology_dimensions_mapping = _make_homology_dimensions_mapping(
             homology_dimensions, self.homology_dimensions_
             )
 

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -206,43 +206,41 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
                     ix = np.flatnonzero(homology_dimensions_arr == dim)[0]
                     _homology_dimensions.append((ix, dim))
 
+        layout_axes_common = {
+            "type": "linear",
+            "ticks": "outside",
+            "showline": True,
+            "zeroline": True,
+            "linewidth": 1,
+            "linecolor": "black",
+            "mirror": False,
+            "showexponent": "all",
+            "exponentformat": "e"
+            }
         layout = {
             "xaxis1": {
                 "title": "Filtration parameter",
                 "side": "bottom",
-                "type": "linear",
-                "ticks": "outside",
-                "anchor": "x1",
-                "showline": True,
-                "zeroline": True,
-                "showexponent": "all",
-                "exponentformat": "e"
+                "anchor": "y1",
+                **layout_axes_common
                 },
             "yaxis1": {
                 "title": "Betti number",
                 "side": "left",
-                "type": "linear",
-                "ticks": "outside",
-                "anchor": "y1",
-                "showline": True,
-                "zeroline": True,
-                "showexponent": "all",
-                "exponentformat": "e"
+                "anchor": "x1",
+                **layout_axes_common
                 },
             "plot_bgcolor": "white",
             "title": f"Betti curves from diagram {sample}"
             }
 
         fig = Figure(layout=layout)
-        fig.update_xaxes(zeroline=True, linewidth=1, linecolor="black",
-                         mirror=False)
-        fig.update_yaxes(zeroline=True, linewidth=1, linecolor="black",
-                         mirror=False)
 
         for ix, dim in _homology_dimensions:
             fig.add_trace(Scatter(x=self.samplings_[dim],
                                   y=Xt[sample][ix],
-                                  mode="lines", showlegend=True,
+                                  mode="lines",
+                                  showlegend=True,
                                   name=f"H{int(dim)}"))
 
         # Update traces and layout according to user input
@@ -452,7 +450,7 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
                     inv_idx = np.flatnonzero(homology_dimensions_arr == dim)[0]
                     _homology_dimensions.append((inv_idx, dim))
 
-        layout_axes_comm = {
+        layout_axes_common = {
             "type": "linear",
             "ticks": "outside",
             "showline": True,
@@ -467,12 +465,12 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
             "xaxis1": {
                 "side": "bottom",
                 "anchor": "y1",
-                **layout_axes_comm
+                **layout_axes_common
                 },
             "yaxis1": {
                 "side": "left",
                 "anchor": "x1",
-                **layout_axes_comm
+                **layout_axes_common
                 },
             "plot_bgcolor": "white",
             }
@@ -1172,37 +1170,34 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
                     ix = np.flatnonzero(homology_dimensions_arr == dim)[0]
                     _homology_dimensions.append((ix, dim))
 
+        layout_axes_common = {
+            "type": "linear",
+            "ticks": "outside",
+            "showline": True,
+            "zeroline": True,
+            "linewidth": 1,
+            "linecolor": "black",
+            "mirror": False,
+            "showexponent": "all",
+            "exponentformat": "e"
+            }
         layout = {
             "xaxis1": {
                 "title": "Filtration parameter",
                 "side": "bottom",
-                "type": "linear",
-                "ticks": "outside",
-                "anchor": "x1",
-                "showline": True,
-                "zeroline": True,
-                "showexponent": "all",
-                "exponentformat": "e"
+                "anchor": "y1",
+                **layout_axes_common
                 },
             "yaxis1": {
                 "side": "left",
-                "type": "linear",
-                "ticks": "outside",
-                "anchor": "y1",
-                "showline": True,
-                "zeroline": True,
-                "showexponent": "all",
-                "exponentformat": "e"
+                "anchor": "x1",
+                **layout_axes_common
                 },
             "plot_bgcolor": "white",
             "title": f"Silhouette representation of diagram {sample}"
             }
 
         fig = Figure(layout=layout)
-        fig.update_xaxes(zeroline=True, linewidth=1, linecolor="black",
-                         mirror=False)
-        fig.update_yaxes(zeroline=True, linewidth=1, linecolor="black",
-                         mirror=False)
 
         for ix, dim in _homology_dimensions:
             fig.add_trace(Scatter(x=self.samplings_[dim],

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -49,7 +49,7 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
 
     Attributes
     ----------
-    homology_dimensions_ : list
+    homology_dimensions_ : tuple
         Homology dimensions seen in :meth:`fit`, sorted in ascending order.
 
     samplings_ : dict
@@ -112,7 +112,10 @@ class BettiCurve(BaseEstimator, TransformerMixin, PlotterMixin):
         validate_params(
             self.get_params(), self._hyperparameters, exclude=["n_jobs"])
 
-        self.homology_dimensions_ = sorted(list(set(X[0, :, 2])))
+        self.homology_dimensions_ = tuple(
+            sorted([int(dim) if dim != np.inf else dim
+                    for dim in set(X[0, :, 2])])
+            )
         self._n_dimensions = len(self.homology_dimensions_)
         self._samplings, _ = _bin(X, "betti", n_bins=self.n_bins)
         self.samplings_ = {dim: s.flatten()
@@ -284,7 +287,7 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
 
     Attributes
     ----------
-    homology_dimensions_ : list
+    homology_dimensions_ : tuple
         Homology dimensions seen in :meth:`fit`.
 
     samplings_ : dict
@@ -350,7 +353,10 @@ class PersistenceLandscape(BaseEstimator, TransformerMixin, PlotterMixin):
         validate_params(
             self.get_params(), self._hyperparameters, exclude=["n_jobs"])
 
-        self.homology_dimensions_ = sorted(list(set(X[0, :, 2])))
+        self.homology_dimensions_ = tuple(
+            sorted([int(dim) if dim != np.inf else dim
+                    for dim in set(X[0, :, 2])])
+            )
         self._n_dimensions = len(self.homology_dimensions_)
         self._samplings, _ = _bin(X, "landscape", n_bins=self.n_bins)
         self.samplings_ = {dim: s.flatten()
@@ -546,7 +552,7 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
 
     Attributes
     ----------
-    homology_dimensions_ : list
+    homology_dimensions_ : tuple
         Homology dimensions seen in :meth:`fit`.
 
     samplings_ : dict
@@ -620,7 +626,10 @@ class HeatKernel(BaseEstimator, TransformerMixin, PlotterMixin):
         validate_params(
             self.get_params(), self._hyperparameters, exclude=["n_jobs"])
 
-        self.homology_dimensions_ = sorted(list(set(X[0, :, 2])))
+        self.homology_dimensions_ = tuple(
+            sorted([int(dim) if dim != np.inf else dim
+                    for dim in set(X[0, :, 2])])
+            )
         self._n_dimensions = len(self.homology_dimensions_)
         self._samplings, self._step_size = _bin(X, "heat", n_bins=self.n_bins)
         self.samplings_ = {dim: s.flatten()
@@ -767,7 +776,7 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
         Effective function corresponding to `weight_function`. Set in
         :meth:`fit`.
 
-    homology_dimensions_ : list
+    homology_dimensions_ : tuple
         Homology dimensions seen in :meth:`fit`.
 
     samplings_ : dict
@@ -855,7 +864,10 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
         else:
             self.effective_weight_function_ = self.weight_function
 
-        self.homology_dimensions_ = sorted(list(set(X[0, :, 2])))
+        self.homology_dimensions_ = tuple(
+            sorted([int(dim) if dim != np.inf else dim
+                    for dim in set(X[0, :, 2])])
+            )
         self._n_dimensions = len(self.homology_dimensions_)
         self._samplings, self._step_size = _bin(X, "persistence_image",
                                                 n_bins=self.n_bins)
@@ -1003,7 +1015,7 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
 
     Attributes
     ----------
-    homology_dimensions_ : list
+    homology_dimensions_ : tuple
         Homology dimensions seen in :meth:`fit`, sorted in ascending order.
 
     samplings_ : dict
@@ -1076,7 +1088,10 @@ class Silhouette(BaseEstimator, TransformerMixin, PlotterMixin):
         validate_params(
             self.get_params(), self._hyperparameters, exclude=["n_jobs"])
 
-        self.homology_dimensions_ = sorted(list(set(X[0, :, 2])))
+        self.homology_dimensions_ = tuple(
+            sorted([int(dim) if dim != np.inf else dim
+                    for dim in set(X[0, :, 2])])
+            )
         self._n_dimensions = len(self.homology_dimensions_)
         self._samplings, _ = _bin(X, "silhouette", n_bins=self.n_bins)
         self.samplings_ = {dim: s.flatten()

--- a/gtda/diagrams/tests/test_distance.py
+++ b/gtda/diagrams/tests/test_distance.py
@@ -321,3 +321,22 @@ def test_da_transform_bottleneck(metric, metric_params, order, n_jobs):
                    order=order, n_jobs=n_jobs)
     X_bottleneck_res = da.fit_transform(X_bottleneck)
     assert_almost_equal(X_bottleneck_res, X_bottleneck_res_exp)
+
+
+@pytest.mark.parametrize('order', [None, 2.])
+@pytest.mark.parametrize('transformer_cls', [PairwiseDistance, Amplitude])
+@pytest.mark.parametrize('Xnew', [X1, X2])
+def test_pi_zero_weight_function(transformer_cls, order, Xnew):
+    """Test that, if a zero weight function is passed to `metric_params` in
+    Amplitude or PairwiseDistance when `metric` is 'persistence_image', the
+    result is zero."""
+    metric = 'persistence_image'
+    metric_params = {
+        'sigma': 0.1, 'weight_function': lambda x: x * 0., 'n_bins': 10
+        }
+    transformer = transformer_cls(
+        metric=metric, metric_params=metric_params, order=order
+        )
+    X_res = transformer.fit(X1).transform(Xnew)
+
+    assert np.array_equal(X_res, np.zeros_like(X_res))

--- a/gtda/diagrams/tests/test_features_representations.py
+++ b/gtda/diagrams/tests/test_features_representations.py
@@ -81,15 +81,15 @@ def test_pe_transform():
     assert_almost_equal(pe_normalize.fit_transform(X), diagram_res)
 
 
-@pytest.mark.parametrize('n_bins', range(10, 51, 10))
+@pytest.mark.parametrize('n_bins', list(range(10, 51, 10)))
 def test_bc_transform_shape(n_bins):
     bc = BettiCurve(n_bins=n_bins)
     X_res = bc.fit_transform(X)
     assert X_res.shape == (1, bc._n_dimensions, n_bins)
 
 
-@pytest.mark.parametrize('n_bins', range(10, 51, 10))
-@pytest.mark.parametrize('n_layers', range(1, 10))
+@pytest.mark.parametrize('n_bins', list(range(10, 51, 10)))
+@pytest.mark.parametrize('n_layers', list(range(1, 10)))
 def test_pl_transform_shape(n_bins, n_layers):
     pl = PersistenceLandscape(n_bins=n_bins, n_layers=n_layers)
     X_res = pl.fit_transform(X)
@@ -180,18 +180,18 @@ pts_gen = arrays(
                     min_value=1.,
                     max_value=10.),
     shape=(1, 20, 2), unique=True
-)
+    )
 dims_gen = arrays(
     dtype=np.int,
     elements=integers(min_value=0,
                       max_value=3),
     shape=(1, 20, 1)
-)
+    )
 
 
 def _validate_distinct(X):
-    """Check if, in X, there is any persistence X for which all births and
-    deaths are equal."""
+    """Check if, in X, there is any persistence diagram for which all births
+    and deaths are equal."""
     unique_values = [np.unique(x[:, 0:2]) for x in X]
     if np.any([len(u) < 2 for u in unique_values]):
         raise ValueError

--- a/gtda/diagrams/tests/test_features_representations.py
+++ b/gtda/diagrams/tests/test_features_representations.py
@@ -249,15 +249,18 @@ def test_hk_positive(pts, dims):
     assert np.all((np.tril(X_t[:, :, ::-1, :]) + 1e-13) >= 0.)
 
 
+@pytest.mark.parametrize('transformer_cls', [HeatKernel, PersistenceImage])
 @given(pts_gen, dims_gen)
-def test_hk_big_sigma(pts, dims):
+def test_hk_pi_big_sigma(transformer_cls, pts, dims):
     """We expect that with a huge sigma, the diagrams are so diluted that they
     are almost 0. Effectively, verifies that the smoothing is applied."""
     n_bins = 10
     X = get_input(pts, dims)
+    # To make the test less flaky, it helps to set al homology dimensions equal
+    X[:, :, 2] = 0.
     sigma = 100 * (np.max(X[:, :, :2]) - np.min(X[:, :, :2]))
 
-    hk = HeatKernel(sigma=sigma, n_bins=n_bins)
+    hk = transformer_cls(sigma=sigma, n_bins=n_bins)
     X_t = hk.fit_transform(X)
 
     max_hk_abs_value = np.max(np.abs(X_t))

--- a/gtda/diagrams/tests/test_features_representations.py
+++ b/gtda/diagrams/tests/test_features_representations.py
@@ -17,43 +17,44 @@ pio.renderers.default = 'plotly_mimetype'
 
 X = np.array([[[0., 1., 0.], [2., 3., 0.], [4., 6., 1.], [2., 6., 1.]]])
 
+line_plots_traces_params = {"mode": "lines+markers"}
+heatmap_trace_params = {"colorscale": "viridis"}
+layout_params = {"title": "New title"}
 
-def test_not_fitted():
+
+@pytest.mark.parametrize('transformer',
+                         [PersistenceEntropy(), BettiCurve(),
+                          PersistenceLandscape(), HeatKernel(),
+                          PersistenceImage(), Silhouette()])
+def test_not_fitted(transformer):
     with pytest.raises(NotFittedError):
-        PersistenceEntropy().transform(X)
-
-    with pytest.raises(NotFittedError):
-        BettiCurve().transform(X)
-
-    with pytest.raises(NotFittedError):
-        PersistenceLandscape().transform(X)
-
-    with pytest.raises(NotFittedError):
-        HeatKernel().transform(X)
-
-    with pytest.raises(NotFittedError):
-        PersistenceImage().transform(X)
-
-    with pytest.raises(NotFittedError):
-        Silhouette().transform(X)
+        transformer.transform(X)
 
 
+@pytest.mark.parametrize('transformer',
+                         [HeatKernel(), PersistenceImage()])
 @pytest.mark.parametrize('hom_dim_idx', [0, 1])
-def test_fit_transform_plot_one_hom_dim(hom_dim_idx):
-    HeatKernel().fit_transform_plot(
-        X, sample=0, homology_dimension_idx=hom_dim_idx)
-    PersistenceImage().fit_transform_plot(
-        X, sample=0, homology_dimension_idx=hom_dim_idx)
+def test_fit_transform_plot_one_hom_dim(transformer, hom_dim_idx):
+    plotly_params = \
+        {"trace": heatmap_trace_params, "layout": layout_params}
+    common_kwargs = {
+        "sample": 0, "homology_dimension_idx": hom_dim_idx,
+        "plotly_params": plotly_params
+        }
+    transformer.fit_transform_plot(X, **common_kwargs)
 
 
+@pytest.mark.parametrize('transformer',
+                         [BettiCurve(), PersistenceLandscape(), Silhouette()])
 @pytest.mark.parametrize('hom_dims', [None, (0,), (1,), (0, 1)])
-def test_fit_transform_plot_many_hom_dims(hom_dims):
-    BettiCurve().fit_transform_plot(
-        X, sample=0, homology_dimensions=hom_dims)
-    PersistenceLandscape().fit_transform_plot(
-        X, sample=0, homology_dimensions=hom_dims)
-    Silhouette().fit_transform_plot(
-        X, sample=0, homology_dimensions=hom_dims)
+def test_fit_transform_plot_many_hom_dims(transformer, hom_dims):
+    plotly_params = \
+        {"traces": line_plots_traces_params, "layout": layout_params}
+    common_kwargs = {
+        "sample": 0, "homology_dimensions": hom_dims,
+        "plotly_params": plotly_params
+        }
+    transformer.fit_transform_plot(X, **common_kwargs)
 
 
 def test_pe_transform():

--- a/gtda/diagrams/tests/test_features_representations.py
+++ b/gtda/diagrams/tests/test_features_representations.py
@@ -103,12 +103,12 @@ def test_pi_zero_weight_function():
 
 
 @given(X=arrays(dtype=np.float, unique=True,
-                elements=floats(min_value=-1e3, max_value=1e3),
+                elements=floats(min_value=-10, max_value=10),
                 shape=array_shapes(min_dims=1, max_dims=1, min_side=11)))
 def test_pi_null(X):
     """Test that, if one trivial diagram (all pts on the diagonal) is provided,
     along with a non-trivial one, then its persistence image is null"""
-    pi = PersistenceImage(sigma=1, n_bins=10)
+    n_bins = 10
     X = np.append(X, 1 + X[-1])
     diagrams = np.expand_dims(
         np.stack([X, X, np.zeros(len(X))]).transpose(), axis=0
@@ -116,20 +116,26 @@ def test_pi_null(X):
     diagrams = np.repeat(diagrams, 2, axis=0)
     diagrams[1, :, 1] += 1
 
+    sigma = (np.max(diagrams[:, :, 1] - np.min(diagrams[:, :, 0]))) / 2
+    pi = PersistenceImage(sigma=sigma, n_bins=n_bins)
+
     assert_almost_equal(pi.fit_transform(diagrams)[0], 0)
 
 
 @given(pts=arrays(dtype=np.float, unique=True,
                   elements=floats(allow_nan=False,
                                   allow_infinity=False,
-                                  min_value=-1e3,
-                                  max_value=1e3),
+                                  min_value=-10,
+                                  max_value=10),
                   shape=(20, 2)))
 def test_pi_positive(pts):
-    pi = PersistenceImage(sigma=1)
-    diagrams = np.expand_dims(np.concatenate([
-        np.sort(pts, axis=1), np.zeros((pts.shape[0], 1))],
-        axis=1), axis=0)
+    diagrams = np.expand_dims(
+        np.concatenate([np.sort(pts, axis=1), np.zeros((pts.shape[0], 1))],
+                       axis=1),
+        axis=0
+        )
+    sigma = (np.max(diagrams[:, :, 1] - np.min(diagrams[:, :, 0]))) / 2
+    pi = PersistenceImage(sigma=sigma)
     assert np.all(pi.fit_transform(diagrams) >= 0.)
 
 

--- a/gtda/diagrams/tests/test_features_representations.py
+++ b/gtda/diagrams/tests/test_features_representations.py
@@ -215,6 +215,7 @@ def get_input(pts, dims):
     X = np.concatenate([np.sort(pts, axis=2), dims], axis=2)
     return X
 
+
 @given(pts_gen, dims_gen)
 def test_hk_shape(pts, dims):
     n_bins = 10

--- a/gtda/diagrams/tests/test_features_representations.py
+++ b/gtda/diagrams/tests/test_features_representations.py
@@ -96,6 +96,12 @@ def test_pl_transform_shape(n_bins, n_layers):
     assert X_res.shape == (1, pl._n_dimensions, n_layers, n_bins)
 
 
+def test_pi_zero_weight_function():
+    pi = PersistenceImage(weight_function=lambda x: x * 0.)
+    X_res = pi.fit_transform(X)
+    assert np.array_equal(X_res, np.zeros_like(X_res))
+
+
 @given(X=arrays(dtype=np.float, unique=True,
                 elements=integers(min_value=-1e10, max_value=1e6),
                 shape=array_shapes(min_dims=1, max_dims=1, min_side=11)))

--- a/gtda/diagrams/tests/test_features_representations.py
+++ b/gtda/diagrams/tests/test_features_representations.py
@@ -173,6 +173,13 @@ def test_silhouette_big_order():
     assert_almost_equal(sht_10.fit_transform(diagrams)[0][0], X_sht_res)
 
 
+@pytest.mark.parametrize('transformer', [HeatKernel(), PersistenceImage()])
+def test_all_pts_the_same(transformer):
+    X = np.zeros((1, 4, 3))
+    X_res = transformer.fit_transform(X)
+    assert np.array_equal(X_res, np.zeros_like(X_res))
+
+
 pts_gen = arrays(
     dtype=np.float,
     elements=floats(allow_nan=False,
@@ -207,14 +214,6 @@ def get_input(pts, dims):
             # add a distinct value, if not provided by hypothesis
     X = np.concatenate([np.sort(pts, axis=2), dims], axis=2)
     return X
-
-
-def test_all_pts_the_same():
-    X = np.zeros((1, 4, 3))
-    hk = HeatKernel(sigma=1)
-    with pytest.raises(OverflowError):
-        _ = hk.fit(X).transform(X)
-
 
 @given(pts_gen, dims_gen)
 def test_hk_shape(pts, dims):

--- a/gtda/diagrams/tests/test_preprocessing.py
+++ b/gtda/diagrams/tests/test_preprocessing.py
@@ -246,9 +246,18 @@ def test_forg_transform_shape(X):
     assert X_res.shape == X.shape
 
 
-parameters_sc = [('wasserstein', {'p': 2}),
-                 ('betti', {'n_bins': 10}),
-                 ('bottleneck', None)]
+parameters_sc = [
+    ('bottleneck', None),
+    ('wasserstein', {'p': 2}),
+    ('betti', {'p': 2.1, 'n_bins': 10}),
+    ('landscape', {'p': 2.1, 'n_bins': 10, 'n_layers': 2}),
+    ('silhouette', {'p': 2.1, 'power': 1.2, 'n_bins': 10}),
+    ('heat', {'p': 2.1, 'sigma': 0.5, 'n_bins': 10}),
+    ('persistence_image',
+     {'p': 2.1, 'sigma': 0.5, 'n_bins': 10}),
+    ('persistence_image',
+     {'p': 2.1, 'sigma': 0.5, 'n_bins': 10, 'weight_function': lambda x: x})
+    ]
 
 
 @pytest.mark.parametrize(('metric', 'metric_params'), parameters_sc)

--- a/gtda/diagrams/tests/test_preprocessing.py
+++ b/gtda/diagrams/tests/test_preprocessing.py
@@ -10,6 +10,8 @@ from sklearn.exceptions import NotFittedError
 from gtda.diagrams import ForgetDimension, Scaler, Filtering
 
 pio.renderers.default = 'plotly_mimetype'
+plotly_params = {"trace": {"marker_size": 20},
+                 "layout": {"title": "New title"}}
 
 X_1 = np.array([[[0., 0.36905774, 0],
                  [0., 0.37293977, 0],
@@ -227,16 +229,22 @@ def test_not_fitted():
 
 
 def test_forg_fit_transform_plot():
-    ForgetDimension().fit_transform_plot(X_1, sample=0)
+    ForgetDimension().fit_transform_plot(
+        X_1, sample=0, plotly_params=plotly_params
+    )
 
 
 @pytest.mark.parametrize('hom_dims', [None, (0,), (1,)])
 def test_fit_transform_plot(hom_dims):
     Scaler().fit_transform_plot(
-        X_1, sample=0, homology_dimensions=hom_dims)
+        X_1, sample=0, homology_dimensions=hom_dims,
+        plotly_params=plotly_params
+    )
 
     Filtering().fit_transform_plot(
-        X_1, sample=0, homology_dimensions=hom_dims)
+        X_1, sample=0, homology_dimensions=hom_dims,
+        plotly_params=plotly_params
+    )
 
 
 @pytest.mark.parametrize('X', [X_1, X_2])

--- a/gtda/diagrams/tests/test_preprocessing.py
+++ b/gtda/diagrams/tests/test_preprocessing.py
@@ -278,6 +278,28 @@ def test_filt_transform_zero(X):
     assert_almost_equal(X_res, X[:, [0], :])
 
 
+def total_lifetimes_in_dims(X, dims):
+    return sum([
+        np.sum(np.diff(X[X[:, :, 2] == dim], axis=1)[:, 0]) for dim in dims
+        ])
+
+
+@pytest.mark.parametrize('homology_dimensions', [None, (0, 1, 2), (0,), (1,),
+                                                 (2,), (0, 1), (0, 2), (1, 2)])
+def test_filt_transform_unfiltered_hom_dims(homology_dimensions):
+    filt = Filtering(epsilon=2., homology_dimensions=homology_dimensions)
+    X_1_res = filt.fit_transform(X_1)
+    if homology_dimensions is None:
+        unfiltered_hom_dims = []
+    else:
+        unfiltered_hom_dims = [
+            dim for dim in filt.homology_dimensions_
+            if dim not in homology_dimensions
+            ]
+    assert total_lifetimes_in_dims(X_1, unfiltered_hom_dims) == \
+           total_lifetimes_in_dims(X_1_res, unfiltered_hom_dims)
+
+
 lifetimes_1 = X_1[:, :, 1] - X_1[:, :, 0]
 epsilons_1 = np.linspace(np.min(lifetimes_1), np.max(lifetimes_1), num=3)
 

--- a/gtda/graphs/kneighbors.py
+++ b/gtda/graphs/kneighbors.py
@@ -69,9 +69,9 @@ class KNeighborsGraph(BaseEstimator, TransformerMixin):
         Additional keyword arguments for the metric function.
 
     n_jobs : int or None, optional, default: ``None``
-        The number of jobs to use for the computation. ``None`` means 1
-        unless in a :obj:`joblib.parallel_backend` context. ``-1`` means
-        using all processors.
+        The number of jobs to use for the computation. ``None`` means 1 unless
+        in a :obj:`joblib.parallel_backend` context. ``-1`` means using all
+        processors.
 
     Examples
     --------

--- a/gtda/mapper/cluster.py
+++ b/gtda/mapper/cluster.py
@@ -42,9 +42,9 @@ class ParallelClustering(BaseEstimator):
         :class:`sklearn.cluster.DBSCAN` is used.
 
     n_jobs : int or None, optional, default: ``None``
-        The number of jobs to use for the computation. ``None`` means 1
-        unless in a :obj:`joblib.parallel_backend` context. ``-1`` means
-        using all processors.
+        The number of jobs to use for the computation. ``None`` means 1 unless
+        in a :obj:`joblib.parallel_backend` context. ``-1`` means using all
+        processors.
 
     parallel_backend_prefer : ``'processes'`` | ``'threads'``, optional, \
         default: ``'threads'``

--- a/gtda/plotting/persistence_diagrams.py
+++ b/gtda/plotting/persistence_diagrams.py
@@ -67,8 +67,11 @@ def plot_diagram(diagram, homology_dimensions=None, plotly_params=None):
             subdiagram, axis=0, return_inverse=True, return_counts=True
             )
         hovertext = [
-            "<br>".join([f"{tuple(unique[unique_row_index][:2])}"]
-                        * counts[unique_row_index])
+            f"{tuple(unique[unique_row_index][:2])}" +
+            (
+                f", multiplicity: {counts[unique_row_index]}"
+                if counts[unique_row_index] > 1 else ""
+            )
             for unique_row_index in inverse
             ]
         fig.add_trace(gobj.Scatter(

--- a/gtda/plotting/persistence_diagrams.py
+++ b/gtda/plotting/persistence_diagrams.py
@@ -63,8 +63,18 @@ def plot_diagram(diagram, homology_dimensions=None, plotly_params=None):
         subdiagram = diagram[diagram[:, 2] == dim]
         diff = (subdiagram[:, 1] != subdiagram[:, 0])
         subdiagram = subdiagram[diff]
-        fig.add_trace(gobj.Scatter(x=subdiagram[:, 0], y=subdiagram[:, 1],
-                                   mode="markers", name=name))
+        unique, inverse, counts = np.unique(
+            subdiagram, axis=0, return_inverse=True, return_counts=True
+            )
+        hovertext = [
+            "<br>".join([f"{tuple(unique[unique_row_index][:2])}"]
+                        * counts[unique_row_index])
+            for unique_row_index in inverse
+            ]
+        fig.add_trace(gobj.Scatter(
+            x=subdiagram[:, 0], y=subdiagram[:, 1], mode="markers",
+            hoverinfo="text", hovertext=hovertext, name=name
+        ))
 
     fig.update_layout(
         width=500,

--- a/gtda/point_clouds/rescaling.py
+++ b/gtda/point_clouds/rescaling.py
@@ -58,9 +58,9 @@ class ConsistentRescaling(BaseEstimator, TransformerMixin, PlotterMixin):
         to the "consistent rescaling" procedure.
 
     n_jobs : int or None, optional, default: ``None``
-        The number of jobs to use for the computation. ``None`` means 1
-        unless in a :obj:`joblib.parallel_backend` context. ``-1`` means
-        using all processors.
+        The number of jobs to use for the computation. ``None`` means 1 unless
+        in a :obj:`joblib.parallel_backend` context. ``-1`` means using all
+        processors.
 
     Attributes
     ----------
@@ -266,9 +266,9 @@ class ConsecutiveRescaling(BaseEstimator, TransformerMixin, PlotterMixin):
         points.
 
     n_jobs : int or None, optional, default: ``None``
-        The number of jobs to use for the computation. ``None`` means 1
-        unless in a :obj:`joblib.parallel_backend` context. ``-1`` means
-        using all processors.
+        The number of jobs to use for the computation. ``None`` means 1 unless
+        in a :obj:`joblib.parallel_backend` context. ``-1`` means using all
+        processors.
 
     Attributes
     ----------

--- a/gtda/tests/test_common.py
+++ b/gtda/tests/test_common.py
@@ -68,6 +68,7 @@ def _get_estimator_name(estimator):
         return estimator.__class__.__name__
 
 
+@pytest.mark.filterwarnings("ignore:Input of `fit` contains")
 @parametrize_with_checks(
     [Binarizer, Inverter]
     )

--- a/gtda/time_series/multivariate.py
+++ b/gtda/time_series/multivariate.py
@@ -13,15 +13,15 @@ from ..utils._docs import adapt_fit_transform_docs
 class PearsonDissimilarity(BaseEstimator, TransformerMixin):
     """Pearson dissimilarities from collections of multivariate time series.
 
-    The sample Pearson correlation coefficients between pairs of
-    components of an :math:`N`-variate time series form an :math:`N
-    \\times N` matrix :math:`R` with entries
+    The sample Pearson correlation coefficients between pairs of components of
+    an :math:`N`-variate time series form an :math:`N \\times N` matrix
+    :math:`R` with entries
 
     .. math:: R_{ij} = \\frac{ C_{ij} }{ \\sqrt{ C_{ii} C_{jj} } },
 
     where :math:`C` is the covariance matrix. Setting :math:`D_{ij} =
-    (1 - R_{ij})/2` or :math:`D_{ij} = 1 - |R_{ij}|` we obtain a
-    dissimilarity matrix with entries between 0 and 1.
+    (1 - R_{ij})/2` or :math:`D_{ij} = 1 - |R_{ij}|` we obtain a dissimilarity
+    matrix with entries between 0 and 1.
 
     This transformer computes one dissimilarity matrix per multivariate time
     series in a collection. Examples of such collections are the outputs of
@@ -30,14 +30,14 @@ class PearsonDissimilarity(BaseEstimator, TransformerMixin):
     Parameters
     ----------
     absolute_value : bool, default: ``False``
-        Whether absolute values of the Pearson correlation coefficients
-        should be taken. Doing so makes pairs of strongly anti-correlated
-        variables as similar as pairs of strongly correlated ones.
+        Whether absolute values of the Pearson correlation coefficients should
+        be taken. Doing so makes pairs of strongly anti-correlated variables as
+        as similar as pairs of strongly correlated ones.
 
     n_jobs : int or None, optional, default: ``None``
-        The number of jobs to use for the computation. ``None`` means 1
-        unless in a :obj:`joblib.parallel_backend` context. ``-1`` means
-        using all processors.
+        The number of jobs to use for the computation. ``None`` means 1 unless
+        in a :obj:`joblib.parallel_backend` context. ``-1`` means using all
+        processors.
 
     See also
     --------

--- a/gtda/utils/validation.py
+++ b/gtda/utils/validation.py
@@ -47,7 +47,7 @@ def check_diagrams(X, copy=False):
             f"components, but there are {X_array.shape[2]} components.")
 
     X_array = X_array.astype(float, copy=False)
-    homology_dimensions = sorted(set(X_array[0, :, 2]))
+    homology_dimensions = sorted(np.unique(X_array[0, :, 2]))
     for dim in homology_dimensions:
         if dim == np.inf:
             if len(homology_dimensions) != 1:

--- a/gtda/utils/validation.py
+++ b/gtda/utils/validation.py
@@ -47,7 +47,7 @@ def check_diagrams(X, copy=False):
             f"components, but there are {X_array.shape[2]} components.")
 
     X_array = X_array.astype(float, copy=False)
-    homology_dimensions = sorted(list(set(X_array[0, :, 2])))
+    homology_dimensions = sorted(set(X_array[0, :, 2]))
     for dim in homology_dimensions:
         if dim == np.inf:
             if len(homology_dimensions) != 1:


### PR DESCRIPTION
**Reference issues/PRs**
Fixes #438 (amongst other things).

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
- **[bug fix]** Extends fix of y-axis as in #453 to `PersistenceImage`.

- **[enhancement]** Represents possible multiplicity of persistence pairs in persistence diagram plots by appending ", multiplicity: i" to the hovertext for points with multiplicity i.

- **[breaking change]** `gaussian_filter` (used to make heat kernel representations and persistence image ones) is now called with `mode="constant"` instead of `"reflect"`.

- **[bug fix/enhancement]** The `PersistenceLandscape` plot method is fixed:

  - Only the figure corresponding to the first seen homology dimension was previously returned.

  - Now, the output is a figure with subplots, a main title, and one subtitle per plot (homology dimension).

- **[breaking change]** The default value of `order` in `Amplitude` has been changed from `2.` to `None` (giving vector instead of scalar features)

- **[breaking change]** The meaning of the default `None` for `weight_function` in `PersistenceImage` (and `Amplitude` and `PairwiseDistance` when `metric="persistence_image"`) has been changed from the identity function (now removed) to the function returning a vector of ones. Reason: `None` corresponding the identity meant that there was a non-trivial weighting. Semantically, this does not seem correct ("None" should mean no weighting at all).

- Important changes to `gtda.diagrams._metrics`:

  - **[breaking change/enhancement]** The computation of heat/persistence image distances and amplitudes has been changed to yield the continuum limit when `n_bins` tends to infinity.

  - **[breaking change/enhancement]** `sigma` in persistence-image-- and heat-kernel--based representations/distances/amplitudes is now measured in the same units as the filtration parameter (not in pixels), thus decoupling its effect from the effect of `n_bins`. Also the default value of this parameter in `PairwiseDistance`, `Amplitude`, `HeatKernel` and `PersistenceImage` has been changed from 1. to 0.1.

  - **[enhancement]** Trivial points are now removed from diagrams before creating a sampled image in `heats` and `persistence_images`. This ensures in particular that the trivial points really give no contribution regardless of the weight function used for persistence images.

  - **[bug fix]** #438 is fixed, as are similar issues with `PairwiseDistance` when the metric is persistence-image--based.

  - **[enhancement]** `silhouettes` now does not create NaNs when a subdiagram is trivial (this was due to division 0/0, now fixed by a cheap trick making the denominator infinity).

  - **[breaking change/bug fix]** The default value of `power` in `silhouette_amplitudes` and `silhouette_distances` is changed to 1., to agree with `Amplitude` and `PairwiseDistance` docs.

  - **[bug fix]** The use of `np.array_equal` in `persistence_image_distances` and `heat_distances` is fixed -- so far the boolean check for equal inputs always failed due to the in-place modifications of `diagrams_1`.

  - **[breaking change]** Weights are no longer stored in the `effective_metric_params_` attribute of `PairwiseDistance`, `Amplitude` and `Scaler` objects when the metric is persistence-image--based. The weight function is.

  - The utility function `_heat` is removed and its logic is incorporated in `heats`.
  
  - The utility functions `_matrix_wrapper` and `_arrays_wrapper` were never used and have been removed.

- **[breaking change?]** The `homology_dimensions_` attributes of several transformers have been converted from lists to tuples and, when possible, homology dimensions are cast to ints there. Also, the keys of the `samplings_` dictionary attributes of several transformers are now cast to ints when possible.

- **[enhancement]** Tests of plot methods in `gtda.diagrams.representations` have been improved to cover the use of `plotly_params` and of other kwargs, and the case of diagrams with homology dimension equaling `np.inf`.

- **[enhancement]** Test coverage of `Amplitude` and `PairwiseDistance` has been improved as follows:

  - Silhouettes and persistence images are covered throughout.

  - The `order` parameter is covered throughout.

- **[enhancement]** Code style and clarity have been improved throughout.

- **[enhancement]** Miscellaneous docstring and linting improvements have been performed.

**Screenshots (if appropriate)**

**Any other comments?**

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.