### PR TITLE
Adds WeakAlphaPersistence

### DIFF
--- a/doc/modules/homology.rst
+++ b/doc/modules/homology.rst
@@ -13,6 +13,7 @@
 
    homology.VietorisRipsPersistence
    homology.SparseRipsPersistence
+   homology.WeakAlphaPersistence
    homology.EuclideanCechPersistence
    homology.FlagserPersistence
    homology.CubicalPersistence

--- a/gtda/homology/__init__.py
+++ b/gtda/homology/__init__.py
@@ -4,7 +4,7 @@ to generate persistence diagrams.
 # License: GNU AGPLv3
 
 from .simplicial import VietorisRipsPersistence, SparseRipsPersistence, \
-    EuclideanCechPersistence, FlagserPersistence
+    EuclideanCechPersistence, FlagserPersistence, WeakAlphaPersistence
 from .cubical import CubicalPersistence
 
 __all__ = [
@@ -12,5 +12,6 @@ __all__ = [
     'SparseRipsPersistence',
     'EuclideanCechPersistence',
     'FlagserPersistence',
+    'WeakAlphaPersistence',
     'CubicalPersistence',
 ]

--- a/gtda/homology/__init__.py
+++ b/gtda/homology/__init__.py
@@ -4,14 +4,14 @@ to generate persistence diagrams.
 # License: GNU AGPLv3
 
 from .simplicial import VietorisRipsPersistence, SparseRipsPersistence, \
-    EuclideanCechPersistence, FlagserPersistence, WeakAlphaPersistence
+    WeakAlphaPersistence, EuclideanCechPersistence, FlagserPersistence
 from .cubical import CubicalPersistence
 
 __all__ = [
     'VietorisRipsPersistence',
     'SparseRipsPersistence',
+    'WeakAlphaPersistence',
     'EuclideanCechPersistence',
     'FlagserPersistence',
-    'WeakAlphaPersistence',
     'CubicalPersistence',
-]
+    ]

--- a/gtda/homology/cubical.py
+++ b/gtda/homology/cubical.py
@@ -229,7 +229,7 @@ class CubicalPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         Parameters
         ----------
-        Xt : ndarray of shape (n_samples, n_points, 3)
+        Xt : ndarray of shape (n_samples, n_features, 3)
             Collection of persistence diagrams, such as returned by
             :meth:`transform`.
 

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -29,13 +29,12 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
     <vietoris-rips_complex_and_vietoris-rips_persistence>`.
 
     Given a :ref:`point cloud <finite_metric_spaces_and_point_clouds>` in
-    Euclidean space, or an abstract
-    :ref:`metric space <finite_metric_spaces_and_point_clouds>` encoded by a
-    distance matrix, information about the appearance and disappearance of
-    topological features (technically,
-    :ref:`homology classes <homology_and_cohomology>`) of various dimension
-    and at different scales is summarised in the corresponding persistence
-    diagram.
+    Euclidean space, or an abstract :ref:`metric space
+    <finite_metric_spaces_and_point_clouds>` encoded by a distance matrix,
+    information about the appearance and disappearance of topological features
+    (technically, :ref:`homology classes <homology_and_cohomology>`) of various
+    dimensions and at different scales is summarised in the corresponding
+    persistence diagram.
 
     Parameters
     ----------
@@ -45,9 +44,9 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         undirected graphs. Otherwise, input data is to be interpreted as a
         collection of point clouds (i.e. feature arrays), and `metric`
         determines a rule with which to calculate distances between pairs of
-        points (i.e. row vectors). If `metric` is a string, it must be one
-        of the options allowed by :func:`scipy.spatial.distance.pdist` for
-        its metric parameter, or a metric listed in
+        points (i.e. row vectors). If `metric` is a string, it must be one of
+        the options allowed by :func:`scipy.spatial.distance.pdist` for its
+        metric parameter, or a metric listed in
         :obj:`sklearn.pairwise.PAIRWISE_DISTANCE_FUNCTIONS`, including
         ``'euclidean'``, ``'manhattan'`` or ``'cosine'``. If `metric` is a
         callable, it should take pairs of vectors (1D arrays) as input and, for
@@ -65,14 +64,14 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
     max_edge_length : float, optional, default: ``numpy.inf``
         Maximum value of the Vietoris–Rips filtration parameter. Points whose
-        distance is greater than this value will never be connected by an
-        edge, and topological features at scales larger than this value will
-        not be detected.
+        distance is greater than this value will never be connected by an edge,
+        and topological features at scales larger than this value will not be
+        detected.
 
     infinity_values : float or None, default: ``None``
         Which death value to assign to features which are still alive at
-        filtration value `max_edge_length`. ``None`` means that this
-        death value is declared to be equal to `max_edge_length`.
+        filtration value `max_edge_length`. ``None`` means that this death
+        value is declared to be equal to `max_edge_length`.
 
     n_jobs : int or None, optional, default: ``None``
         The number of jobs to use for the computation. ``None`` means 1 unless
@@ -92,14 +91,14 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
     Notes
     -----
-    `Ripser <https://github.com/Ripser/ripser>`_ is used as a C++ backend
-    for computing Vietoris–Rips persistent homology. Python bindings were
-    modified for performance from the `ripser.py
+    `Ripser <https://github.com/Ripser/ripser>`_ is used as a C++ backend for
+    computing Vietoris–Rips persistent homology. Python bindings were modified
+    for performance from the `ripser.py
     <https://github.com/scikit-tda/ripser.py>`_ package.
 
-    Persistence diagrams produced by this class must be interpreted with
-    care due to the presence of padding triples which carry no information.
-    See :meth:`transform` for additional information.
+    Persistence diagrams produced by this class must be interpreted with care
+    due to the presence of padding triples which carry no information. See
+    :meth:`transform` for additional information.
 
     References
     ----------
