### PR TITLE
Temp fix for macOS CI failures by preventing automatic brew cleanup

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,12 +47,6 @@ jobs:
 
   - script: |
       set -e
-      brew update
-      brew install boost ccache
-    displayName: 'Install system dependencies'
-
-  - script: |
-      set -e
       which python
       python -m pip install --upgrade pip setuptools
       python -m pip install wheel

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,7 @@ jobs:
 
   - script: |
       set -e
+      which python
       python -m pip install --upgrade pip setuptools
       python -m pip install wheel
       source .azure-ci/setup_ccache.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,7 +144,6 @@ jobs:
 
   - script: |
       set -e
-      brew update
       echo 'export PATH="/usr/local/opt/python@$(python.version)/bin:$PATH"' >> /Users/runner/.bash_profile
       brew install boost ccache
     displayName: 'Install system dependencies'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,7 +145,8 @@ jobs:
   - script: |
       set -e
       brew update
-      brew install openssl boost ccache
+      brew reinstall openssl@1.1
+      brew install boost ccache
     displayName: 'Install system dependencies'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,8 +19,8 @@ jobs:
     matrix:
       Python36:
         python.version: '3.6'
-      Python37:
-        python.version: '3.7'
+      Python38:
+        python.version: '3.8'
   variables:
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,8 +144,8 @@ jobs:
 
   - script: |
       set -e
-      brew update && brew upgrade
-      brew install boost ccache
+      brew update
+      brew install openssl boost ccache
     displayName: 'Install system dependencies'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,7 +146,7 @@ jobs:
       set -e
       brew update
       brew install boost ccache
-      brew install openssl@1.1.1g
+      brew install openssl@1.1
     displayName: 'Install system dependencies'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '"ccache-wheels-v2020.09.10" | $(Agent.OS) | "$(python.version)"'
+      key: '"ccache-wheels-v2020.10.05" | $(Agent.OS) | "$(python.version)"'
       path: $(CCACHE_DIR)
     displayName: ccache
 
@@ -138,7 +138,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '"ccache-v2020.09.10" | $(Agent.OS) | "$(python.version)"'
+      key: '"ccache-v2020.10.05" | $(Agent.OS) | "$(python.version)"'
       path: $(CCACHE_DIR)
     displayName: ccache
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,101 @@ pr:
 
 jobs:
 
