### PR TITLE
Make PyPI nightly uploads more robust to changes in quote types

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,6 +48,7 @@ jobs:
   - bash: |
       set -e
       sed -i "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
+      sed -i 's/"giotto-tda"/"giotto-tda-nightly"/1' setup.py
       sed -i "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
     condition: eq(variables.nightlyRelease, true)
     displayName: 'Change name to giotto-tda-nightly'
@@ -128,6 +129,7 @@ jobs:
   - bash: |
       set -e
       sed -i.bak "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
+      sed -i 's/"giotto-tda"/"giotto-tda-nightly"/1' setup.py
       rm setup.py.bak
       sed -i.bak "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
       rm gtda/_version.py.bak
@@ -245,6 +247,7 @@ jobs:
   - bash: |
       set -e
       sed -i "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
+      sed -i 's/"giotto-tda"/"giotto-tda-nightly"/1' setup.py
       sed -i "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
     condition: eq(variables.nightlyRelease, true)
     displayName: 'Change name to giotto-tda-nightly'

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open(version_file) as f:
 with open("requirements.txt") as f:
     requirements = f.read().splitlines()
 
-DISTNAME = 'giotto-tda'
+DISTNAME = "giotto-tda"
 DESCRIPTION = "Toolbox for Machine Learning using Topological Data Analysis."
 with codecs.open("README.rst", encoding="utf-8-sig") as f:
     LONG_DESCRIPTION = f.read()


### PR DESCRIPTION
Look for both single and double quotes when modifying DISTNAME in setup.py. Helps avoid incorrect uploads of the distribution as `giotto-tda` instead of `giotto-tda-nightly`.

**Reference issues/PRs**
Supersedes #470.