### PR TITLE
Bump macOS version in Azure jobs to 10.15

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,9 +108,9 @@ jobs:
     displayName: 'Upload nightly wheels to PyPI'
 
 
-- job: 'macOS1014'
+- job: 'macOS1015'
   pool:
-    vmImage: 'macOS-10.14'
+    vmImage: 'macOS-10.15'
   strategy:
     matrix:
       Python36:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '"ccache-wheels-v2020.10.27" | $(Agent.OS) | "$(python.version)"'
+      key: '"ccache-wheels-v2020.11.01" | $(Agent.OS) | "$(python.version)"'
       path: $(CCACHE_DIR)
     displayName: ccache
 
@@ -139,7 +139,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '"ccache-v2020.10.27" | $(Agent.OS) | "$(python.version)"'
+      key: '"ccache-v2020.11.01" | $(Agent.OS) | "$(python.version)"'
       path: $(CCACHE_DIR)
     displayName: ccache
 


### PR DESCRIPTION
Attempt to fix the brew woes in the Azure jobs by trying the suggestion in https://developercommunity.visualstudio.com/comments/1239467/view.html

Addresses (but is not a real fix of) #514 