### PR TITLE
Fix read-only error analogous to #427 in Amplitude and PairwiseDistance

### DIFF
--- a/gtda/diagrams/distance.py
+++ b/gtda/diagrams/distance.py
@@ -229,9 +229,9 @@ class PairwiseDistance(BaseEstimator, TransformerMixin):
 
         """
         check_is_fitted(self)
-        X = check_diagrams(X, copy=True)
+        Xt = check_diagrams(X, copy=True)
 
-        Xt = _parallel_pairwise(X, self._X, self.metric,
+        Xt = _parallel_pairwise(Xt, self._X, self.metric,
                                 self.effective_metric_params_,
                                 self.homology_dimensions_,
                                 self.n_jobs)

--- a/gtda/diagrams/features.py
+++ b/gtda/diagrams/features.py
@@ -386,7 +386,7 @@ class Amplitude(BaseEstimator, TransformerMixin):
                                  self.effective_metric_params_,
                                  self.homology_dimensions_,
                                  self.n_jobs)
-        if self.order is None:
-            return Xt
-        Xt = np.linalg.norm(Xt, axis=1, ord=self.order).reshape(-1, 1)
+        if self.order is not None:
+            Xt = np.linalg.norm(Xt, axis=1, ord=self.order).reshape(-1, 1)
+
         return Xt

--- a/gtda/diagrams/tests/test_features_representations.py
+++ b/gtda/diagrams/tests/test_features_representations.py
@@ -4,7 +4,7 @@
 import numpy as np
 import plotly.io as pio
 import pytest
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis.extra.numpy import arrays, array_shapes
 from hypothesis.strategies import floats, integers
 from numpy.testing import assert_almost_equal
@@ -230,6 +230,7 @@ def get_input(pts, dims):
 
 
 @pytest.mark.parametrize('n_jobs', [1, 2])
+@settings(deadline=None)
 @given(pts_gen, dims_gen)
 def test_hk_shape(n_jobs, pts, dims):
     n_bins = 10

--- a/gtda/diagrams/tests/test_features_representations.py
+++ b/gtda/diagrams/tests/test_features_representations.py
@@ -139,7 +139,7 @@ def test_pi_positive(pts):
     assert np.all(pi.fit_transform(diagrams) >= 0.)
 
 
-def test_large_pi_null_multithreaded():
+def test_large_pi_null_parallel():
     """Test that pi is computed correctly when the input array is at least 1MB
     and more than 1 process is used, triggering joblib's use of memmaps"""
     X = np.linspace(0, 100, 300000)
@@ -286,7 +286,7 @@ def test_hk_with_diag_points(pts):
     assert_almost_equal(X_with_diag_points_t, X_t, decimal=13)
 
 
-def test_large_hk_shape_multithreaded():
+def test_large_hk_shape_parallel():
     """Test that HeatKernel returns something of the right shape when the input
     array is at least 1MB and more than 1 process is used, triggering joblib's
     use of memmaps"""

--- a/gtda/diagrams/tests/test_features_representations.py
+++ b/gtda/diagrams/tests/test_features_representations.py
@@ -70,8 +70,9 @@ def test_fit_transform_plot_wrong_hom_dims(transformer):
         transformer.fit_transform_plot(X, sample=0, homology_dimensions=(2,))
 
 
-def test_pe_transform():
-    pe = PersistenceEntropy()
+@pytest.mark.parametrize('n_jobs', [1, 2, -1])
+def test_pe_transform(n_jobs):
+    pe = PersistenceEntropy(n_jobs=n_jobs)
     diagram_res = np.array([[1., 0.91829583405]])
 
     assert_almost_equal(pe.fit_transform(X), diagram_res)
@@ -82,22 +83,25 @@ def test_pe_transform():
 
 
 @pytest.mark.parametrize('n_bins', list(range(10, 51, 10)))
-def test_bc_transform_shape(n_bins):
-    bc = BettiCurve(n_bins=n_bins)
+@pytest.mark.parametrize('n_jobs', [1, 2, -1])
+def test_bc_transform_shape(n_bins, n_jobs):
+    bc = BettiCurve(n_bins=n_bins, n_jobs=n_jobs)
     X_res = bc.fit_transform(X)
     assert X_res.shape == (1, bc._n_dimensions, n_bins)
 
 
 @pytest.mark.parametrize('n_bins', list(range(10, 51, 10)))
 @pytest.mark.parametrize('n_layers', list(range(1, 10)))
