### PR TITLE
Change default value of nan_fill_value in PersistenceEntropy to -1

### DIFF
--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -81,7 +81,7 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
         'normalize': {'type': bool},
         'nan_fill_value': {'type': (Real, type(None))}}
 
-    def __init__(self, normalize=False, nan_fill_value=-1, n_jobs=None):
+    def __init__(self, normalize=False, nan_fill_value=-1., n_jobs=None):
         self.normalize = normalize
         self.nan_fill_value = nan_fill_value
         self.n_jobs = n_jobs

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -79,7 +79,8 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
 
     _hyperparameters = {
         'normalize': {'type': bool},
-        'nan_fill_value': {'type': (Real, type(None))}}
+        'nan_fill_value': {'type': (Real, type(None))}
+        }
 
     def __init__(self, normalize=False, nan_fill_value=-1., n_jobs=None):
         self.normalize = normalize

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -47,9 +47,10 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
         Can aid comparison between diagrams in an input collection when these
         have different numbers of (non-trivial) points. [1]_
 
-    nan_fill_value : float or None, optional, default: ``None``
+    nan_fill_value : float or None, optional, default: ``-1.``
         If a float, (normalized) persistence entropies initially computed as
-        ``numpy.nan`` are replaced with this value.
+        ``numpy.nan`` are replaced with this value. If ``None``, these values
+        are left as ``numpy.nan``.
 
     n_jobs : int or None, optional, default: ``None``
         The number of jobs to use for the computation. ``None`` means 1 unless
@@ -80,7 +81,7 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
         'normalize': {'type': bool},
         'nan_fill_value': {'type': (Real, type(None))}}
 
-    def __init__(self, normalize=False, nan_fill_value=None, n_jobs=None):
+    def __init__(self, normalize=False, nan_fill_value=-1, n_jobs=None):
         self.normalize = normalize
         self.nan_fill_value = nan_fill_value
         self.n_jobs = n_jobs
@@ -170,7 +171,7 @@ class PersistenceEntropy(BaseEstimator, TransformerMixin):
                     _subdiagrams(X[s], [dim]),
                     normalize=self.normalize,
                     nan_fill_value=self.nan_fill_value
-                )
+                    )
                 for dim in self.homology_dimensions_
                 for s in gen_even_slices(len(X), effective_n_jobs(self.n_jobs))
                 )

--- a/gtda/diagrams/tests/test_features_representations.py
+++ b/gtda/diagrams/tests/test_features_representations.py
@@ -40,7 +40,7 @@ def test_fit_transform_plot_one_hom_dim(transformer, hom_dim_idx):
     transformer.fit_transform_plot(
         X, sample=0, homology_dimension_idx=hom_dim_idx,
         plotly_params=plotly_params
-    )
+        )
 
 
 @pytest.mark.parametrize('transformer',
@@ -51,7 +51,7 @@ def test_fit_transform_plot_many_hom_dims(transformer, hom_dims):
         {"traces": line_plots_traces_params, "layout": layout_params}
     transformer.fit_transform_plot(
         X, sample=0, homology_dimensions=hom_dims, plotly_params=plotly_params
-    )
+        )
 
 
 @pytest.mark.parametrize('transformer',


### PR DESCRIPTION
**Reference issues/PRs**
#450 

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
Favours a default value of `nan_fill_value` which is guaranteed not to break a pipeline in downstream tasks. ``-1.`` is negative and hence cannot be an entropy. `None` is still available to the user, at their own risk.

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.
<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