+- job: 'manylinux2010'
+  pool:
+    vmImage: 'ubuntu-16.04'
+  strategy:
+    matrix:
+      Python36:
+        arch: x86_64
+        plat: manylinux2010_x86_64
+        python_ver: '36'
+        python.version: '3.6'
+      Python37:
+        arch: x86_64
+        plat: manylinux2010_x86_64
+        python_ver: '37'
+        python.version: '3.7'
+      Python38:
+        arch: x86_64
+        plat: manylinux2010_x86_64
+        python_ver: '38'
+        python.version: '3.8'
+  variables:
+    CCACHE_DIR: $(Pipeline.Workspace)/ccache
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+
+  - task: Cache@2
+    inputs:
+      key: '"ccache-wheels-v2020.09.10" | $(Agent.OS) | "$(python.version)"'
+      path: $(CCACHE_DIR)
+    displayName: ccache
+
+  - bash: |
+      set -e
+      sed -i "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
+      sed -i 's/"giotto-tda"/"giotto-tda-nightly"/1' setup.py
+      sed -i "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
+    condition: eq(variables.nightlyRelease, true)
+    displayName: 'Change name to giotto-tda-nightly'
+
+  - task: Bash@3
+    inputs:
+      filePath: .azure-ci/build_manylinux2010.sh
+    env:
+      python_ver: $(python_ver)
+      CCACHE_DIR: $(CCACHE_DIR)
+    displayName: 'Run docker container, install and uninstall dev environment, test with pytest and flake8, build the wheels'
+
+  - script: |
+      set -e
+      python -m pip install --upgrade pip
+      python -m pip install dist/*manylinux2010*.whl
+    displayName: 'Install the wheels'
+
+  - script: |
+      set -e
+      python -m pip install pytest pytest-cov pytest-azurepipelines pytest-benchmark hypothesis
+      mkdir tmp_test_cov
+      cd tmp_test_cov
+      pytest --pyargs gtda --ignore-glob='*externals*' --no-cov --no-coverage-upload
+    displayName: 'Test the wheels with pytest'
+
+  - script: |
+      set -e
+      python -m pip install pandas openml matplotlib
+      python -m pip install papermill
+      cd examples
+      for n in *.ipynb
+      do
+        papermill --start_timeout 2000 $n -
+      done
+    condition: eq(variables['notebooks_check'], 'true')
+    displayName: 'Test jupyter notebooks with papermill'
+
+  - task: CopyFiles@2
+    displayName: 'Copy files'
+    inputs:
+      contents: 'dist/*'
+      targetFolder: '$(Build.ArtifactStagingDirectory)'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Create download link'
+    inputs:
+      pathToPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: 'wheel'
+
+  - bash: |
+      set -e
+      python -m pip install twine
+      twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*manylinux2010*.whl
+    condition: eq(variables.nightlyRelease, true)
+    displayName: 'Upload nightly wheels to PyPI'
+
 
 - job: 'macOS1014'
   pool:
@@ -19,6 +114,8 @@ jobs:
     matrix:
       Python36:
         python.version: '3.6'
+      Python37:
+        python.version: '3.7'
       Python38:
         python.version: '3.8'
   variables:
@@ -41,7 +138,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '"ccache-wheels-v2020.10.05" | $(Agent.OS) | "$(python.version)"'
+      key: '"ccache-v2020.09.10" | $(Agent.OS) | "$(python.version)"'
       path: $(CCACHE_DIR)
     displayName: ccache
 
@@ -54,7 +151,6 @@ jobs:
 
   - script: |
       set -e
-      which python
       python -m pip install --upgrade pip setuptools
       python -m pip install wheel
       source .azure-ci/setup_ccache.sh
@@ -124,6 +220,98 @@ jobs:
 
   - bash: |
       set -e
+      twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*
+    condition: eq(variables.nightlyRelease, true)
+    displayName: 'Upload nightly wheels to PyPI'
+
+
+- job: 'win2016'
+  pool:
+    vmImage: 'vs2017-win2016'
+  strategy:
+    matrix:
+      Python36:
+        python_ver: '36'
+        python.version: '3.6'
+      Python37:
+        python_ver: '37'
+        python.version: '3.7'
+      Python38:
+        python_ver: '38'
+        python.version: '3.8'
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+
+  - bash: |
+      set -e
+      sed -i "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
+      sed -i 's/"giotto-tda"/"giotto-tda-nightly"/1' setup.py
+      sed -i "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
+    condition: eq(variables.nightlyRelease, true)
+    displayName: 'Change name to giotto-tda-nightly'
+
+  # Set BOOST_ROOT_PIPELINE to the version used in the pipeline
+  # See https://github.com/actions/virtual-environments/issues/687#issuecomment-616345933
+  - script: |
+      echo "##vso[task.setvariable variable=BOOST_ROOT_PIPELINE]%BOOST_ROOT_1_72_0%"
+    displayName: 'Set env variable for boost version'
+
+  - script: |
+      python -m pip install --upgrade pip setuptools
+      python -m pip install wheel
+      python -m pip install -e ".[dev]"
+    displayName: 'Install dev environment'
+
+  - script: |
+      pytest gtda --no-cov --no-coverage-upload || exit /b
+    displayName: 'Test dev install with pytest'
+
+  - script: |
+      python -m pip uninstall -y giotto-tda
+      python -m pip uninstall -y giotto-tda-nightly
+    displayName: 'Uninstall giotto-tda/giotto-tda-nightly dev'
+
+  - bash: |
+      set -e
+      sed -i $'s/\r$//' README.rst
+      python setup.py bdist_wheel
+    displayName: 'Build the wheels'
+
+  - bash: python -m pip install dist/*.whl
+    displayName: 'Install the wheels'
+
+  - script: |
+      mkdir tmp_test_cov
+      cd tmp_test_cov
+      pytest --pyargs gtda --ignore-glob='*externals*' --no-cov --no-coverage-upload
+    displayName: 'Test the wheels with pytest'
+
+  - script: |
+      python -m pip install -e ".[examples]"
+      python -m pip install papermill
+      cd examples
+      FOR %%n in (*.ipynb) DO (papermill --start_timeout 2000 %%n - || exit /b)
+    condition: eq(variables['notebooks_check'], 'true')
+    displayName: 'Test jupyter notebooks with papermill'
+
+  - task: CopyFiles@2
+    displayName: 'Copy files'
+    inputs:
+      contents: 'dist/*'
+      targetFolder: '$(Build.ArtifactStagingDirectory)'
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Create download link'
+    inputs:
+      pathToPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: 'wheel'
+
+  - bash: |
+      set -e
+      python -m pip install twine
       twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*
     condition: eq(variables.nightlyRelease, true)
     displayName: 'Upload nightly wheels to PyPI'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,7 +146,8 @@ jobs:
       set -e
       brew update
       brew reinstall openssl@1.1
-      brew uninstall --ignore-dependencies python
+      brew uninstall --ignore-dependencies
+      brew reinstall python
       brew install boost ccache
     displayName: 'Install system dependencies'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,9 +145,7 @@ jobs:
   - script: |
       set -e
       brew update
-      brew reinstall openssl@1.1
-      brew uninstall --ignore-dependencies python
-      brew reinstall python
+      echo 'export PATH="/usr/local/opt/python@$(python.version)/bin:$PATH"' >> /Users/runner/.bash_profile
       brew install boost ccache
     displayName: 'Install system dependencies'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,8 +145,8 @@ jobs:
   - script: |
       set -e
       brew update
+      brew reinstall python
       brew install boost ccache
-      brew install openssl@1.1
     displayName: 'Install system dependencies'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,6 +146,7 @@ jobs:
       set -e
       brew update
       brew reinstall openssl@1.1
+      brew uninstall python
       brew install boost ccache
     displayName: 'Install system dependencies'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,8 +144,6 @@ jobs:
 
   - script: |
       set -e
-      brew update
-      brew reinstall python@$(python.version)
       brew install boost ccache
     displayName: 'Install system dependencies'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,7 +146,7 @@ jobs:
       set -e
       brew update
       brew install boost ccache
-      brew install openssl@1_1_1g
+      brew install openssl@1.1.1g
     displayName: 'Install system dependencies'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '"ccache-wheels-v2020.09.10" | $(Agent.OS) | "$(python.version)"'
+      key: '"ccache-wheels-v2020.10.04" | $(Agent.OS) | "$(python.version)"'
       path: $(CCACHE_DIR)
     displayName: ccache
 
@@ -138,7 +138,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '"ccache-v2020.09.10" | $(Agent.OS) | "$(python.version)"'
+      key: '"ccache-v2020.10.04" | $(Agent.OS) | "$(python.version)"'
       path: $(CCACHE_DIR)
     displayName: ccache
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,101 +11,6 @@ pr:
 
 jobs:
 
-- job: 'manylinux2010'
-  pool:
-    vmImage: 'ubuntu-16.04'
-  strategy:
-    matrix:
-      Python36:
-        arch: x86_64
-        plat: manylinux2010_x86_64
-        python_ver: '36'
-        python.version: '3.6'
-      Python37:
-        arch: x86_64
-        plat: manylinux2010_x86_64
-        python_ver: '37'
-        python.version: '3.7'
-      Python38:
-        arch: x86_64
-        plat: manylinux2010_x86_64
-        python_ver: '38'
-        python.version: '3.8'
-  variables:
-    CCACHE_DIR: $(Pipeline.Workspace)/ccache
-
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '$(python.version)'
-
-  - task: Cache@2
-    inputs:
-      key: '"ccache-wheels-v2020.10.04" | $(Agent.OS) | "$(python.version)"'
-      path: $(CCACHE_DIR)
-    displayName: ccache
-
-  - bash: |
-      set -e
-      sed -i "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
-      sed -i 's/"giotto-tda"/"giotto-tda-nightly"/1' setup.py
-      sed -i "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
-    condition: eq(variables.nightlyRelease, true)
-    displayName: 'Change name to giotto-tda-nightly'
-
-  - task: Bash@3
-    inputs:
-      filePath: .azure-ci/build_manylinux2010.sh
-    env:
-      python_ver: $(python_ver)
-      CCACHE_DIR: $(CCACHE_DIR)
-    displayName: 'Run docker container, install and uninstall dev environment, test with pytest and flake8, build the wheels'
-
-  - script: |
-      set -e
-      python -m pip install --upgrade pip
-      python -m pip install dist/*manylinux2010*.whl
-    displayName: 'Install the wheels'
-
-  - script: |
-      set -e
-      python -m pip install pytest pytest-cov pytest-azurepipelines pytest-benchmark hypothesis
-      mkdir tmp_test_cov
-      cd tmp_test_cov
-      pytest --pyargs gtda --ignore-glob='*externals*' --no-cov --no-coverage-upload
-    displayName: 'Test the wheels with pytest'
-
-  - script: |
-      set -e
-      python -m pip install pandas openml matplotlib
-      python -m pip install papermill
-      cd examples
-      for n in *.ipynb
-      do
-        papermill --start_timeout 2000 $n -
-      done
-    condition: eq(variables['notebooks_check'], 'true')
-    displayName: 'Test jupyter notebooks with papermill'
-
-  - task: CopyFiles@2
-    displayName: 'Copy files'
-    inputs:
-      contents: 'dist/*'
-      targetFolder: '$(Build.ArtifactStagingDirectory)'
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Create download link'
-    inputs:
-      pathToPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: 'wheel'
-
-  - bash: |
-      set -e
-      python -m pip install twine
-      twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*manylinux2010*.whl
-    condition: eq(variables.nightlyRelease, true)
-    displayName: 'Upload nightly wheels to PyPI'
-
 
 - job: 'macOS1014'
   pool:
@@ -114,10 +19,6 @@ jobs:
     matrix:
       Python36:
         python.version: '3.6'
-      Python37:
-        python.version: '3.7'
-      Python38:
-        python.version: '3.8'
   variables:
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
 
@@ -144,7 +45,8 @@ jobs:
 
   - script: |
       set -e
-      echo 'export PATH="/usr/local/opt/python@$(python.version)/bin:$PATH"' >> /Users/runner/.bash_profile
+      brew update
+      which python
       brew install boost ccache
     displayName: 'Install system dependencies'
 
@@ -222,96 +124,3 @@ jobs:
       twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*
     condition: eq(variables.nightlyRelease, true)
     displayName: 'Upload nightly wheels to PyPI'
-
-
-- job: 'win2016'
-  pool:
-    vmImage: 'vs2017-win2016'
-  strategy:
-    matrix:
-      Python36:
-        python_ver: '36'
-        python.version: '3.6'
-      Python37:
-        python_ver: '37'
-        python.version: '3.7'
-      Python38:
-        python_ver: '38'
-        python.version: '3.8'
-
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '$(python.version)'
-
-  - bash: |
-      set -e
-      sed -i "s/'giotto-tda'/'giotto-tda-nightly'/1" setup.py
-      sed -i 's/"giotto-tda"/"giotto-tda-nightly"/1' setup.py
-      sed -i "s/__version__.*/__version__ = '$(Build.BuildNumber)'/1" gtda/_version.py
-    condition: eq(variables.nightlyRelease, true)
-    displayName: 'Change name to giotto-tda-nightly'
-
-  # Set BOOST_ROOT_PIPELINE to the version used in the pipeline
-  # See https://github.com/actions/virtual-environments/issues/687#issuecomment-616345933
-  - script: |
-      echo "##vso[task.setvariable variable=BOOST_ROOT_PIPELINE]%BOOST_ROOT_1_72_0%"
-    displayName: 'Set env variable for boost version'
-
-  - script: |
-      python -m pip install --upgrade pip setuptools
-      python -m pip install wheel
-      python -m pip install -e ".[dev]"
-    displayName: 'Install dev environment'
-
-  - script: |
-      pytest gtda --no-cov --no-coverage-upload || exit /b
-    displayName: 'Test dev install with pytest'
-
-  - script: |
-      python -m pip uninstall -y giotto-tda
-      python -m pip uninstall -y giotto-tda-nightly
-    displayName: 'Uninstall giotto-tda/giotto-tda-nightly dev'
-
-  - bash: |
-      set -e
-      sed -i $'s/\r$//' README.rst
-      python setup.py bdist_wheel
-    displayName: 'Build the wheels'
-
-  - bash: python -m pip install dist/*.whl
-    displayName: 'Install the wheels'
-
-  - script: |
-      mkdir tmp_test_cov
-      cd tmp_test_cov
-      pytest --pyargs gtda --ignore-glob='*externals*' --no-cov --no-coverage-upload
-    displayName: 'Test the wheels with pytest'
-
-  - script: |
-      python -m pip install -e ".[examples]"
-      python -m pip install papermill
-      cd examples
-      FOR %%n in (*.ipynb) DO (papermill --start_timeout 2000 %%n - || exit /b)
-    condition: eq(variables['notebooks_check'], 'true')
-    displayName: 'Test jupyter notebooks with papermill'
-
-  - task: CopyFiles@2
-    displayName: 'Copy files'
-    inputs:
-      contents: 'dist/*'
-      targetFolder: '$(Build.ArtifactStagingDirectory)'
-
-  - task: PublishBuildArtifacts@1
-    displayName: 'Create download link'
-    inputs:
-      pathToPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: 'wheel'
-
-  - bash: |
-      set -e
-      python -m pip install twine
-      twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*
-    condition: eq(variables.nightlyRelease, true)
-    displayName: 'Upload nightly wheels to PyPI'
-

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,7 +146,7 @@ jobs:
       set -e
       brew update
       brew reinstall openssl@1.1
-      brew uninstall python
+      brew uninstall --ignore-dependencies python
       brew install boost ccache
     displayName: 'Install system dependencies'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,6 +145,7 @@ jobs:
   - script: |
       set -e
       brew update
+      brew reinstall python@$(python.version)
       brew install boost ccache
     displayName: 'Install system dependencies'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,9 +107,9 @@ jobs:
     displayName: 'Upload nightly wheels to PyPI'
 
 
-- job: 'macOS1015'
+- job: 'macOS1014'
   pool:
-    vmImage: 'macOS-10.15'
+    vmImage: 'macOS-10.14'
   strategy:
     matrix:
       Python36:
@@ -138,7 +138,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '"ccache-v2020.10.04" | $(Agent.OS) | "$(python.version)"'
+      key: '"ccache-wheels-v2020.10.05" | $(Agent.OS) | "$(python.version)"'
       path: $(CCACHE_DIR)
     displayName: ccache
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,6 +47,11 @@ jobs:
 
   - script: |
       set -e
+      brew install boost ccache
+    displayName: 'Install system dependencies'
+
+  - script: |
+      set -e
       which python
       python -m pip install --upgrade pip setuptools
       python -m pip install wheel

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,8 @@ jobs:
     matrix:
       Python36:
         python.version: '3.6'
+      Python37:
+        python.version: '3.7'
   variables:
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,9 +107,9 @@ jobs:
     displayName: 'Upload nightly wheels to PyPI'
 
 
-- job: 'macOS1014'
+- job: 'macOS1015'
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   strategy:
     matrix:
       Python36:
@@ -145,7 +145,6 @@ jobs:
   - script: |
       set -e
       brew update
-      brew reinstall python
       brew install boost ccache
     displayName: 'Install system dependencies'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,7 +146,7 @@ jobs:
       set -e
       brew update
       brew reinstall openssl@1.1
-      brew uninstall --ignore-dependencies
+      brew uninstall --ignore-dependencies python
       brew reinstall python
       brew install boost ccache
     displayName: 'Install system dependencies'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,6 @@ jobs:
   - script: |
       set -e
       brew update
-      which python
       brew install boost ccache
     displayName: 'Install system dependencies'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,6 +47,8 @@ jobs:
 
   - script: |
       set -e
+      export HOMEBREW_NO_INSTALL_CLEANUP=1
+      brew update
       brew install boost ccache
     displayName: 'Install system dependencies'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,6 +144,7 @@ jobs:
 
   - script: |
       set -e
+      brew update && brew upgrade
       brew install boost ccache
     displayName: 'Install system dependencies'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,6 +146,7 @@ jobs:
       set -e
       brew update
       brew install boost ccache
+      brew install openssl@1_1_1g
     displayName: 'Install system dependencies'
 
   - script: |

--- a/gtda/mapper/tests/test_nerve.py
+++ b/gtda/mapper/tests/test_nerve.py
@@ -15,8 +15,8 @@ from gtda.mapper import Projection, OneDimensionalCover, make_mapper_pipeline
 @given(X=arrays(dtype=np.float, unique=True,
                 elements=floats(allow_nan=False,
                                 allow_infinity=False,
-                                min_value=-1e5,
-                                max_value=1e5),
+                                min_value=-1e6,
+                                max_value=1e6),
                 shape=array_shapes(min_dims=2, max_dims=2, min_side=11)))
 def test_node_intersection(X):
     # TODO: Replace pipe and graph by Nerve transformer
@@ -39,8 +39,8 @@ def test_node_intersection(X):
 @given(X=arrays(dtype=np.float, unique=True,
                 elements=floats(allow_nan=False,
                                 allow_infinity=False,
-                                min_value=-1e10,
-                                max_value=1e10),
+                                min_value=-1e6,
+                                max_value=1e6),
                 shape=array_shapes(min_dims=2, max_dims=2, min_side=11)))
 def test_edge_elements(X):
     # TODO: Replace pipe and graph by Nerve transformer
@@ -91,8 +91,8 @@ def test_edge_elements(X):
 @given(X=arrays(dtype=np.float, unique=True,
                 elements=floats(allow_nan=False,
                                 allow_infinity=False,
-                                min_value=-1e10,
-                                max_value=1e10),
+                                min_value=-1e6,
+                                max_value=1e6),
                 shape=array_shapes(min_dims=2, max_dims=2, min_side=11)))
 def test_min_intersection(X, min_intersection):
     # TODO: Replace pipe and graph by Nerve transformer

--- a/gtda/mapper/tests/test_nerve.py
+++ b/gtda/mapper/tests/test_nerve.py
@@ -15,8 +15,8 @@ from gtda.mapper import Projection, OneDimensionalCover, make_mapper_pipeline
 @given(X=arrays(dtype=np.float, unique=True,
                 elements=floats(allow_nan=False,
                                 allow_infinity=False,
-                                min_value=-1e10,
-                                max_value=1e10),
+                                min_value=-1e5,
+                                max_value=1e5),
                 shape=array_shapes(min_dims=2, max_dims=2, min_side=11)))
 def test_node_intersection(X):
     # TODO: Replace pipe and graph by Nerve transformer


### PR DESCRIPTION
Since yesterday, Azure jobs for the macOS 10.14 machines have started to fail at the "Install [python] dependencies and dev environment" step. Python complains about the SSL module being missing, see e.g. https://dev.azure.com/maintainers/f3825528-0a61-43d7-87c2-e296dd6abb14/_apis/build/builds/3096/logs/50.  The Azure VM image version was the same as two days ago when things worked, namely `Current image version: '20200904.1'`. After some investigation, it seemed that `brew cleanup` was corrupting some of the Python installations in the previous "Install system dependencies" step, see https://dev.azure.com/maintainers/Giotto/_build/results?buildId=3096&view=logs&j=e1e30141-6252-56cf-eccb-600499366ae7&t=3b015888-a459-5ae0-9425-e35a85d96e73. When the strategy matrix was reduced from 3 Python versions to just 1, the problem disappeared.

This PR provides a patch by setting the `HOMEBREW_NO_CLEANUP_INSTALL` flag to 1 to prevent `brew` from running `cleanup` automatically.

A ticket with Azure DevOps is open at: https://docs.microsoft.com/en-us/answers/questions/116675/python-ssl-module-suddenly-not-found-in-jobs-invol.html?childToView=116668#answer-116668 with my current understanding of the situation.