### PR TITLE
Fix and improve validate_params

### DIFF
--- a/gtda/images/filtrations.py
+++ b/gtda/images/filtrations.py
@@ -1,7 +1,7 @@
 """Filtrations of 2D/3D binary images."""
 # License: GNU AGPLv3
 
-from numbers import Real
+from numbers import Real, Integral
 from types import FunctionType
 from warnings import warn
 
@@ -304,7 +304,7 @@ class RadialFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
     """
 
     _hyperparameters = {
-        'center': {'type': (np.ndarray, type(None)), 'of': {'type': int}},
+        'center': {'type': (np.ndarray, type(None)), 'of': {'type': Integral}},
         'radius': {'type': Real, 'in': Interval(0, np.inf, closed='right')},
         'metric': {'type': (str, FunctionType)},
         'metric_params': {'type': (dict, type(None))}
@@ -382,8 +382,8 @@ class RadialFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
         self.mesh_[self.mesh_ > self.radius] = np.inf
 
         self.max_value_ = 0.
-        self.max_value_ = np.max(self._calculate_radial(
-            np.ones((1, *X.shape[1:])))) + 1
+        self.max_value_ = \
+            np.max(self._calculate_radial(np.ones((1, *X.shape[1:])))) + 1
 
         return self
 

--- a/gtda/images/preprocessing.py
+++ b/gtda/images/preprocessing.py
@@ -3,7 +3,7 @@
 
 from functools import reduce
 from operator import iconcat
-from numbers import Real
+from numbers import Real, Integral
 from warnings import warn
 
 import numpy as np
@@ -382,7 +382,7 @@ class Padder(BaseEstimator, TransformerMixin, PlotterMixin):
 
     _hyperparameters = {
         'padding': {'type': (np.ndarray, type(None)),
-                    'of': {'type': int}},
+                    'of': {'type': Integral}},
         'value': {'type': (bool, Real)}
         }
 

--- a/gtda/images/preprocessing.py
+++ b/gtda/images/preprocessing.py
@@ -222,7 +222,7 @@ class Inverter(BaseEstimator, TransformerMixin, PlotterMixin):
 
     _hyperparameters = {
         'max_value': {'type': (bool, Real, type(None))}
-    }
+        }
 
     def __init__(self, max_value=None, n_jobs=None):
         self.max_value = max_value
@@ -381,11 +381,10 @@ class Padder(BaseEstimator, TransformerMixin, PlotterMixin):
     """
 
     _hyperparameters = {
-        'padding': {
-            'type': (np.ndarray, type(None)),
-            'of': {'type': int}},
+        'padding': {'type': (np.ndarray, type(None)),
+                    'of': {'type': int}},
         'value': {'type': (bool, Real)}
-    }
+        }
 
     def __init__(self, padding=None, value=False, n_jobs=None):
         self.padding = padding

--- a/gtda/point_clouds/rescaling.py
+++ b/gtda/point_clouds/rescaling.py
@@ -296,7 +296,7 @@ class ConsecutiveRescaling(BaseEstimator, TransformerMixin, PlotterMixin):
         'metric': {'type': (str, FunctionType)},
         'metric_params': {'type': (dict, type(None))},
         'factor': {'type': Real, 'in': Interval(0, np.inf, closed='both')}
-    }
+        }
 
     def __init__(self, metric='euclidean', metric_params=None, factor=0.,
                  n_jobs=None):

--- a/gtda/utils/tests/test_validation.py
+++ b/gtda/utils/tests/test_validation.py
@@ -1,12 +1,15 @@
 """Tests for validation functions."""
 # License: GNU AGPLv3
 
+from numbers import Integral
+
 import numpy as np
 import pytest
 from sklearn.exceptions import DataDimensionalityWarning
 
 from gtda.utils import check_collection, check_point_clouds, check_diagrams, \
     validate_params
+from gtda.utils.intervals import Interval
 
 
 # Testing for validate_params
