### PR TITLE
Extend Padder and Inverter to greyscale images

### DIFF
--- a/gtda/diagrams/tests/test_preprocessing.py
+++ b/gtda/diagrams/tests/test_preprocessing.py
@@ -305,7 +305,7 @@ def test_filt_transform_unfiltered_hom_dims(homology_dimensions):
             if dim not in homology_dimensions
             ]
     assert total_lifetimes_in_dims(X_1, unfiltered_hom_dims) == \
-           total_lifetimes_in_dims(X_1_res, unfiltered_hom_dims)
+        total_lifetimes_in_dims(X_1_res, unfiltered_hom_dims)
 
 
 lifetimes_1 = X_1[:, :, 1] - X_1[:, :, 0]

--- a/gtda/images/preprocessing.py
+++ b/gtda/images/preprocessing.py
@@ -187,6 +187,11 @@ class Binarizer(BaseEstimator, TransformerMixin, PlotterMixin):
 class Inverter(BaseEstimator, TransformerMixin, PlotterMixin):
     """Invert all 2D/3D images in a collection.
 
+    Applies an inversion function to the value of all pixels of all images in
+    the input collection. The inversion function is defined as
+    :math:`f(x) = M - x`, where `x` is a pixel value and `M` is the maximum value
+    of all pixels in all the images of the collection.
+
     Parameters
     ----------
     max_value : bool, int, float or None, optional, default: ``None``
@@ -215,7 +220,7 @@ class Inverter(BaseEstimator, TransformerMixin, PlotterMixin):
     """
 
     _hyperparameters = {
-        'max_value': {'type': (Real, type(None))}
+        'max_value': {'type': (bool, Real, type(None))}
     }
 
     def __init__(self, max_value=None, n_jobs=None):

--- a/gtda/images/preprocessing.py
+++ b/gtda/images/preprocessing.py
@@ -189,10 +189,9 @@ class Inverter(BaseEstimator, TransformerMixin, PlotterMixin):
 
     Applies an inversion function to the value of all pixels of all images in
     the input collection. If the images are binary, the inversion function is
-    defined as the logical NOT function. Otherwise, it is a function
+    defined as the logical NOT function. Otherwise, it is the function
     :math:`f(x) = M - x`, where `x` is a pixel value and `M` is
-    :attr:`max_value`, the maximum possible pixel value in the images of the
-    collection.
+    :attr:`max_value_`.
 
     Parameters
     ----------

--- a/gtda/images/preprocessing.py
+++ b/gtda/images/preprocessing.py
@@ -189,8 +189,8 @@ class Inverter(BaseEstimator, TransformerMixin, PlotterMixin):
 
     Applies an inversion function to the value of all pixels of all images in
     the input collection. The inversion function is defined as
-    :math:`f(x) = M - x`, where `x` is a pixel value and `M` is the maximum value
-    of all pixels in all the images of the collection.
+    :math:`f(x) = M - x`, where `x` is a pixel value and `M` is :attr:`max_value,
+    the maximum possible pixel value in the images of the collection.
 
     Parameters
     ----------

--- a/gtda/images/preprocessing.py
+++ b/gtda/images/preprocessing.py
@@ -188,9 +188,11 @@ class Inverter(BaseEstimator, TransformerMixin, PlotterMixin):
     """Invert all 2D/3D images in a collection.
 
     Applies an inversion function to the value of all pixels of all images in
-    the input collection. The inversion function is defined as
-    :math:`f(x) = M - x`, where `x` is a pixel value and `M` is :attr:`max_value,
-    the maximum possible pixel value in the images of the collection.
+    the input collection. If the images are binary, the inversion function is
+    defined as the logical NOT function. Otherwise, it is a function
+    :math:`f(x) = M - x`, where `x` is a pixel value and `M` is
+    :attr:`max_value`, the maximum possible pixel value in the images of the
+    collection.
 
     Parameters
     ----------

