### PR TITLE
Fix some warnings seen in tests

### DIFF
--- a/gtda/mapper/visualization.py
+++ b/gtda/mapper/visualization.py
@@ -404,7 +404,6 @@ def plot_interactive_mapper_graph(
                 yield (key, widgets.ToggleButton(
                     value=value,
                     description=description,
-                    continuous_update=False,
                     disabled=False,
                     layout=Layout(width="90%"),
                     style=style

--- a/gtda/time_series/tests/test_embedding.py
+++ b/gtda/time_series/tests/test_embedding.py
@@ -119,7 +119,7 @@ def test_window_slice_windows():
     X_windows = windows.fit_transform(X)
     slice_idx = windows.slice_windows(X)
     assert_almost_equal(
-        np.stack(X[begin:end] for begin, end in slice_idx), X_windows
+        np.stack([X[begin:end] for begin, end in slice_idx]), X_windows
         )
 
 

--- a/gtda/utils/tests/test_validation.py
+++ b/gtda/utils/tests/test_validation.py
@@ -263,7 +263,7 @@ def test_check_collection_ragged_array():
 
 
 def test_check_collection_array_of_list():
-    X = np.array([list(range(2)), list(range(3))])
+    X = np.array([list(range(2)), list(range(3))], dtype=object)
     with pytest.raises(ValueError):
         check_collection(X)
 


### PR DESCRIPTION
- `continuous_updates` is deprecated from `ToggleButton`
- `np.stack` should not take generators
- should explicitly pass `dtype=object` for ragged arrays