@@ -36,10 +39,44 @@ def test_validate_params_list():
     references[parameter_name]['of']."""
     references = {
         'par1': {'type': list, 'of': {'type': float, 'in': [1., 2.]}}
-    }
+        }
     parameters = {'par1': [1.]}
 
     validate_params(parameters, references)
+
+
+def test_validate_params_tuple_of_types():
+    references = {
+        'n_coefficients': {'type': (type(None), list, int),
+                           'in': Interval(1, np.inf, closed='left'),
+                           'of': {'type': Integral,
+                                  'in': Interval(1, np.inf, closed='left')}}
+        }
+    parameters = {'n_coefficients': None}
+
+    validate_params(parameters, references)
+
+    parameters['n_coefficients'] = 1
+    validate_params(parameters, references)
+
+    parameters['n_coefficients'] = 1.
+    with pytest.raises(TypeError):
+        validate_params(parameters, references)
+
+    parameters['n_coefficients'] = 0
+    with pytest.raises(ValueError):
+        validate_params(parameters, references)
+
+    parameters['n_coefficients'] = [1, 2]
+    validate_params(parameters, references)
+
+    parameters['n_coefficients'] = [1., 2.]
+    with pytest.raises(TypeError):
+        validate_params(parameters, references)
+
+    parameters['n_coefficients'] = [0, 2]
+    with pytest.raises(ValueError):
+        validate_params(parameters, references)
 
 
 # Testing check_diagrams
@@ -61,9 +98,8 @@ def test_inputs_arrayStruc_V():
 # Testing check_point_clouds
 # Create several kinds of inputs
 class CreateInputs:
-    def __init__(
-            self, n_samples, n_1, n_2, n_samples_extra, n_1_extra, n_2_extra
-    ):
+    def __init__(self, n_samples, n_1, n_2, n_samples_extra, n_1_extra,
+                 n_2_extra):
         N = n_samples * n_1 * n_2
         n_1_rectang = n_1 + 1
         n_2_rectang = n_2 - 1

--- a/gtda/utils/validation.py
+++ b/gtda/utils/validation.py
@@ -88,45 +88,50 @@ def check_graph(X):
     return X
 
 
-def _validate_params_single(parameter, reference, name):
-    if reference is None:
-        return
-
-    ref_type = reference.get('type', None)
-
-    # Check that parameter has the correct type
-    if (ref_type is not None) and (not isinstance(parameter, ref_type)):
-        raise TypeError(
-            f"Parameter `{name}` is of type {type(parameter)} while "
-            f"it should be of type {ref_type}.")
-
-    # If the reference type parameter is not list, tuple, np.ndarray or dict,
-    # the checks are performed on the parameter object directly.
-    elif ref_type not in [list, tuple, np.ndarray, dict]:
-        ref_in = reference.get('in', None)
-        ref_other = reference.get('other', None)
-        if parameter is not None:
-            if (ref_in is not None) and (parameter not in ref_in):
-                raise ValueError(
-                    f"Parameter `{name}` is {parameter}, which is not in "
-                    f"{ref_in}.")
-        # Perform any other checks via the callable ref_others
-        if ref_other is not None:
-            return ref_other(parameter)
-
-    # Explicitly return the type of reference if one of list, tuple, np.ndarray
-    # or dict.
-    else:
-        return ref_type
-
-
 def _validate_params(parameters, references, rec_name=None):
+    types_tuple = (list, tuple, np.ndarray, dict)
+
+    def _validate_params_single(_parameter, _reference, _name):
+        if _reference is None:
+            return
+
+        _ref_type = _reference.get('type', None)
+
+        # Check that _parameter has the correct type
+        if not ((_ref_type is None) or isinstance(_parameter, _ref_type)):
+            raise TypeError(
+                f"Parameter `{_name}` is of type {type(_parameter)} while it "
+                f"should be of type {_ref_type}."
+                )
+
+        # If neither the reference type is list, tuple, np.ndarray or dict,
+        # nor _parameter is an instance of one of these types, the checks are
+        # performed on _parameter directly.
+        elif not ((_ref_type in types_tuple)
+                  or isinstance(_parameter, types_tuple)):
+            ref_in = _reference.get('in', None)
+            ref_other = _reference.get('other', None)
+            if _parameter is not None:
+                if not ((ref_in is None) or _parameter in ref_in):
+                    raise ValueError(
+                        f"Parameter `{_name}` is {_parameter}, which is not in"
+                        f"{ref_in}.")
+            # Perform any other checks via the callable ref_others
+            if ref_other is not None:
+                return ref_other(_parameter)
+
+        # Explicitly return the type of _reference if one of list, tuple,
+        # np.ndarray or dict.
+        else:
+            return _ref_type
+
     for name, parameter in parameters.items():
         if name not in references.keys():
             name_extras = "" if rec_name is None else f" in `{rec_name}`"
             raise KeyError(
                 f"`{name}`{name_extras} is not an available parameter. "
-                f"Available parameters are in {list(references.keys())}.")
+                f"Available parameters are in {list(references.keys())}."
+                )
 
         reference = references[name]
         ref_type = _validate_params_single(parameter, reference, name)
@@ -136,8 +141,8 @@ def _validate_params(parameters, references, rec_name=None):
                 _validate_params(parameter, ref_of, rec_name=name)
             else:  # List, tuple or ndarray type
                 for i, parameter_elem in enumerate(parameter):
-                    _validate_params_single(
-                        parameter_elem, ref_of, f"{name}[{i}]")
+                    _validate_params_single(parameter_elem, ref_of,
+                                            f"{name}[{i}]")
 
 
 def validate_params(parameters, references, exclude=None):

--- a/gtda/utils/validation.py
+++ b/gtda/utils/validation.py
@@ -166,9 +166,9 @@ def validate_params(parameters, references, exclude=None):
         - ``'type'``, mapping to a class or tuple of classes. ``parameter``
           is checked to be an instance of this class or tuple of classes.
 
-        - ``'in'``, mapping to a dictionary, when the value of ``'type'`` is
+        - ``'in'``, mapping to an object, when the value of ``'type'`` is
           not one of ``list``, ``tuple``, ``numpy.ndarray`` or ``dict``.
-          Letting ``ref_in`` denote that dictionary, the following check is
+          Letting ``ref_in`` denote that object, the following check is
           performed: ``parameter in ref_in``.
 
         - ``'of'``, mapping to a dictionary, when the value of ``'type'``


### PR DESCRIPTION
**Reference issues/PRs**
Motivated by discussion in #479. 

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
I found that `validate_params` did not work as intended when allowed types are in a tuple. The `'of'` key was ignored in that case. So e.g. in
```
hyperparameters = {"parameter": {"type": (type(None), np.ndarray), "of": {"type": np.float}}}
```
the type of each entry in the case of ndarray was not actually being checked to be an instance of `np.float`. Furthermore, a simple fix allows to address the case relevant to #479 of tuples of types including list-like and numeric types. Previously, it would not be possible to have both an `'in'` and an `'of'` key. Now it is, and `'in'` is only used for non-list-like types, and `'of'` otherwise.

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.

<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
