### PR TITLE
Increase timeout deadline to 500ms in some flaky tests

### DIFF
--- a/gtda/externals/python/tests/test_ripser.py
+++ b/gtda/externals/python/tests/test_ripser.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats, integers, composite
 from numpy.testing import assert_almost_equal
@@ -47,6 +47,7 @@ def get_sparse_distance_matrices(draw):
 
 @pytest.mark.parametrize('thresh', [False, True])
 @pytest.mark.parametrize('coeff', [2, 7])
+@settings(deadline=500)
 @given(distance_matrix=get_dense_distance_matrices())
 def test_collapse_consistent_with_no_collapse_dense(thresh,
                                                     coeff, distance_matrix):
@@ -66,6 +67,7 @@ def test_collapse_consistent_with_no_collapse_dense(thresh,
 
 @pytest.mark.parametrize('thresh', [False, True])
 @pytest.mark.parametrize('coeff', [2, 7])
+@settings(deadline=500)
 @given(distance_matrix=get_sparse_distance_matrices())
 def test_collapse_consistent_with_no_collapse_coo(thresh,
                                                   coeff, distance_matrix):

--- a/gtda/mapper/tests/test_cluster.py
+++ b/gtda/mapper/tests/test_cluster.py
@@ -5,7 +5,7 @@ for ParallelClustering."""
 import numpy as np
 import pytest
 import sklearn as sk
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis.extra.numpy import arrays
 from hypothesis.strategies import floats, integers, composite
 from numpy.testing import assert_almost_equal
@@ -138,6 +138,7 @@ def get_input(draw, n_clusters=None, n_points_per_cluster=None,
                      dim, std=std))
 
 
+@settings(deadline=500)
 @given(inp=get_input(n_clusters=1, n_points_per_cluster=1, std=1))
 def test_on_trivial_input(inp):
     """Test that with one cluster, and one point, we always get one cluster,
@@ -152,6 +153,7 @@ def test_on_trivial_input(inp):
     assert fh.n_clusters_ == n_clusters
 
 
+@settings(deadline=500)
 @given(inp=get_input(std=0.02))
 def test_firstsimplegap(inp):
     """For a multimodal distribution, check that ``FirstSimpleGap`` with
@@ -169,6 +171,7 @@ def test_firstsimplegap(inp):
     assert_almost_equal(counts, n_points_per_cluster)
 
 
+@settings(deadline=500)
 @given(inp=get_input(n_clusters=2, std=0.02))
 def test_firsthistogramgap(inp):
     """For a multimodal distribution, check that the ``FirstHistogramGap`` with
@@ -185,6 +188,7 @@ def test_firsthistogramgap(inp):
     assert_almost_equal(counts, n_points_per_cluster)
 
 
+@settings(deadline=500)
 @given(inp=get_input(), max_frac=floats(min_value=0., exclude_min=True,
                                         max_value=1., exclude_max=False))
 def test_max_fraction_clusters(inp, max_frac):
@@ -202,6 +206,7 @@ def test_max_fraction_clusters(inp, max_frac):
     assert fh.n_clusters_ <= np.floor(max_num_clusters)
 
 
+@settings(deadline=500)
 @given(inp=get_input())
 def test_precomputed_distances(inp):
     """Verify that the clustering based on a distance matrix is the same as

--- a/gtda/time_series/_utils.py
+++ b/gtda/time_series/_utils.py
@@ -36,10 +36,7 @@ def _time_delay_embedding(X, time_delay=1, dimension=2, stride=1,
         func = partial(_time_delay_embedding, time_delay=time_delay,
                        dimension=dimension, stride=stride, flatten=flatten,
                        ensure_last_value=ensure_last_value)
-        X_embedded = []
-        for x in X:
-            x_embedded = func(x[None, ...])[0]
-            X_embedded.append(x_embedded)
+        X_embedded = [func(x[None, ...])[0] for x in X]
 
     return X_embedded
 


### PR DESCRIPTION
Increases `hypothesis` timeout deadline to 500ms in tests for the edge collapser and for `FirstSimpleGap` and `FirstHistogramGap` in the mapper subpackage. This should hopefully make the tests less flaky in the CI.