### PR TITLE
Change DISTNAME back form "giotto-tda" to 'giotto-tda' in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open(version_file) as f:
 with open("requirements.txt") as f:
     requirements = f.read().splitlines()
 
-DISTNAME = "giotto-tda"
+DISTNAME = 'giotto-tda'
 DESCRIPTION = "Toolbox for Machine Learning using Topological Data Analysis."
 with codecs.open("README.rst", encoding="utf-8-sig") as f:
     LONG_DESCRIPTION = f.read()


### PR DESCRIPTION
Emergency patch to avoid accidentally uploading distributions meant as nightly to the official distribution on PyPI, as happened due to the bash scripts present in our CI on 28.08.2020.