@@ -277,30 +276,28 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
     <vietoris-rips_complex_and_vietoris-rips_persistence>`.
 
     Given a :ref:`point cloud <finite_metric_spaces_and_point_clouds>` in
-    Euclidean space, or an abstract
-    :ref:`metric space <finite_metric_spaces_and_point_clouds>`
-    encoded by a distance matrix, information about the appearance and
-    disappearance of topological features (technically,
-    :ref:`homology classes <homology_and_cohomology>`) of various dimensions
-    and at different scales is summarised in the corresponding persistence
-    diagram.
+    Euclidean space, or an abstract :ref:`metric space
+    <finite_metric_spaces_and_point_clouds>` encoded by a distance matrix,
+    information about the appearance and disappearance of topological features
+    (technically, :ref:`homology classes <homology_and_cohomology>`) of various
+    dimensions and at different scales is summarised in the corresponding
+    persistence diagram.
 
     Parameters
     ----------
     metric : string or callable, optional, default: ``'euclidean'``
         If set to ``'precomputed'``, input data is to be interpreted as a
         collection of distance matrices. Otherwise, input data is to be
-        interpreted as a collection of point clouds (i.e. feature arrays),
-        and `metric` determines a rule with which to calculate distances
-        between pairs of instances (i.e. rows) in these arrays.
-        If `metric` is a string, it must be one of the options allowed by
+        interpreted as a collection of point clouds (i.e. feature arrays), and
+        `metric` determines a rule with which to calculate distances between
+        pairs of instances (i.e. rows) in these arrays. If `metric` is a
+        string, it must be one of the options allowed by
         :func:`scipy.spatial.distance.pdist` for its metric parameter, or a
         metric listed in :obj:`sklearn.pairwise.PAIRWISE_DISTANCE_FUNCTIONS`,
-        including "euclidean", "manhattan", or "cosine".
-        If `metric` is a callable function, it is called on each pair of
-        instances and the resulting value recorded. The callable should take
-        two arrays from the entry in `X` as input, and return a value
-        indicating the distance between them.
+        including "euclidean", "manhattan", or "cosine". If `metric` is a
+        callable, it is called on each pair of instances and the resulting
+        value recorded. The callable should take two arrays from the entry in
+        `X` as input, and return a value indicating the distance between them.
 
     homology_dimensions : list or tuple, optional, default: ``(0, 1)``
         Dimensions (non-negative integers) of the topological features to be
@@ -313,19 +310,19 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
     epsilon : float between 0. and 1., optional, default: ``0.1``
         Parameter controlling the approximation to the exact Vietoris–Rips
-        filtration. If set to `0.`, :class:`SparseRipsPersistence` leads to
-        the same results as :class:`VietorisRipsPersistence` but is slower.
+        filtration. If set to `0.`, :class:`SparseRipsPersistence` leads to the
+        same results as :class:`VietorisRipsPersistence` but is slower.
 
     max_edge_length : float, optional, default: ``numpy.inf``
         Maximum value of the Sparse Rips filtration parameter. Points whose
-        distance is greater than this value will never be connected by an
-        edge, and topological features at scales larger than this value will
-        not be detected.
+        distance is greater than this value will never be connected by an edge,
+        and topological features at scales larger than this value will not be
+        detected.
 
     infinity_values : float or None, default : ``None``
         Which death value to assign to features which are still alive at
-        filtration value `max_edge_length`. ``None`` means that this
-        death value is declared to be equal to `max_edge_length`.
+        filtration value `max_edge_length`. ``None`` means that this death
+        value is declared to be equal to `max_edge_length`.
 
     n_jobs : int or None, optional, default: ``None``
         The number of jobs to use for the computation. ``None`` means 1 unless
@@ -349,9 +346,9 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
     for computing sparse Vietoris–Rips persistent homology. Python bindings
     were modified for performance.
 
-    Persistence diagrams produced by this class must be interpreted with
-    care due to the presence of padding triples which carry no information.
-    See :meth:`transform` for additional information.
+    Persistence diagrams produced by this class must be interpreted with care
+    due to the presence of padding triples which carry no information. See
+    :meth:`transform` for additional information.
 
     References
     ----------
@@ -539,10 +536,9 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
     Given a :ref:`point cloud <finite_metric_spaces_and_point_clouds>` in
     Euclidean space, information about the appearance and disappearance of
-    topological features (technically,
-    :ref:`homology classes <homology_and_cohomology>`) of various dimensions
-    and at different scales is summarised in the corresponding persistence
-    diagram.
+    topological features (technically, :ref:`homology classes
+    <homology_and_cohomology>`) of various dimensions and at different scales
+    is summarised in the corresponding persistence diagram.
 
     Parameters
     ----------
@@ -583,12 +579,12 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
     Notes
     -----
     `GUDHI <https://github.com/GUDHI/gudhi-devel>`_ is used as a C++ backend
-    for computing Cech persistent homology. Python bindings were modified
-    for performance.
+    for computing Cech persistent homology. Python bindings were modified for
+    performance.
 
-    Persistence diagrams produced by this class must be interpreted with
-    care due to the presence of padding triples which carry no information.
-    See :meth:`transform` for additional information.
+    Persistence diagrams produced by this class must be interpreted with care
+    due to the presence of padding triples which carry no information. See
+    :meth:`transform` for additional information.
 
     References
     ----------
@@ -757,9 +753,8 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
     Given a weighted directed or undirected graph, information about the
     appearance and disappearance of topological features (technically,
-    :ref:`homology classes <homology_and_cohomology>`) of various dimension
-    and at different scales is summarised in the corresponding persistence
-    diagram.
+    :ref:`homology classes <homology_and_cohomology>`) of various dimension and
+    at different scales is summarised in the corresponding persistence diagram.
 
     Parameters
     ----------
@@ -768,11 +763,11 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         detected.
 
     directed : bool, optional, default: ``True``
-        If ``True``, :meth:`transform` computes the persistence diagrams of
-        the filtered directed flag complexes arising from the input collection
-        of weighted directed graphs. If ``False``, :meth:`transform` computes
-        the persistence diagrams of the filtered undirected flag complexes
-        obtained by regarding all input weighted graphs as undirected, and:
+        If ``True``, :meth:`transform` computes the persistence diagrams of the
+        filtered directed flag complexes arising from the input collection of
+        weighted directed graphs. If ``False``, :meth:`transform` computes the
+        persistence diagrams of the filtered undirected flag complexes obtained
+        by regarding all input weighted graphs as undirected, and:
 
         - if `max_edge_weight` is ``numpy.inf``, it is sufficient to pass a
           collection of (dense or sparse) upper-triangular matrices;
@@ -799,8 +794,8 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
     infinity_values : float or None, default : ``None``
         Which death value to assign to features which are still alive at
-        filtration value `max_edge_weight`. ``None`` means that this
-        death value is declared to be equal to `max_edge_weight`.
+        filtration value `max_edge_weight`. ``None`` means that this death
+        value is declared to be equal to `max_edge_weight`.
 
     max_entries : int, optional, default: ``-1``
         Number controlling the degree of precision in the matrix
@@ -830,16 +825,16 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
     -----
     The `pyflagser <https://github.com/giotto-ai/pyflagser>`_ Python package
     is used for binding `Flagser <https://github.com/luetge/flagser>`_, a C++
-    backend for computing the (persistent) homology of (filtered) directed
-    flag complexes.
+    backend for computing the (persistent) homology of (filtered) directed flag
+    complexes.
 
     For more details, please refer to the `flagser documentation \
     <https://github.com/luetge/flagser/blob/master/docs/\
     documentation_flagser.pdf>`_.
 
-    Persistence diagrams produced by this class must be interpreted with
-    care due to the presence of padding triples which carry no information.
-    See :meth:`transform` for additional information.
+    Persistence diagrams produced by this class must be interpreted with care
+    due to the presence of padding triples which carry no information. See
+    :meth:`transform` for additional information.
 
 
     References
