### PR TITLE
Improve ripser bindings performance

### DIFF
--- a/gtda/externals/bindings/ripser_bindings.cpp
+++ b/gtda/externals/bindings/ripser_bindings.cpp
@@ -7,8 +7,10 @@
 #include <ripser.cpp>
 
 // PYBIND11
+#include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
 
 namespace py = pybind11;
 
@@ -32,21 +34,22 @@ PYBIND11_MODULE(gtda_ripser, m) {
       .def_readwrite("num_edges", &ripserResults::num_edges);
 
   m.def("rips_dm",
-        [](std::vector<float> D, int N, int modulus, int dim_max,
+        [](py::array_t<float>& D, int N, int modulus, int dim_max,
            float threshold, int do_cocycles) {
-          ripserResults ret =
-              rips_dm(&D[0], N, modulus, dim_max, threshold, do_cocycles);
+          ripserResults ret = rips_dm((float*)D.request().ptr, N, modulus,
+                                      dim_max, threshold, do_cocycles);
           return ret;
         },
         "D"_a, "N"_a, "modulus"_a, "dim_max"_a, "threshold"_a, "do_cocycles"_a,
         "ripser distance matrix");
   m.def("rips_dm_sparse",
-        [](std::vector<int> I, std::vector<int> J, std::vector<float> V,
+        [](py::array_t<int>& I, py::array_t<int>& J, py::array_t<float>& V,
            int NEdges, int N, int modulus, int dim_max, float threshold,
            int do_cocycles) {
           ripserResults ret =
-              rips_dm_sparse(&I[0], &J[0], &V[0], NEdges, N, modulus, dim_max,
-                             threshold, do_cocycles);
+              rips_dm_sparse((int*)I.request().ptr, (int*)J.request().ptr,
+                             (float*)V.request().ptr, NEdges, N, modulus,
+                             dim_max, threshold, do_cocycles);
           return ret;
         },
         "I"_a, "J"_a, "V"_a, "NEdges"_a, "N"_a, "modulus"_a, "dim_max"_a,

--- a/gtda/externals/python/ripser_interface.py
+++ b/gtda/externals/python/ripser_interface.py
@@ -295,8 +295,8 @@ def ripser(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
             )
     else:
         # Only consider strict upper diagonal
-        idx = np.triu_indices(n_points, 1)
-        DParam = dm[idx].astype(np.float32)
+        DParam = dm[np.invert(np.tri(n_points, k=0, dtype=np.bool))].astype(
+            np.float32).flatten()
         res = DRFDM(DParam, maxdim, thresh, coeff)
 
     # Unwrap persistence diagrams

--- a/gtda/externals/python/ripser_interface.py
+++ b/gtda/externals/python/ripser_interface.py
@@ -21,10 +21,7 @@ def DRFDM(DParam, maxHomDim, thresh=-1, coeff=2, do_cocycles=0):
     else:
         ret = gtda_ripser_coeff.rips_dm(DParam, DParam.shape[0], coeff,
                                         maxHomDim, thresh, do_cocycles)
-    ret_rips = {}
-    ret_rips.update({"births_and_deaths_by_dim": ret.births_and_deaths_by_dim})
-    ret_rips.update({"num_edges": ret.num_edges})
-    return ret_rips
+    return ret
 
 
 def DRFDMSparse(I, J, V, N, maxHomDim, thresh=-1, coeff=2, do_cocycles=0):
@@ -34,10 +31,7 @@ def DRFDMSparse(I, J, V, N, maxHomDim, thresh=-1, coeff=2, do_cocycles=0):
     else:
         ret = gtda_ripser_coeff.rips_dm_sparse(I, J, V, I.size, N, coeff,
                                                maxHomDim, thresh, do_cocycles)
-    ret_rips = {}
-    ret_rips.update({"births_and_deaths_by_dim": ret.births_and_deaths_by_dim})
-    ret_rips.update({"num_edges": ret.num_edges})
-    return ret_rips
+    return ret
 
 
 def dpoint2pointcloud(X, i, metric):
@@ -300,14 +294,14 @@ def ripser(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
         res = DRFDM(DParam, maxdim, thresh, coeff)
 
     # Unwrap persistence diagrams
-    dgms = res["births_and_deaths_by_dim"]
+    dgms = res.births_and_deaths_by_dim
     for dim in range(len(dgms)):
         N = int(len(dgms[dim]) / 2)
         dgms[dim] = np.reshape(np.array(dgms[dim]), [N, 2])
 
     ret = {
         "dgms": dgms,
-        "num_edges": res["num_edges"],
+        "num_edges": res.num_edges,
         "dperm2all": dperm2all,
         "idx_perm": idx_perm,
         "r_cover": r_cover,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the guidelines for contributing: https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines
-->

**Reference issues/PRs**
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.

Pull requests which are not related to open issues may be rejected!
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

None

**Types of changes**
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
<!--
Describe your changes in detail.
-->

Benchmarking showed that with big datasets (e.g. [Torus 50000](https://github.com/Ripser/ripser-benchmark/blob/master/clifford_torus_50000.points.txt) point-cloud), the copy performed when calling the bindings becomes costly in terms of performance (runtime and memory).

To prevent this, the bindings where updated to accept by reference `numpy` matrices/arrays.

Some clean-up and improvements were done inside `ripser_interface`.

**Screenshots (if appropriate)**

**Any other comments?**

**Checklist**
<!--
Go over all the following points, and put an `x` in all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.

<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