--- a/gtda/images/tests/test_preprocessing.py
+++ b/gtda/images/tests/test_preprocessing.py
@@ -21,6 +21,11 @@ images_3D = np.stack([
     np.concatenate([np.ones((7, 4, 4)), np.zeros((7, 4, 4))], axis=1),
     np.zeros((7, 8, 4))], axis=0)
 
+images_3D_float = np.stack([
+    2.5*np.ones((7, 8, 4)),
+    3.*np.concatenate([np.ones((7, 4, 4)), np.zeros((7, 4, 4))], axis=1),
+    np.zeros((7, 8, 4))], axis=0)
+
 
 def test_binarizer_not_fitted():
     binarizer = Binarizer()
@@ -68,7 +73,8 @@ images_3D_inverted = np.stack(
 
 @pytest.mark.parametrize("images, expected",
                          [(images_2D, images_2D_inverted),
-                          (images_3D, images_3D_inverted)])
+                          (images_3D, images_3D_inverted),
+                          (images_3D.astype(bool), images_3D_inverted.astype(bool))])
 def test_inverter_transform(images, expected):
     inverter = Inverter()
 
@@ -89,7 +95,8 @@ def test_padder_not_fitted():
 @pytest.mark.parametrize("images, padding",
                          [(images_2D, np.array([1, 1], dtype=np.int)),
                           (images_2D, None),
-                          (images_3D, np.array([2, 2, 2], dtype=np.int))])
+                          (images_3D, np.array([2, 2, 2], dtype=np.int)),
+                          (images_3D_float, np.array([2, 2, 2], dtype=np.int))])
 def test_padder_transform(images, padding):
     padder = Padder(padding=padding)
 

--- a/gtda/images/tests/test_preprocessing.py
+++ b/gtda/images/tests/test_preprocessing.py
@@ -74,7 +74,8 @@ images_3D_inverted = np.stack(
 @pytest.mark.parametrize("images, expected",
                          [(images_2D, images_2D_inverted),
                           (images_3D, images_3D_inverted),
-                          (images_3D.astype(bool), images_3D_inverted.astype(bool))])
+                          (images_3D.astype(bool),
+                           images_3D_inverted.astype(bool))])
 def test_inverter_transform(images, expected):
     inverter = Inverter()
 
@@ -96,7 +97,8 @@ def test_padder_not_fitted():
                          [(images_2D, np.array([1, 1], dtype=np.int)),
                           (images_2D, None),
                           (images_3D, np.array([2, 2, 2], dtype=np.int)),
-                          (images_3D_float, np.array([2, 2, 2], dtype=np.int))])
+                          (images_3D_float,
+                           np.array([2, 2, 2], dtype=np.int))])
 def test_padder_transform(images, padding):
     padder = Padder(padding=padding)
 

--- a/gtda/images/tests/test_preprocessing.py
+++ b/gtda/images/tests/test_preprocessing.py
@@ -86,17 +86,17 @@ def test_padder_not_fitted():
         padder.transform(images_2D)
 
 
-@pytest.mark.parametrize("images, paddings",
+@pytest.mark.parametrize("images, padding",
                          [(images_2D, np.array([1, 1], dtype=np.int)),
                           (images_2D, None),
                           (images_3D, np.array([2, 2, 2], dtype=np.int))])
-def test_padder_transform(images, paddings):
-    padder = Padder(paddings=paddings)
+def test_padder_transform(images, padding):
+    padder = Padder(padding=padding)
 
-    if paddings is None:
+    if padding is None:
         expected_shape = np.asarray(images.shape[1:]) + 2
     else:
-        expected_shape = images.shape[1:] + 2 * paddings
+        expected_shape = images.shape[1:] + 2 * padding
 
     assert_equal(padder.fit_transform(images).shape[1:],
                  expected_shape)


### PR DESCRIPTION
**Types of changes**
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
Extends images.Padder and images.Inverter to greyscale images.

**Screenshots (if appropriate)**

**Any other comments?**

**Checklist**
<!--
Go over all the following points, and put an `x` in all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.

<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