-def test_pl_transform_shape(n_bins, n_layers):
-    pl = PersistenceLandscape(n_bins=n_bins, n_layers=n_layers)
+@pytest.mark.parametrize('n_jobs', [1, 2, -1])
+def test_pl_transform_shape(n_bins, n_layers, n_jobs):
+    pl = PersistenceLandscape(n_bins=n_bins, n_layers=n_layers, n_jobs=n_jobs)
     X_res = pl.fit_transform(X)
     assert X_res.shape == (1, pl._n_dimensions, n_layers, n_bins)
 
 
-def test_pi_zero_weight_function():
-    pi = PersistenceImage(weight_function=lambda x: x * 0.)
+@pytest.mark.parametrize('n_jobs', [1, 2, -1])
+def test_pi_zero_weight_function(n_jobs):
+    pi = PersistenceImage(weight_function=lambda x: x * 0., n_jobs=n_jobs)
     X_res = pi.fit_transform(X)
     assert np.array_equal(X_res, np.zeros_like(X_res))
 
@@ -153,8 +157,9 @@ def test_large_pi_null_parallel():
     assert_almost_equal(pi.fit_transform(diagrams)[0], 0)
 
 
-def test_silhouette_transform():
-    sht = Silhouette(n_bins=31, power=1.)
+@pytest.mark.parametrize('n_jobs', [1, 2, -1])
+def test_silhouette_transform(n_jobs):
+    sht = Silhouette(n_bins=31, power=1., n_jobs=n_jobs)
     X_sht_res = np.array([0., 0.05, 0.1, 0.15, 0.2, 0.25, 0.2, 0.15, 0.1,
                           0.05, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0., 0.05,
                           0.1, 0.15, 0.2, 0.25, 0.2, 0.15, 0.1, 0.05, 0.])
@@ -162,9 +167,10 @@ def test_silhouette_transform():
     assert_almost_equal(sht.fit_transform(X)[0][0], X_sht_res)
 
 
-def test_silhouette_big_order():
+@pytest.mark.parametrize('n_jobs', [1, 2, -1])
+def test_silhouette_big_order(n_jobs):
     diagrams = np.array([[[0, 2, 0], [1, 4, 0]]])
-    sht_10 = Silhouette(n_bins=41, power=10.)
+    sht_10 = Silhouette(n_bins=41, power=10., n_jobs=n_jobs)
     X_sht_res = np.array([0., 0.00170459, 0.00340919, 0.00511378, 0.00681837,
                           0.00852296, 0.01022756, 0.01193215, 0.01363674,
                           0.01534133, 0.01704593, 0.11363674, 0.21022756,
@@ -179,10 +185,11 @@ def test_silhouette_big_order():
     assert_almost_equal(sht_10.fit_transform(diagrams)[0][0], X_sht_res)
 
 
-@pytest.mark.parametrize('transformer', [HeatKernel(), PersistenceImage()])
-def test_all_pts_the_same(transformer):
+@pytest.mark.parametrize('transformer_cls', [HeatKernel, PersistenceImage])
+@pytest.mark.parametrize('n_jobs', [1, 2, -1])
+def test_all_pts_the_same(transformer_cls, n_jobs):
     X = np.zeros((1, 4, 3))
-    X_res = transformer.fit_transform(X)
+    X_res = transformer_cls(n_jobs=n_jobs).fit_transform(X)
     assert np.array_equal(X_res, np.zeros_like(X_res))
 
 
@@ -222,13 +229,14 @@ def get_input(pts, dims):
     return X
 
 
+@pytest.mark.parametrize('n_jobs', [1, 2])
 @given(pts_gen, dims_gen)
-def test_hk_shape(pts, dims):
+def test_hk_shape(n_jobs, pts, dims):
     n_bins = 10
     X = get_input(pts, dims)
     sigma = (np.max(X[:, :, :2]) - np.min(X[:, :, :2])) / 2
 
-    hk = HeatKernel(sigma=sigma, n_bins=n_bins)
+    hk = HeatKernel(sigma=sigma, n_bins=n_bins, n_jobs=n_jobs)
     num_dimensions = len(np.unique(dims))
     X_t = hk.fit_transform(X)
 


### PR DESCRIPTION
**Reference issues/PRs**
#428 and #427

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
Extends #428, fixing the analogous issue to #427 in `Amplitude` and `PairwiseDistance`, and adds a regression test. Also improves the handling of edge cases (zero range of births or persistences) in the `persistence_images` function in `gtda/diagrams/_metrics.py`.

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.