### PR TITLE
Fix handling of COO matrices by ripser, mirroring https://github.com/scikit-tda/ripser.py/pull/104

### DIFF
--- a/gtda/externals/python/ripser_interface.py
+++ b/gtda/externals/python/ripser_interface.py
@@ -207,16 +207,27 @@ def ripser(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
         dm = sparse.coo_matrix(dm)
 
     if sparse.issparse(dm):
-        coo = dm.tocoo()
+        if sparse.isspmatrix_coo(dm):
+            # If the matrix is already COO, we need to order the row and column
+            # indices lexicographically to avoid errors. See
+            # https://github.com/scikit-tda/ripser.py/issues/103
+            row, col, data = dm.row, dm.col, dm.data
+            lex_sort_idx = np.lexsort((col, row))
+            row, col, data = \
+                row[lex_sort_idx], col[lex_sort_idx], data[lex_sort_idx]
+        else:
+            # Lexicographic sorting is performed by scipy upon conversion
+            coo = dm.tocoo()
+            row, col, data = coo.row, coo.col, coo.data
         res = DRFDMSparse(
-            coo.row.astype(dtype=np.int32, order="C"),
-            coo.col.astype(dtype=np.int32, order="C"),
-            np.array(coo.data, dtype=np.float32, order="C"),
+            row.astype(dtype=np.int32, order="C"),
+            col.astype(dtype=np.int32, order="C"),
+            np.array(data, dtype=np.float32, order="C"),
             n_points,
             maxdim,
             thresh,
             coeff,
-        )
+            )
     else:
         I, J = np.meshgrid(np.arange(n_points), np.arange(n_points))
         DParam = np.array(dm[I > J], dtype=np.float32)


### PR DESCRIPTION
**Reference issues/PRs**
Fixes the analogous issue to https://github.com/scikit-tda/ripser.py/issues/103. The fix is a replica of https://github.com/scikit-tda/ripser.py/pull/104.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
See https://github.com/scikit-tda/ripser.py/issues/103 and https://github.com/scikit-tda/ripser.py/pull/104. Note that an alternative would have been to first convert to another sparse format (e.g. CSR) and then to COO again. But this is slower unless the input is very large.

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.