### PR TITLE
Change sed -i to sed -i.bak in macOS Azure jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -129,7 +129,7 @@ jobs:
   - bash: |
       set -e
       sed -i.bak "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
-      sed -i 's/"giotto-tda"/"giotto-tda-nightly"/1' setup.py
+      sed -i.bak 's/"giotto-tda"/"giotto-tda-nightly"/1' setup.py
       rm setup.py.bak
       sed -i.bak "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
       rm gtda/_version.py.bak


### PR DESCRIPTION
**Reference issues/PRs**
Fixes an error introduced in #471.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
Fixes an invalid bash command in `azure-pipelines.yml`.