@@ -1031,13 +1026,21 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 @adapt_fit_transform_docs
 class WeakAlphaPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
     """:ref:`Persistence diagrams <persistence_diagram>` resulting from
-    :ref:`weak Alpha filtrations <TODO>`.
+    :ref:`weak alpha filtrations <TODO>`.
 
     Given a :ref:`point cloud <finite_metric_spaces_and_point_clouds>` in
     Euclidean space, information about the appearance and disappearance of
     topological features (technically, :ref:`homology classes
     <homology_and_cohomology>`) of various dimension and at different scales is
     summarised in the corresponding persistence diagram.
+
+    The weak alpha filtration of a point cloud is defined to be the
+    :ref:`Vietoris–Rips filtration
+    <vietoris-rips_complex_and_vietoris-rips_persistence>` of the sparse matrix
+    of Euclidean distances between neighbouring vertices in the Delaunay
+    triangulation of the point cloud. In low dimensions, computing the
+    persistent homology of this filtration can be much faster than computing
+    Vietoris-Rips persistent homology via :class:`VietorisRipsPersistence`.
 
     Parameters
     ----------
@@ -1052,14 +1055,14 @@ class WeakAlphaPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
     max_edge_length : float, optional, default: ``numpy.inf``
         Maximum value of the Vietoris–Rips filtration parameter. Points whose
-        distance is greater than this value will never be connected by an
-        edge, and topological features at scales larger than this value will
-        not be detected.
+        distance is greater than this value will never be connected by an edge,
+        and topological features at scales larger than this value will not be
+        detected.
 
     infinity_values : float or None, default: ``None``
         Which death value to assign to features which are still alive at
-        filtration value `max_edge_length`. ``None`` means that this
-        death value is declared to be equal to `max_edge_length`.
+        filtration value `max_edge_length`. ``None`` means that this death
+        value is declared to be equal to `max_edge_length`.
 
     n_jobs : int or None, optional, default: ``None``
         The number of jobs to use for the computation. ``None`` means 1 unless
@@ -1079,9 +1082,9 @@ class WeakAlphaPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
     Notes
     -----
-    `Ripser <https://github.com/Ripser/ripser>`_ is used as a C++ backend
-    for computing Vietoris–Rips persistent homology. Python bindings were
-    modified for performance from the `ripser.py
+    `Ripser <https://github.com/Ripser/ripser>`_ is used as a C++ backend for
+    computing Vietoris–Rips persistent homology. Python bindings were modified
+    for performance from the `ripser.py
     <https://github.com/scikit-tda/ripser.py>`_ package.
 
     Persistence diagrams produced by this class must be interpreted with

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -153,9 +153,9 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             adjacency matrices of weighted undirected graphs otherwise. Can be
             either a 3D ndarray whose zeroth dimension has size ``n_samples``,
             or a list containing ``n_samples`` 2D ndarrays/sparse matrices.
-            Point cloud arrays have shape (n_points, n_dimensions), and if `X`
-            is a list these shapes can vary between point clouds. If `metric`
-            was set to ``'precomputed'``, each entry of `X` should be
+            Point cloud arrays have shape ``(n_points, n_dimensions)``, and if
+            `X` is a list these shapes can vary between point clouds. If
+            `metric` was set to ``'precomputed'``, each entry of `X` should be
             compatible with a filtration, i.e. the value at index (i, j) should
             be no smaller than the values at diagonal indices (i, i) and
             (j, j).
@@ -204,9 +204,9 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             adjacency matrices of weighted undirected graphs otherwise. Can be
             either a 3D ndarray whose zeroth dimension has size ``n_samples``,
             or a list containing ``n_samples`` 2D ndarrays/sparse matrices.
-            Point cloud arrays have shape (n_points, n_dimensions), and if `X`
-            is a list these shapes can vary between point clouds. If `metric`
-            was set to ``'precomputed'``, each entry of `X` should be
+            Point cloud arrays have shape ``(n_points, n_dimensions)``, and if
+            `X` is a list these shapes can vary between point clouds. If
+            `metric` was set to ``'precomputed'``, each entry of `X` should be
             compatible with a filtration, i.e. the value at index (i, j) should
             be no smaller than the values at diagonal indices (i, i) and
             (j, j).
@@ -243,7 +243,7 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         Parameters
         ----------
-        Xt : ndarray of shape (n_samples, n_points, 3)
+        Xt : ndarray of shape (n_samples, n_features, 3)
             Collection of persistence diagrams, such as returned by
             :meth:`transform`.
 
@@ -418,9 +418,9 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             was not set to ``'precomputed'``, and of distance matrices
             otherwise. Can be either a 3D ndarray whose zeroth dimension has
             size ``n_samples``, or a list containing ``n_samples`` 2D ndarrays.
-            Point cloud arrays have shape (n_points, n_dimensions), and if `X`
-            is a list these shapes can vary between point clouds. If `metric`
-            was set to ``'precomputed'``, each entry of `X` should be
+            Point cloud arrays have shape ``(n_points, n_dimensions)``, and if
+            `X` is a list these shapes can vary between point clouds. If
+            `metric` was set to ``'precomputed'``, each entry of `X` should be
             compatible with a filtration, i.e. the value at index (i, j) should
             be no smaller than the values at diagonal indices (i, i) and
             (j, j).
@@ -468,9 +468,9 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             was not set to ``'precomputed'``, and of distance matrices
             otherwise. Can be either a 3D ndarray whose zeroth dimension has
             size ``n_samples``, or a list containing ``n_samples`` 2D ndarrays.
-            Point cloud arrays have shape (n_points, n_dimensions), and if `X`
-            is a list these shapes can vary between point clouds. If `metric`
-            was set to ``'precomputed'``, each entry of `X` should be
+            Point cloud arrays have shape ``(n_points, n_dimensions)``, and if
+            `X` is a list these shapes can vary between point clouds. If
+            `metric` was set to ``'precomputed'``, each entry of `X` should be
             compatible with a filtration, i.e. the value at index (i, j) should
             be no smaller than the values at diagonal indices (i, i) and
             (j, j).
@@ -507,7 +507,7 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         Parameters
         ----------
-        Xt : ndarray of shape (n_samples, n_points, 3)
+        Xt : ndarray of shape (n_samples, n_features, 3)
             Collection of persistence diagrams, such as returned by
             :meth:`transform`.
 
@@ -671,8 +671,8 @@ class WeakAlphaPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             Input data representing a collection of point clouds. Can be either
             a 3D ndarray whose zeroth dimension has size ``n_samples``, or a
             list containing ``n_samples`` 2D ndarrays. Point cloud arrays have
-            shape (n_points, n_dimensions), and if `X` is a list these shapes
-            can vary between point clouds.
+            shape ``(n_points, n_dimensions)``, and if `X` is a list these
+            shapes can vary between point clouds.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -714,8 +714,8 @@ class WeakAlphaPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             Input data representing a collection of point clouds. Can be either
             a 3D ndarray whose zeroth dimension has size ``n_samples``, or a
             list containing ``n_samples`` 2D ndarrays. Point cloud arrays have
-            shape (n_points, n_dimensions), and if `X` is a list these shapes
-            can vary between point clouds.
+            shape ``(n_points, n_dimensions)``, and if `X` is a list these
+            shapes can vary between point clouds.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -748,7 +748,7 @@ class WeakAlphaPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         Parameters
         ----------
-        Xt : ndarray of shape (n_samples, n_points, 3)
+        Xt : ndarray of shape (n_samples, n_features, 3)
             Collection of persistence diagrams, such as returned by
             :meth:`transform`.
 
@@ -892,8 +892,8 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             Input data representing a collection of point clouds. Can be either
             a 3D ndarray whose zeroth dimension has size ``n_samples``, or a
             list containing ``n_samples`` 2D ndarrays. Point cloud arrays have
-            shape (n_points, n_dimensions), and if `X` is a list these shapes
-            can vary between point clouds.
+            shape ``(n_points, n_dimensions)``, and if `X` is a list these
+            shapes can vary between point clouds.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -935,8 +935,8 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             Input data representing a collection of point clouds. Can be either
             a 3D ndarray whose zeroth dimension has size ``n_samples``, or a
             list containing ``n_samples`` 2D ndarrays. Point cloud arrays have
-            shape (n_points, n_dimensions), and if `X` is a list these shapes
-            can vary between point clouds.
+            shape ``(n_points, n_dimensions)``, and if `X` is a list these
+            shapes can vary between point clouds.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -968,7 +968,7 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         Parameters
         ----------
-        Xt : ndarray of shape (n_samples, n_points, 3)
+        Xt : ndarray of shape (n_samples, n_features, 3)
             Collection of persistence diagrams, such as returned by
             :meth:`transform`.
 
@@ -1246,7 +1246,7 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         Parameters
         ----------
-        Xt : ndarray of shape (n_samples, n_points, 3)
+        Xt : ndarray of shape (n_samples, n_features, 3)
             Collection of persistence diagrams, such as returned by
             :meth:`transform`.
 

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -1116,8 +1116,7 @@ class WeakAlphaPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
     def _weak_alpha_diagram(self, X):
         N = len(X)
-        d = Delaunay(X)
-        indptr, indices = d.vertex_neighbor_vertices
+        indptr, indices = Delaunay(X).vertex_neighbor_vertices
 
         row = np.zeros_like(indices)
         row[indptr[1:-1]] = 1

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -546,7 +546,7 @@ class WeakAlphaPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
     of Euclidean distances between neighbouring vertices in the Delaunay
     triangulation of the point cloud. In low dimensions, computing the
     persistent homology of this filtration can be much faster than computing
-    Vietoris-Rips persistent homology via :class:`VietorisRipsPersistence`.
+    Vietoris–Rips persistent homology via :class:`VietorisRipsPersistence`.
 
     Parameters
     ----------

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -152,10 +152,10 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             was not set to ``'precomputed'``, and of distance matrices or
             adjacency matrices of weighted undirected graphs otherwise. Can be
             either a 3D ndarray whose zeroth dimension has size ``n_samples``,
-            or a list containing ``n_samples`` 2D ndarrays/sparse matrices. In
-            the case of a list of point clouds, each point cloud can have a
-            different number of points and be in a different dimension. If
-            `metric` was set to ``'precomputed'``, each entry of `X` should be
+            or a list containing ``n_samples`` 2D ndarrays/sparse matrices.
+            Point cloud arrays have shape (n_points, n_dimensions), and if `X`
+            is a list these shapes can vary between point clouds. If `metric`
+            was set to ``'precomputed'``, each entry of `X` should be
             compatible with a filtration, i.e. the value at index (i, j) should
             be no smaller than the values at diagonal indices (i, i) and
             (j, j).
@@ -203,10 +203,10 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             was not set to ``'precomputed'``, and of distance matrices or
             adjacency matrices of weighted undirected graphs otherwise. Can be
             either a 3D ndarray whose zeroth dimension has size ``n_samples``,
-            or a list containing ``n_samples`` 2D ndarrays/sparse matrices. In
-            the case of a list of point clouds, each point cloud can have a
-            different number of points and be in a different dimension. If
-            `metric` was set to ``'precomputed'``, each entry of `X` should be
+            or a list containing ``n_samples`` 2D ndarrays/sparse matrices.
+            Point cloud arrays have shape (n_points, n_dimensions), and if `X`
+            is a list these shapes can vary between point clouds. If `metric`
+            was set to ``'precomputed'``, each entry of `X` should be
             compatible with a filtration, i.e. the value at index (i, j) should
             be no smaller than the values at diagonal indices (i, i) and
             (j, j).
@@ -418,12 +418,12 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             was not set to ``'precomputed'``, and of distance matrices
             otherwise. Can be either a 3D ndarray whose zeroth dimension has
             size ``n_samples``, or a list containing ``n_samples`` 2D ndarrays.
-            In the case of a list of point clouds, each point cloud can have a
-            different number of points and be in a different dimension. If
-            `metric` was set to ``'precomputed'``, entries of `X` must be
-            square arrays and should be compatible with a filtration, i.e. the
-            value at index (i, j) should be no smaller than the values at
-            diagonal indices (i, i) and (j, j).
+            Point cloud arrays have shape (n_points, n_dimensions), and if `X`
+            is a list these shapes can vary between point clouds. If `metric`
+            was set to ``'precomputed'``, each entry of `X` should be
+            compatible with a filtration, i.e. the value at index (i, j) should
+            be no smaller than the values at diagonal indices (i, i) and
+            (j, j).
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -468,12 +468,12 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             was not set to ``'precomputed'``, and of distance matrices
             otherwise. Can be either a 3D ndarray whose zeroth dimension has
             size ``n_samples``, or a list containing ``n_samples`` 2D ndarrays.
-            In the case of a list of point clouds, each point cloud can have a
-            different number of points and be in a different dimension. If
-            `metric` was set to ``'precomputed'``, entries of `X` must be
-            square arrays and should be compatible with a filtration, i.e. the
-            value at index (i, j) should be no smaller than the values at
-            diagonal indices (i, i) and (j, j).
+            Point cloud arrays have shape (n_points, n_dimensions), and if `X`
+            is a list these shapes can vary between point clouds. If `metric`
+            was set to ``'precomputed'``, each entry of `X` should be
+            compatible with a filtration, i.e. the value at index (i, j) should
+            be no smaller than the values at diagonal indices (i, i) and
+            (j, j).
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -670,9 +670,9 @@ class WeakAlphaPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         X : ndarray or list of length n_samples
             Input data representing a collection of point clouds. Can be either
             a 3D ndarray whose zeroth dimension has size ``n_samples``, or a
-            list containing ``n_samples`` 2D ndarrays. If a list of point
-            clouds, each point cloud can have a different number of points and
-            be in a different dimension.
+            list containing ``n_samples`` 2D ndarrays. Point cloud arrays have
+            shape (n_points, n_dimensions), and if `X` is a list these shapes
+            can vary between point clouds.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -713,9 +713,9 @@ class WeakAlphaPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         X : ndarray or list of length n_samples
             Input data representing a collection of point clouds. Can be either
             a 3D ndarray whose zeroth dimension has size ``n_samples``, or a
-            list containing ``n_samples`` 2D ndarrays. If a list of point
-            clouds, each point cloud can have a different number of points and
-            be in a different dimension.
+            list containing ``n_samples`` 2D ndarrays. Point cloud arrays have
+            shape (n_points, n_dimensions), and if `X` is a list these shapes
+            can vary between point clouds.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -891,9 +891,9 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         X : ndarray or list of length n_samples
             Input data representing a collection of point clouds. Can be either
             a 3D ndarray whose zeroth dimension has size ``n_samples``, or a
-            list containing ``n_samples`` 2D ndarrays. If a list of point
-            clouds, each point cloud can have a different number of points and
-            be in a different dimension.
+            list containing ``n_samples`` 2D ndarrays. Point cloud arrays have
+            shape (n_points, n_dimensions), and if `X` is a list these shapes
+            can vary between point clouds.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -934,9 +934,9 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         X : ndarray or list of length n_samples
             Input data representing a collection of point clouds. Can be either
             a 3D ndarray whose zeroth dimension has size ``n_samples``, or a
-            list containing ``n_samples`` 2D ndarrays. If a list of point
-            clouds, each point cloud can have a different number of points and
-            be in a different dimension.
+            list containing ``n_samples`` 2D ndarrays. Point cloud arrays have
+            shape (n_points, n_dimensions), and if `X` is a list these shapes
+            can vary between point clouds.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -147,16 +147,18 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         Parameters
         ----------
-        X : ndarray or list
+        X : ndarray or list of length n_samples
             Input data representing a collection of point clouds if `metric`
             was not set to ``'precomputed'``, and of distance matrices or
             adjacency matrices of weighted undirected graphs otherwise. Can be
             either a 3D ndarray whose zeroth dimension has size ``n_samples``,
-            or a list containing ``n_samples`` 2D ndarrays/sparse matrices.
-            If `metric` was set to ``'precomputed'``, each entry of `X` should
-            be compatible with a filtration, i.e. the value at index (i, j)
-            should be no smaller than the values at diagonal indices (i, i)
-            and (j, j).
+            or a list containing ``n_samples`` 2D ndarrays/sparse matrices. In
+            the case of a list of point clouds, each point cloud can have a
+            different number of points and be in a different dimension. If
+            `metric` was set to ``'precomputed'``, each entry of `X` should be
+            compatible with a filtration, i.e. the value at index (i, j) should
+            be no smaller than the values at diagonal indices (i, i) and
+            (j, j).
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -196,16 +198,18 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         Parameters
         ----------
-        X : ndarray or list
+        X : ndarray or list of length n_samples
             Input data representing a collection of point clouds if `metric`
             was not set to ``'precomputed'``, and of distance matrices or
             adjacency matrices of weighted undirected graphs otherwise. Can be
             either a 3D ndarray whose zeroth dimension has size ``n_samples``,
-            or a list containing ``n_samples`` 2D ndarrays/sparse matrices.
-            If `metric` was set to ``'precomputed'``, each entry of `X` should
-            be compatible with a filtration, i.e. the value at index (i, j)
-            should be no smaller than the values at diagonal indices (i, i)
-            and (j, j).
+            or a list containing ``n_samples`` 2D ndarrays/sparse matrices. In
+            the case of a list of point clouds, each point cloud can have a
+            different number of points and be in a different dimension. If
+            `metric` was set to ``'precomputed'``, each entry of `X` should be
+            compatible with a filtration, i.e. the value at index (i, j) should
+            be no smaller than the values at diagonal indices (i, i) and
+            (j, j).
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -409,12 +413,14 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         Parameters
         ----------
-        X : ndarray or list
+        X : ndarray or list of length n_samples
             Input data representing a collection of point clouds if `metric`
             was not set to ``'precomputed'``, and of distance matrices
             otherwise. Can be either a 3D ndarray whose zeroth dimension has
             size ``n_samples``, or a list containing ``n_samples`` 2D ndarrays.
-            If `metric` was set to ``'precomputed'``, entries of `X` must be
+            In the case of a list of point clouds, each point cloud can have a
+            different number of points and be in a different dimension. If
+            `metric` was set to ``'precomputed'``, entries of `X` must be
             square arrays and should be compatible with a filtration, i.e. the
             value at index (i, j) should be no smaller than the values at
             diagonal indices (i, i) and (j, j).
@@ -457,12 +463,14 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         Parameters
         ----------
-        X : ndarray or list
+        X : ndarray or list of length n_samples
             Input data representing a collection of point clouds if `metric`
             was not set to ``'precomputed'``, and of distance matrices
             otherwise. Can be either a 3D ndarray whose zeroth dimension has
             size ``n_samples``, or a list containing ``n_samples`` 2D ndarrays.
-            If `metric` was set to ``'precomputed'``, entries of `X` must be
+            In the case of a list of point clouds, each point cloud can have a
+            different number of points and be in a different dimension. If
+            `metric` was set to ``'precomputed'``, entries of `X` must be
             square arrays and should be compatible with a filtration, i.e. the
             value at index (i, j) should be no smaller than the values at
             diagonal indices (i, i) and (j, j).
@@ -659,10 +667,12 @@ class WeakAlphaPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         Parameters
         ----------
-        X : ndarray or list
+        X : ndarray or list of length n_samples
             Input data representing a collection of point clouds. Can be either
             a 3D ndarray whose zeroth dimension has size ``n_samples``, or a
-            list containing ``n_samples`` 2D ndarrays.
+            list containing ``n_samples`` 2D ndarrays. If a list of point
+            clouds, each point cloud can have a different number of points and
+            be in a different dimension.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -687,23 +697,25 @@ class WeakAlphaPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         return self
 
     def transform(self, X, y=None):
-        """For each point cloud or distance matrix in `X`, compute the
-        relevant persistence diagram as an array of triples [b, d, q]. Each
-        triple represents a persistent topological feature in dimension q
-        (belonging to `homology_dimensions`) which is born at b and dies at d.
-        Only triples in which b < d are meaningful. Triples in which b and d
-        are equal ("diagonal elements") may be artificially introduced during
-        the computation for padding purposes, since the number of non-trivial
+        """For each point cloud in `X`, compute the relevant persistence
+        diagram as an array of triples [b, d, q]. Each triple represents a
+        persistent topological feature in dimension q (belonging to
+        `homology_dimensions`) which is born at b and dies at d. Only triples
+        in which b < d are meaningful. Triples in which b and d are equal
+        ("diagonal elements") may be artificially introduced during the
+        computation for padding purposes, since the number of non-trivial
         persistent topological features is typically not constant across
         samples. They carry no information and hence should be effectively
         ignored by any further computation.
 
         Parameters
         ----------
-        X : ndarray or list
+        X : ndarray or list of length n_samples
             Input data representing a collection of point clouds. Can be either
             a 3D ndarray whose zeroth dimension has size ``n_samples``, or a
-            list containing ``n_samples`` 2D ndarrays.
+            list containing ``n_samples`` 2D ndarrays. If a list of point
+            clouds, each point cloud can have a different number of points and
+            be in a different dimension.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -876,10 +888,12 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         Parameters
         ----------
-        X : ndarray or list
+        X : ndarray or list of length n_samples
             Input data representing a collection of point clouds. Can be either
             a 3D ndarray whose zeroth dimension has size ``n_samples``, or a
-            list containing ``n_samples`` 2D ndarrays.
+            list containing ``n_samples`` 2D ndarrays. If a list of point
+            clouds, each point cloud can have a different number of points and
+            be in a different dimension.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -917,10 +931,12 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         Parameters
         ----------
-        X : ndarray of shape (n_samples, n_points, n_dimensions)
+        X : ndarray or list of length n_samples
             Input data representing a collection of point clouds. Can be either
             a 3D ndarray whose zeroth dimension has size ``n_samples``, or a
-            list containing ``n_samples`` 2D ndarrays.
+            list containing ``n_samples`` 2D ndarrays. If a list of point
+            clouds, each point cloud can have a different number of points and
+            be in a different dimension.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -1127,7 +1143,7 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         Parameters
         ----------
-        X : ndarray or list
+        X : ndarray or list of length n_samples
             Input collection of adjacency matrices of weighted directed or
             undirected graphs. Can be either a 3D ndarray whose zeroth
             dimension has size ``n_samples``, or a list containing
@@ -1182,7 +1198,7 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         Parameters
         ----------
-        X : ndarray or list
+        X : ndarray or list of length n_samples
             Input collection of adjacency matrices of weighted directed or
             undirected graphs. Can be either a 3D ndarray whose zeroth
             dimension has size ``n_samples``, or a list containing

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -1147,15 +1147,9 @@ class WeakAlphaPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         Parameters
         ----------
         X : ndarray or list
-            Input data representing a collection of point clouds if `metric`
-            was not set to ``'precomputed'``, and of distance matrices or
-            adjacency matrices of weighted undirected graphs otherwise. Can be
-            either a 3D ndarray whose zeroth dimension has size ``n_samples``,
-            or a list containing ``n_samples`` 2D ndarrays/sparse matrices.
-            If `metric` was set to ``'precomputed'``, each entry of `X` should
-            be compatible with a filtration, i.e. the value at index (i, j)
-            should be no smaller than the values at diagonal indices (i, i)
-            and (j, j).
+            Input data representing a collection of point clouds. Can be either
+            a 3D ndarray whose zeroth dimension has size ``n_samples``, or a
+            list containing ``n_samples`` 2D ndarrays.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline
@@ -1194,15 +1188,9 @@ class WeakAlphaPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         Parameters
         ----------
         X : ndarray or list
-            Input data representing a collection of point clouds if `metric`
-            was not set to ``'precomputed'``, and of distance matrices or
-            adjacency matrices of weighted undirected graphs otherwise. Can be
-            either a 3D ndarray whose zeroth dimension has size ``n_samples``,
-            or a list containing ``n_samples`` 2D ndarrays/sparse matrices.
-            If `metric` was set to ``'precomputed'``, each entry of `X` should
-            be compatible with a filtration, i.e. the value at index (i, j)
-            should be no smaller than the values at diagonal indices (i, i)
-            and (j, j).
+            Input data representing a collection of point clouds. Can be either
+            a 3D ndarray whose zeroth dimension has size ``n_samples``, or a
+            list containing ``n_samples`` 2D ndarrays.
 
         y : None
             There is no need for a target in a transformer, yet the pipeline

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -7,8 +7,9 @@ from types import FunctionType
 import numpy as np
 from joblib import Parallel, delayed
 from pyflagser import flagser_weighted
+from scipy.sparse import csr_matrix
+from scipy.spatial import Delaunay
 from sklearn.base import BaseEstimator, TransformerMixin
-
 from sklearn.metrics.pairwise import pairwise_distances
 from sklearn.utils.validation import check_is_fitted
 
@@ -17,7 +18,6 @@ from ..base import PlotterMixin
 from ..externals.python import ripser, SparseRipsComplex, CechComplex
 from ..plotting import plot_diagram
 from ..utils._docs import adapt_fit_transform_docs
-
 from ..utils.intervals import Interval
 from ..utils.validation import validate_params, check_point_clouds
 
@@ -60,8 +60,8 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
     coeff : int prime, optional, default: ``2``
         Compute homology with coefficients in the prime field
-        :math:`\\mathbb{F}_p = \\{ 0, \\ldots, p - 1 \\}` where
-        :math:`p` equals `coeff`.
+        :math:`\\mathbb{F}_p = \\{ 0, \\ldots, p - 1 \\}` where :math:`p`
+        equals `coeff`.
 
     max_edge_length : float, optional, default: ``numpy.inf``
         Maximum value of the Vietoris–Rips filtration parameter. Points whose
@@ -308,8 +308,8 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
     coeff : int prime, optional, default: ``2``
         Compute homology with coefficients in the prime field
-        :math:`\\mathbb{F}_p = \\{ 0, \\ldots, p - 1 \\}` where
-        :math:`p` equals `coeff`.
+        :math:`\\mathbb{F}_p = \\{ 0, \\ldots, p - 1 \\}` where :math:`p`
+        equals `coeff`.
 
     epsilon : float between 0. and 1., optional, default: ``0.1``
         Parameter controlling the approximation to the exact Vietoris–Rips
@@ -552,8 +552,8 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
     coeff : int prime, optional, default: ``2``
         Compute homology with coefficients in the prime field
-        :math:`\\mathbb{F}_p = \\{ 0, \\ldots, p - 1 \\}` where
-        :math:`p` equals `coeff`.
+        :math:`\\mathbb{F}_p = \\{ 0, \\ldots, p - 1 \\}` where :math:`p`
+        equals `coeff`.
 
     max_edge_length : float, optional, default: ``numpy.inf``
         Maximum value of the Cech filtration parameter. Topological features at
@@ -788,8 +788,8 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
     coeff : int prime, optional, default: ``2``
         Compute homology with coefficients in the prime field
-        :math:`\\mathbb{F}_p = \\{ 0, \\ldots, p - 1 \\}` where
-        :math:`p` equals `coeff`.
+        :math:`\\mathbb{F}_p = \\{ 0, \\ldots, p - 1 \\}` where :math:`p`
+        equals `coeff`.
 
     max_edge_weight : float, optional, default: ``numpy.inf``
         Maximum edge weight to be considered in the filtration. All edge
@@ -986,6 +986,242 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         Xt = Parallel(n_jobs=self.n_jobs)(
             delayed(self._flagser_diagram)(x) for x in X)
+
+        Xt = _postprocess_diagrams(Xt, self._homology_dimensions,
+                                   self.infinity_values_, self.n_jobs)
+        return Xt
+
+    @staticmethod
+    def plot(Xt, sample=0, homology_dimensions=None, plotly_params=None):
+        """Plot a sample from a collection of persistence diagrams, with
+        homology in multiple dimensions.
+
+        Parameters
+        ----------
+        Xt : ndarray of shape (n_samples, n_points, 3)
+            Collection of persistence diagrams, such as returned by
+            :meth:`transform`.
+
+        sample : int, optional, default: ``0``
+            Index of the sample in `Xt` to be plotted.
+
+        homology_dimensions : list, tuple or None, optional, default: ``None``
+            Which homology dimensions to include in the plot. ``None`` means
+            plotting all dimensions present in ``Xt[sample]``.
+
+        plotly_params : dict or None, optional, default: ``None``
+            Custom parameters to configure the plotly figure. Allowed keys are
+            ``"traces"`` and ``"layout"``, and the corresponding values should
+            be dictionaries containing keyword arguments as would be fed to the
+            :meth:`update_traces` and :meth:`update_layout` methods of
+            :class:`plotly.graph_objects.Figure`.
+
+        Returns
+        -------
+        fig : :class:`plotly.graph_objects.Figure` object
+            Plotly figure.
+
+        """
+        return plot_diagram(
+            Xt[sample], homology_dimensions=homology_dimensions,
+            plotly_params=plotly_params
+            )
+
+
+@adapt_fit_transform_docs
+class WeakAlphaPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
+    """:ref:`Persistence diagrams <persistence_diagram>` resulting from
+    :ref:`weak Alpha filtrations <TODO>`.
+
+    Given a :ref:`point cloud <finite_metric_spaces_and_point_clouds>` in
+    Euclidean space, information about the appearance and disappearance of
+    topological features (technically, :ref:`homology classes
+    <homology_and_cohomology>`) of various dimension and at different scales is
+    summarised in the corresponding persistence diagram.
+
+    Parameters
+    ----------
+    homology_dimensions : list or tuple, optional, default: ``(0, 1)``
+        Dimensions (non-negative integers) of the topological features to be
+        detected.
+
+    coeff : int prime, optional, default: ``2``
+        Compute homology with coefficients in the prime field
+        :math:`\\mathbb{F}_p = \\{ 0, \\ldots, p - 1 \\}` where :math:`p`
+        equals `coeff`.
+
+    max_edge_length : float, optional, default: ``numpy.inf``
+        Maximum value of the Vietoris–Rips filtration parameter. Points whose
+        distance is greater than this value will never be connected by an
+        edge, and topological features at scales larger than this value will
+        not be detected.
+
+    infinity_values : float or None, default: ``None``
+        Which death value to assign to features which are still alive at
+        filtration value `max_edge_length`. ``None`` means that this
+        death value is declared to be equal to `max_edge_length`.
+
+    n_jobs : int or None, optional, default: ``None``
+        The number of jobs to use for the computation. ``None`` means 1 unless
+        in a :obj:`joblib.parallel_backend` context. ``-1`` means using all
+        processors.
+
+    Attributes
+    ----------
+    infinity_values_ : float
+        Effective death value to assign to features which are still alive at
+        filtration value `max_edge_length`.
+
+    See also
+    --------
+    VietorisRipsPersistence, FlagserPersistence, SparseRipsPersistence, \
+    EuclideanCechPersistence, ConsistentRescaling, ConsecutiveRescaling
+
+    Notes
+    -----
+    `Ripser <https://github.com/Ripser/ripser>`_ is used as a C++ backend
+    for computing Vietoris–Rips persistent homology. Python bindings were
+    modified for performance from the `ripser.py
+    <https://github.com/scikit-tda/ripser.py>`_ package.
+
+    Persistence diagrams produced by this class must be interpreted with
+    care due to the presence of padding triples which carry no information.
+    See :meth:`transform` for additional information.
+
+    References
+    ----------
+    [1] U. Bauer, "Ripser: efficient computation of Vietoris–Rips persistence \
+        barcodes", 2019; `arXiv:1908.02518 \
+        <https://arxiv.org/abs/1908.02518>`_.
+
+    """
+
+    _hyperparameters = {
+        'homology_dimensions': {
+            'type': (list, tuple),
+            'of': {'type': int, 'in': Interval(0, np.inf, closed='left')}
+            },
+        'coeff': {'type': int, 'in': Interval(2, np.inf, closed='left')},
+        'max_edge_length': {'type': Real},
+        'infinity_values': {'type': (Real, type(None))}
+        }
+
+    def __init__(self, homology_dimensions=(0, 1), coeff=2,
+                 max_edge_length=np.inf, infinity_values=None, n_jobs=None):
+        self.homology_dimensions = homology_dimensions
+        self.coeff = coeff
+        self.max_edge_length = max_edge_length
+        self.infinity_values = infinity_values
+        self.n_jobs = n_jobs
+
+    def _weak_alpha_diagram(self, X):
+        N = len(X)
+        d = Delaunay(X)
+        indptr, indices = d.vertex_neighbor_vertices
+
+        row = np.zeros_like(indices)
+        row[indptr[1:-1]] = 1
+        np.cumsum(row, out=row)
+
+        mask = indices > row
+        row, col = row[mask], indices[mask]
+        dists = np.linalg.norm(X[row] - X[col], axis=1)
+        dm = csr_matrix((dists, (row, col)), shape=(N, N))
+
+        Xdgms = ripser(dm, maxdim=self._max_homology_dimension,
+                       thresh=self.max_edge_length, coeff=self.coeff,
+                       metric='precomputed')['dgms']
+
+        if 0 in self._homology_dimensions:
+            Xdgms[0] = Xdgms[0][:-1, :]  # Remove one infinite bar
+
+        return Xdgms
+
+    def fit(self, X, y=None):
+        """Calculate :attr:`infinity_values_`. Then, return the estimator.
+
+        This method is here to implement the usual scikit-learn API and hence
+        work in pipelines.
+
+        Parameters
+        ----------
+        X : ndarray or list
+            Input data representing a collection of point clouds if `metric`
+            was not set to ``'precomputed'``, and of distance matrices or
+            adjacency matrices of weighted undirected graphs otherwise. Can be
+            either a 3D ndarray whose zeroth dimension has size ``n_samples``,
+            or a list containing ``n_samples`` 2D ndarrays/sparse matrices.
+            If `metric` was set to ``'precomputed'``, each entry of `X` should
+            be compatible with a filtration, i.e. the value at index (i, j)
+            should be no smaller than the values at diagonal indices (i, i)
+            and (j, j).
+
+        y : None
+            There is no need for a target in a transformer, yet the pipeline
+            API requires this parameter.
+
+        Returns
+        -------
+        self : object
+
+        """
+        validate_params(
+            self.get_params(), self._hyperparameters, exclude=['n_jobs'])
+        check_point_clouds(X)
+
+        if self.infinity_values is None:
+            self.infinity_values_ = self.max_edge_length
+        else:
+            self.infinity_values_ = self.infinity_values
+
+        self._homology_dimensions = sorted(self.homology_dimensions)
+        self._max_homology_dimension = self._homology_dimensions[-1]
+        return self
+
+    def transform(self, X, y=None):
+        """For each point cloud or distance matrix in `X`, compute the
+        relevant persistence diagram as an array of triples [b, d, q]. Each
+        triple represents a persistent topological feature in dimension q
+        (belonging to `homology_dimensions`) which is born at b and dies at d.
+        Only triples in which b < d are meaningful. Triples in which b and d
+        are equal ("diagonal elements") may be artificially introduced during
+        the computation for padding purposes, since the number of non-trivial
+        persistent topological features is typically not constant across
+        samples. They carry no information and hence should be effectively
+        ignored by any further computation.
+
+        Parameters
+        ----------
+        X : ndarray or list
+            Input data representing a collection of point clouds if `metric`
+            was not set to ``'precomputed'``, and of distance matrices or
+            adjacency matrices of weighted undirected graphs otherwise. Can be
+            either a 3D ndarray whose zeroth dimension has size ``n_samples``,
+            or a list containing ``n_samples`` 2D ndarrays/sparse matrices.
+            If `metric` was set to ``'precomputed'``, each entry of `X` should
+            be compatible with a filtration, i.e. the value at index (i, j)
+            should be no smaller than the values at diagonal indices (i, i)
+            and (j, j).
+
+        y : None
+            There is no need for a target in a transformer, yet the pipeline
+            API requires this parameter.
+
+        Returns
+        -------
+        Xt : ndarray of shape (n_samples, n_features, 3)
+            Array of persistence diagrams computed from the feature arrays or
+            distance matrices in `X`. ``n_features`` equals
+            :math:`\\sum_q n_q`, where :math:`n_q` is the maximum number of
+            topological features in dimension :math:`q` across all samples in
+            `X`.
+
+        """
+        check_is_fitted(self)
+        X = check_point_clouds(X)
+
+        Xt = Parallel(n_jobs=self.n_jobs)(
+            delayed(self._weak_alpha_diagram)(x) for x in X)
 
         Xt = _postprocess_diagrams(Xt, self._homology_dimensions,
                                    self.infinity_values_, self.n_jobs)

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -1115,7 +1115,6 @@ class WeakAlphaPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         self.n_jobs = n_jobs
 
     def _weak_alpha_diagram(self, X):
-        N = len(X)
         indptr, indices = Delaunay(X).vertex_neighbor_vertices
 
         row = np.zeros_like(indices)
@@ -1125,7 +1124,7 @@ class WeakAlphaPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         mask = indices > row
         row, col = row[mask], indices[mask]
         dists = np.linalg.norm(X[row] - X[col], axis=1)
-        dm = coo_matrix((dists, (row, col)), shape=(N, N))
+        dm = coo_matrix((dists, (row, col)))
 
         Xdgms = ripser(dm, maxdim=self._max_homology_dimension,
                        thresh=self.max_edge_length, coeff=self.coeff,

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -86,8 +86,8 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
     See also
     --------
-    FlagserPersistence, SparseRipsPersistence, EuclideanCechPersistence, \
-    ConsistentRescaling, ConsecutiveRescaling
+    FlagserPersistence, SparseRipsPersistence, WeakAlphaPersistence, \
+    EuclideanCechPersistence, ConsistentRescaling, ConsecutiveRescaling
 
     Notes
     -----
@@ -337,8 +337,8 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
     See also
     --------
-    VietorisRipsPersistence, FlagserPersistence, EuclideanCechPersistence, \
-    ConsistentRescaling, ConsecutiveRescaling
+    VietorisRipsPersistence, FlagserPersistence, WeakAlphaPersistence, \
+    EuclideanCechPersistence, ConsistentRescaling, ConsecutiveRescaling
 
     Notes
     -----
@@ -573,8 +573,8 @@ class EuclideanCechPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
     See also
     --------
-    VietorisRipsPersistence, FlagserPersistence, SparseRipsPersistence, \
-    ConsistentRescaling, ConsecutiveRescaling
+    VietorisRipsPersistence, FlagserPersistence, SparseRipsPersistence,
+    WeakAlphaPersistence
 
     Notes
     -----
@@ -818,8 +818,8 @@ class FlagserPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
     See also
     --------
-    VietorisRipsPersistence, SparseRipsPersistence, EuclideanCechPersistence, \
-    ConsistentRescaling, ConsecutiveRescaling
+    VietorisRipsPersistence, SparseRipsPersistence, WeakAlphaPersistence,
+    EuclideanCechPersistence, ConsistentRescaling, ConsecutiveRescaling
 
     Notes
     -----
@@ -1078,11 +1078,12 @@ class WeakAlphaPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
     See also
     --------
     VietorisRipsPersistence, FlagserPersistence, SparseRipsPersistence, \
-    EuclideanCechPersistence, ConsistentRescaling, ConsecutiveRescaling
+    EuclideanCechPersistence
 
     Notes
     -----
-    `Ripser <https://github.com/Ripser/ripser>`_ is used as a C++ backend for
+    Delaunay triangulation are computed by :class:`scipy.spatial.Delaunay`.
+    Ripser <https://github.com/Ripser/ripser>`_ is used as a C++ backend for
     computing Vietoris–Rips persistent homology. Python bindings were modified
     for performance from the `ripser.py
     <https://github.com/scikit-tda/ripser.py>`_ package.

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -625,12 +625,15 @@ class WeakAlphaPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         self.n_jobs = n_jobs
 
     def _weak_alpha_diagram(self, X):
+        # `indices` will serve as the array of column indices
         indptr, indices = Delaunay(X).vertex_neighbor_vertices
 
+        # Compute the array of row indices
         row = np.zeros_like(indices)
         row[indptr[1:-1]] = 1
         np.cumsum(row, out=row)
 
+        # We only need the upper diagonal
         mask = indices > row
         row, col = row[mask], indices[mask]
         dists = np.linalg.norm(X[row] - X[col], axis=1)

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -634,7 +634,10 @@ class WeakAlphaPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         mask = indices > row
         row, col = row[mask], indices[mask]
         dists = np.linalg.norm(X[row] - X[col], axis=1)
-        dm = coo_matrix((dists, (row, col)))
+        # Note: passing the shape explicitly should not be needed in more
+        # recent versions of C++ ripser
+        n_points = len(X)
+        dm = coo_matrix((dists, (row, col)), shape=(n_points, n_points))
 
         Xdgms = ripser(dm, maxdim=self._max_homology_dimension,
                        thresh=self.max_edge_length, coeff=self.coeff,

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -7,7 +7,7 @@ from types import FunctionType
 import numpy as np
 from joblib import Parallel, delayed
 from pyflagser import flagser_weighted
-from scipy.sparse import csr_matrix
+from scipy.sparse import coo_matrix
 from scipy.spatial import Delaunay
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.metrics.pairwise import pairwise_distances

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -1125,7 +1125,7 @@ class WeakAlphaPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         mask = indices > row
         row, col = row[mask], indices[mask]
         dists = np.linalg.norm(X[row] - X[col], axis=1)
-        dm = csr_matrix((dists, (row, col)), shape=(N, N))
+        dm = coo_matrix((dists, (row, col)), shape=(N, N))
 
         Xdgms = ripser(dm, maxdim=self._max_homology_dimension,
                        thresh=self.max_edge_length, coeff=self.coeff,

--- a/gtda/homology/tests/test_simplicial.py
+++ b/gtda/homology/tests/test_simplicial.py
@@ -173,7 +173,7 @@ def test_wap_params():
     coeff = 'not_defined'
     wap = WeakAlphaPersistence(coeff=coeff)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         wap.fit_transform(X_pc)
 
 

--- a/gtda/homology/tests/test_simplicial.py
+++ b/gtda/homology/tests/test_simplicial.py
@@ -38,7 +38,7 @@ X_circle = np.array([
      [0.70821787, 0.68571714],
      [-0.73369765, -0.71298056],
      [0.01110395, -1.03739883],
-     [-0.64968271, 0.7011624 ],
+     [-0.64968271, 0.7011624],
      [0.03895963, 0.94494511],
      [0.76291108, -0.68774373],
      [-1.01932365, -0.05793851]]
@@ -243,7 +243,7 @@ def test_wap_low_infinity_values(X):
 
 @pytest.mark.parametrize('X', [X_pc, X_pc_list])
 @pytest.mark.parametrize('hom_dims', [None, (0,), (1,), (0, 1)])
-def test_vrp_fit_transform_plot(X, hom_dims):
+def test_wap_fit_transform_plot(X, hom_dims):
     WeakAlphaPersistence().fit_transform_plot(
         X, sample=0, homology_dimensions=hom_dims)
 

--- a/gtda/homology/tests/test_simplicial.py
+++ b/gtda/homology/tests/test_simplicial.py
@@ -10,7 +10,7 @@ from scipy.spatial.distance import pdist, squareform
 from sklearn.exceptions import NotFittedError
 
 from gtda.homology import VietorisRipsPersistence, SparseRipsPersistence, \
-    EuclideanCechPersistence, FlagserPersistence, WeakAlphaPersistence
+    WeakAlphaPersistence, EuclideanCechPersistence, FlagserPersistence
 
 pio.renderers.default = 'plotly_mimetype'
 
@@ -156,6 +156,64 @@ def test_srp_fit_transform_plot(X, metric, hom_dims):
         X, sample=0, homology_dimensions=hom_dims)
 
 
+def test_wap_params():
+    coeff = 'not_defined'
+    wap = WeakAlphaPersistence(coeff=coeff)
+
+    with pytest.raises(ValueError):
+        wap.fit_transform(X_pc)
+
+
+def test_wap_not_fitted():
+    wap = WeakAlphaPersistence()
+
+    with pytest.raises(NotFittedError):
+        wap.transform(X_pc)
+
+
+X_vrp_res = np.array([
+    [[0., 0.43094373, 0.],
+     [0., 0.5117411, 0.],
+     [0., 0.60077095, 0.],
+     [0., 0.62186205, 0.],
+     [0.69093919, 0.80131882, 1.]]
+    ])
+
+
+@pytest.mark.parametrize('X', [X_pc, X_pc_list])
+@pytest.mark.parametrize('max_edge_length', [np.inf, 0.8])
+@pytest.mark.parametrize('infinity_values', [10, 30])
+def test_wap_transform(X, max_edge_length, infinity_values):
+    wap = WeakAlphaPersistence(max_edge_length=max_edge_length,
+                               infinity_values=infinity_values)
+    # This is not generally true, it is only a way to obtain the res array
+    # in this specific case
+    X_res = X_vrp_res.copy()
+    X_res[:, :, :2][X_res[:, :, :2] >= max_edge_length] = infinity_values
+    assert_almost_equal(wap.fit_transform(X), X_res)
+
+
+def test_wap_list_of_arrays_different_size():
+    X_2 = np.array([[0., 1.], [1., 2.]])
+    wap = WeakAlphaPersistence()
+    assert_almost_equal(wap.fit_transform([X_pc[0], X_2])[0], X_vrp_res[0])
+
+
+@pytest.mark.parametrize('X', [X_pc, X_pc_list])
+def test_wap_low_infinity_values(X):
+    wap = WeakAlphaPersistence(max_edge_length=0.001,
+                               infinity_values=-1)
+    assert_almost_equal(wap.fit_transform(X)[:, :, :2],
+                        np.zeros((1, 2, 2)))
+
+
+@pytest.mark.parametrize('X', [X_pc, X_pc_list])
+@pytest.mark.parametrize('hom_dims', [None, (0,), (1,), (0, 1)])
+def test_vrp_fit_transform_plot(X, hom_dims):
+    WeakAlphaPersistence().fit_transform_plot(
+        X, sample=0, homology_dimensions=hom_dims)
+
+
 def test_cp_params():
     coeff = 'not_defined'
     cp = EuclideanCechPersistence(coeff=coeff)
@@ -272,61 +330,3 @@ def test_fp_transform_undirected(X, max_edge_weight, infinity_values):
 def test_fp_fit_transform_plot(X, hom_dims):
     FlagserPersistence(directed=False).fit_transform_plot(
         X_dist, sample=0, homology_dimensions=hom_dims)
-
-
-def test_wap_params():
-    coeff = 'not_defined'
-    wap = WeakAlphaPersistence(coeff=coeff)
-
-    with pytest.raises(ValueError):
-        wap.fit_transform(X_pc)
-
-
-def test_wap_not_fitted():
-    wap = WeakAlphaPersistence()
-
-    with pytest.raises(NotFittedError):
-        wap.transform(X_pc)
-
-
-X_vrp_res = np.array([
-    [[0., 0.43094373, 0.],
-     [0., 0.5117411, 0.],
-     [0., 0.60077095, 0.],
-     [0., 0.62186205, 0.],
-     [0.69093919, 0.80131882, 1.]]
-    ])
-
-
-@pytest.mark.parametrize('X', [X_pc, X_pc_list])
-@pytest.mark.parametrize('max_edge_length', [np.inf, 0.8])
-@pytest.mark.parametrize('infinity_values', [10, 30])
-def test_wap_transform(X, max_edge_length, infinity_values):
-    wap = WeakAlphaPersistence(max_edge_length=max_edge_length,
-                               infinity_values=infinity_values)
-    # This is not generally true, it is only a way to obtain the res array
-    # in this specific case
-    X_res = X_vrp_res.copy()
-    X_res[:, :, :2][X_res[:, :, :2] >= max_edge_length] = infinity_values
-    assert_almost_equal(wap.fit_transform(X), X_res)
-
-
-def test_wap_list_of_arrays_different_size():
-    X_2 = np.array([[0., 1.], [1., 2.]])
-    wap = WeakAlphaPersistence()
-    assert_almost_equal(wap.fit_transform([X_pc[0], X_2])[0], X_vrp_res[0])
-
-
-@pytest.mark.parametrize('X', [X_pc, X_pc_list])
-def test_wap_low_infinity_values(X):
-    wap = WeakAlphaPersistence(max_edge_length=0.001,
-                               infinity_values=-1)
-    assert_almost_equal(wap.fit_transform(X)[:, :, :2],
-                        np.zeros((1, 2, 2)))
-
-
-@pytest.mark.parametrize('X', [X_pc, X_pc_list])
-@pytest.mark.parametrize('hom_dims', [None, (0,), (1,), (0, 1)])
-def test_vrp_fit_transform_plot(X, hom_dims):
-    WeakAlphaPersistence().fit_transform_plot(
-        X, sample=0, homology_dimensions=hom_dims)

--- a/gtda/tests/test_common.py
+++ b/gtda/tests/test_common.py
@@ -69,9 +69,7 @@ def _get_estimator_name(estimator):
 
 
 @pytest.mark.filterwarnings("ignore:Input of `fit` contains")
-@parametrize_with_checks(
-    [Binarizer, Inverter]
-    )
+@parametrize_with_checks([Binarizer(), Inverter()])
 def test_sklearn_api(check, estimator, request):
     estimator_name = _get_estimator_name(estimator)
     check_name = _get_callable_name(check)


### PR DESCRIPTION
**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
The `WeakAlphaPersistence` transformer computes Vietoris-Rips persistent homology of the sparse matrix of distances between neighbours in a Delaunay triangulation.  It is not computing the true alpha complex, but can be considerably faster than `VietorisRipsPersistence` in low dimensions.

**Additional comments**
This type of complex/persistence is not yet covered by our theory pages.

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.

<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
