### PR TITLE
Enable edge collapse in VietorisRipsPersistence

### DIFF
--- a/examples/persistent_homology_graphs.ipynb
+++ b/examples/persistent_homology_graphs.ipynb
@@ -549,7 +549,8 @@
    "source": [
     "# Construct the adjacency matrix\n",
     "weights = np.ones(n_vertices)\n",
-    "directed_circle_flipped = csr_matrix((weights, (row_flipped, column_flipped)))\n",
+    "directed_circle_flipped = csr_matrix((weights, (row_flipped, column_flipped)),\n",
+    "                                     shape=(n_vertices, n_vertices))\n",
     "\n",
     "# Run FlagserPersistence directly on the adjacency matrix\n",
     "FlagserPersistence().fit_transform_plot([directed_circle_flipped]);"
@@ -604,7 +605,8 @@
    "source": [
     "# Construct the adjacency matrix\n",
     "weights = np.ones(n_vertices)\n",
-    "two_semicircles = csr_matrix((weights, (row_two_semicircles, column_two_semicircles)))\n",
+    "two_semicircles = csr_matrix((weights, (row_two_semicircles, column_two_semicircles)),\n",
+    "                             shape=(n_vertices, n_vertices))\n",
     "\n",
     "# Run FlagserPersistence directly on the adjacency matrix\n",
     "FlagserPersistence().fit_transform_plot([two_semicircles]);"

--- a/examples/persistent_homology_graphs.ipynb
+++ b/examples/persistent_homology_graphs.ipynb
@@ -549,8 +549,7 @@
    "source": [
     "# Construct the adjacency matrix\n",
     "weights = np.ones(n_vertices)\n",
-    "directed_circle_flipped = csr_matrix((weights, (row_flipped, column_flipped)),\n",
-    "                                     shape=(n_vertices, n_vertices))\n",
+    "directed_circle_flipped = csr_matrix((weights, (row_flipped, column_flipped)))\n",
     "\n",
     "# Run FlagserPersistence directly on the adjacency matrix\n",
     "FlagserPersistence().fit_transform_plot([directed_circle_flipped]);"
@@ -605,8 +604,7 @@
    "source": [
     "# Construct the adjacency matrix\n",
     "weights = np.ones(n_vertices)\n",
-    "two_semicircles = csr_matrix((weights, (row_two_semicircles, column_two_semicircles)),\n",
-    "                             shape=(n_vertices, n_vertices))\n",
+    "two_semicircles = csr_matrix((weights, (row_two_semicircles, column_two_semicircles)))\n",
     "\n",
     "# Run FlagserPersistence directly on the adjacency matrix\n",
     "FlagserPersistence().fit_transform_plot([two_semicircles]);"

--- a/gtda/externals/python/ripser_interface.py
+++ b/gtda/externals/python/ripser_interface.py
@@ -185,6 +185,16 @@ def ripser(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
             If n_perm <= 0, then the full point cloud was used and this is 0
     }
 
+    Notes
+    -----
+    `Ripser <https://github.com/Ripser/ripser>`_ is used as a C++ backend
+    for computing Vietoris–Rips persistent homology. Python bindings were
+    modified for performance from the `ripser.py
+    <https://github.com/scikit-tda/ripser.py>`_ package.
+
+    `GUDHI <https://github.com/GUDHI/gudhi-devel>`_ is used as a C++ backend
+    for the edge collapse algorithm described in [2]_.
+
     References
     ----------
     [1] U. Bauer, "Ripser: efficient computation of Vietoris–Rips persistence \
@@ -197,16 +207,6 @@ def ripser(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
         Dagstuhl-Leibniz–Zentrum für Informatik, 2020;
         `DOI: 10.4230/LIPIcs.SoCG.2020.19 \
         <https://doi.org/10.4230/LIPIcs.SoCG.2020.19>`_.
-
-    Notes
-    -----
-    `Ripser <https://github.com/Ripser/ripser>`_ is used as a C++ backend
-    for computing Vietoris–Rips persistent homology. Python bindings were
-    modified for performance from the `ripser.py
-    <https://github.com/scikit-tda/ripser.py>`_ package.
-
-    `GUDHI <https://github.com/GUDHI/gudhi-devel>`_ is used as a C++ backend
-    for the edge collapse algorithm described in [2]_.
 
     """
     if n_perm and sparse.issparse(X):

--- a/gtda/externals/python/tests/test_ripser.py
+++ b/gtda/externals/python/tests/test_ripser.py
@@ -46,14 +46,18 @@ def get_sparse_distance_matrices(draw):
 
 
 @pytest.mark.parametrize('thresh', [False, True])
+@pytest.mark.parametrize('coeff', [2, 7])
 @given(distance_matrix=get_dense_distance_matrices())
-def test_collapse_consistent_with_no_collapse_dense(thresh, distance_matrix):
+def test_collapse_consistent_with_no_collapse_dense(thresh,
+                                                    coeff, distance_matrix):
     thresh = np.max(distance_matrix) / 2 if thresh else np.inf
     maxdim = 3
     pd_collapse = ripser(distance_matrix, thresh=thresh, maxdim=maxdim,
-                         metric='precomputed', collapse_edges=True)['dgms']
+                         coeff=coeff, metric='precomputed',
+                         collapse_edges=True)['dgms']
     pd_no_collapse = ripser(distance_matrix, thresh=thresh, maxdim=maxdim,
-                            metric='precomputed', collapse_edges=False)['dgms']
+                            coeff=coeff, metric='precomputed',
+                            collapse_edges=False)['dgms']
     for i in range(maxdim + 1):
         pd_collapse[i] = np.sort(pd_collapse[i], axis=0)
         pd_no_collapse[i] = np.sort(pd_no_collapse[i], axis=0)
@@ -61,17 +65,21 @@ def test_collapse_consistent_with_no_collapse_dense(thresh, distance_matrix):
 
 
 @pytest.mark.parametrize('thresh', [False, True])
+@pytest.mark.parametrize('coeff', [2, 7])
 @given(distance_matrix=get_sparse_distance_matrices())
-def test_collapse_consistent_with_no_collapse_coo(thresh, distance_matrix):
+def test_collapse_consistent_with_no_collapse_coo(thresh,
+                                                  coeff, distance_matrix):
     if thresh and distance_matrix.nnz:
         thresh = np.max(distance_matrix) / 2
     else:
         thresh = np.inf
     maxdim = 3
     pd_collapse = ripser(distance_matrix, thresh=thresh, maxdim=maxdim,
-                         metric='precomputed', collapse_edges=True)['dgms']
+                         coeff=coeff, metric='precomputed',
+                         collapse_edges=True)['dgms']
     pd_no_collapse = ripser(distance_matrix, thresh=thresh, maxdim=maxdim,
-                            metric='precomputed', collapse_edges=False)['dgms']
+                            coeff=coeff, metric='precomputed',
+                            collapse_edges=False)['dgms']
     for i in range(maxdim + 1):
         pd_collapse[i] = np.sort(pd_collapse[i], axis=0)
         pd_no_collapse[i] = np.sort(pd_no_collapse[i], axis=0)

--- a/gtda/homology/tests/test_simplicial.py
+++ b/gtda/homology/tests/test_simplicial.py
@@ -75,11 +75,14 @@ X_vrp_exp = np.array([
                                        (X_dist, 'precomputed'),
                                        (X_dist_list, 'precomputed'),
                                        (X_dist_sparse, 'precomputed')])
+@pytest.mark.parametrize('collapse_edges', [True, False])
 @pytest.mark.parametrize('max_edge_length', [np.inf, 0.8])
 @pytest.mark.parametrize('infinity_values', [10, 30])
-def test_vrp_transform(X, metric, max_edge_length, infinity_values):
-    vrp = VietorisRipsPersistence(max_edge_length=max_edge_length,
-                                  metric=metric,
+def test_vrp_transform(X, metric, collapse_edges, max_edge_length,
+                       infinity_values):
+    vrp = VietorisRipsPersistence(metric=metric,
+                                  collapse_edges=collapse_edges,
+                                  max_edge_length=max_edge_length,
                                   infinity_values=infinity_values)
     # This is not generally true, it is only a way to obtain the res array
     # in this specific case


### PR DESCRIPTION
**Reference issues/PRs**
Follows #469.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
- Adds a `collapse_edges` kwarg to `VietorisRipsPersistence` to enable edge collapse in `ripser`. Default is `False`.
- Adds coverage for coefficients different from 2 in tests of `ripser` with the collapser enabled.

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.
