### PR TITLE
Bump package dependencies to latest available in conda

### DIFF
--- a/.azure-ci/docker_scripts.sh
+++ b/.azure-ci/docker_scripts.sh
@@ -7,7 +7,7 @@ echo "Start manylinux2010 docker build"
 PYTHON_PATH=$(eval find "/opt/python/*${python_ver}*" -print)
 export PATH="${PYTHON_PATH}/bin:${PATH}"
 pip config set global.progress_bar off
-pip install --upgrade pip==19.3.1 setuptools
+pip install --upgrade pip setuptools
 
 # Install CMake
 pip install cmake

--- a/README.rst
+++ b/README.rst
@@ -63,13 +63,13 @@ Dependencies
 The latest stable version of ``giotto-tda`` requires:
 
 - Python (>= 3.6)
-- NumPy (>= 1.17.0)
-- SciPy (>= 0.17.0)
-- joblib (>= 0.13)
-- scikit-learn (>= 0.22.0)
+- NumPy (>= 1.19.1)
+- SciPy (>= 1.5.0)
+- joblib (>= 0.16.0)
+- scikit-learn (>= 0.23.1)
 - pyflagser (>= 0.4.0)
-- python-igraph (>= 0.7.1.post6)
-- plotly (>= 4.4.1)
+- python-igraph (>= 0.8.2)
+- plotly (>= 4.8.2)
 - ipywidgets (>= 7.5.1)
 
 To run the examples, jupyter is required.

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -11,13 +11,13 @@ Dependencies
 The latest stable version of giotto-tda requires:
 
 - Python (>= 3.6)
-- NumPy (>= 1.17.0)
-- SciPy (>= 0.17.0)
-- joblib (>= 0.13)
-- scikit-learn (>= 0.22.0)
+- NumPy (>= 1.19.1)
+- SciPy (>= 1.5.0)
+- joblib (>= 0.16.0)
+- scikit-learn (>= 0.23.1)
 - pyflagser (>= 0.4.0)
-- python-igraph (>= 0.7.1.post6)
-- plotly (>= 4.4.1)
+- python-igraph (>= 0.8.2)
+- plotly (>= 4.8.2)
 - ipywidgets (>= 7.5.1)
 
 To run the examples, jupyter is required.

--- a/gtda/mapper/cluster.py
+++ b/gtda/mapper/cluster.py
@@ -8,17 +8,13 @@ import numpy as np
 from joblib import Parallel, delayed
 from sklearn.base import BaseEstimator, ClusterMixin, clone
 from sklearn.cluster import DBSCAN
-
-try:  # scikit-learn >= 0.22.1
-    from sklearn.cluster._agglomerative import _TREE_BUILDERS, _hc_cut
-except ImportError:
-    from sklearn.cluster._hierarchical import _TREE_BUILDERS, _hc_cut
+from sklearn.cluster._agglomerative import _TREE_BUILDERS, _hc_cut
 from sklearn.utils import check_array
 from sklearn.utils.validation import check_memory
 
+from .utils._cluster import _num_clusters_histogram, _num_clusters_simple
 from ..utils.intervals import Interval
 from ..utils.validation import validate_params
-from .utils._cluster import _num_clusters_histogram, _num_clusters_simple
 
 
 class ParallelClustering(BaseEstimator):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-numpy >= 1.17.0
-scipy >= 0.17.0
-joblib >= 0.13
-scikit-learn >= 0.22.0
+numpy >= 1.19.1
+scipy >= 1.5.0
+joblib >= 0.16.0
+scikit-learn >= 0.23.1
 pyflagser >= 0.4.0
-python-igraph >= 0.7.1.post6
-plotly >= 4.4.1
+python-igraph >= 0.8.2
+plotly >= 4.8.2
 ipywidgets >= 7.5.1


### PR DESCRIPTION
**Reference issues/PRs**
Relevant to #442. Suggested by @gtauzin in the course of that PR (https://github.com/giotto-ai/giotto-tda/pull/442#discussion_r464058859).

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
Bumps our core dependencies to the latest available in conda (which in several cases also means the latest on PyPI). In the case of `scikit-learn` and `joblib`, this is done to maintain our tight integration with those libraries. In other cases, there is no strong argument that I know of for retrocompatibility, but I'd welcome opinions.

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] ~~I have added tests to cover my changes.~~
- [ ] All new and existing tests passed. I used `pytest` to check this on Python tests.