### PR TITLE
Add weighted (in part. DTM) Rips filtrations

### DIFF
--- a/doc/modules/homology.rst
+++ b/doc/modules/homology.rst
@@ -14,6 +14,7 @@ Undirected simplicial homology
    :template: class.rst
 
    homology.VietorisRipsPersistence
+   homology.WeightedRipsPersistence
    homology.SparseRipsPersistence
    homology.WeakAlphaPersistence
    homology.EuclideanCechPersistence

--- a/gtda/externals/python/ripser_interface.py
+++ b/gtda/externals/python/ripser_interface.py
@@ -177,12 +177,12 @@ def _weigh_filtration(weights_x, weights_y, distances, p):
     if p == np.inf:
         return np.maximum(distances, np.maximum(weights_x, weights_y))
     elif p == 1:
-        return np.where(distances <= np.abs(weights_x - weights_y),
+        return np.where(distances <= np.abs(weights_x - weights_y) / 2,
                         np.maximum(weights_x, weights_y),
                         distances + (weights_x + weights_y) / 2)
     elif p == 2:
         return np.where(
-            distances <= np.abs(weights_x**2 - weights_y**2)**.5,
+            distances <= np.abs(weights_x**2 - weights_y**2)**.5 / 2,
             np.maximum(weights_x, weights_y),
             np.sqrt((distances**2 + ((weights_x + weights_y) / 2)**2) *
                     (distances**2 + ((weights_x - weights_y) / 2)**2)) /

--- a/gtda/externals/python/ripser_interface.py
+++ b/gtda/externals/python/ripser_interface.py
@@ -428,7 +428,7 @@ def ripser(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
             row, col, data = \
                 row[off_diag_mask], col[off_diag_mask], data[off_diag_mask]
             data = _weight_filtration_sparse(row, col, data, weights,
-                                             p=weights_p)
+                                             weights_p)
             # Add diagonal information given by `weights`
             row, col, data = (np.concatenate([row, np.arange(n_points)]),
                               np.concatenate([col, np.arange(n_points)]),
@@ -465,7 +465,7 @@ def ripser(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
             else:
                 weights = _check_weights(weights, n_points)
 
-            dm = _weight_filtration_dense(dm, weights, p=weights_p)
+            dm = _weight_filtration_dense(dm, weights, weights_p)
             np.fill_diagonal(dm, weights)
 
         if (dm.diagonal() != 0).any():

--- a/gtda/externals/python/ripser_interface.py
+++ b/gtda/externals/python/ripser_interface.py
@@ -160,6 +160,7 @@ def _resolve_symmetry_conflicts(coo):
 
 
 def weigh_filtration_sparse(row, col, data, weights, p=np.inf):
+    # TODO fix
     weights_1d = weights.flatten()
     if p == np.inf:
         return np.maximum(np.maximum(data / 2, weights_1d[row]),
@@ -177,16 +178,19 @@ def weigh_filtration_sparse(row, col, data, weights, p=np.inf):
 
 def weigh_filtration_dense(dm, weights, p=np.inf):
     weights_1d = weights.flatten()
-    dm_weighted = np.maximum(weights, weights_1d)
     if p == np.inf:
-        return np.maximum(dm / 2, dm_weighted)
+        return np.maximum(dm / 2, np.maximum(weights, weights_1d))
     elif p == 1:
-        return (dm + weights_1d + weights) / 2
+        return np.where(dm <= np.abs(weights - weights_1d),
+                        np.maximum(weights, weights_1d),
+                        (dm + weights_1d + weights) / 2)
     elif p == 2:
-        return np.sqrt(
-            ((weights_1d + weights)**2 + dm**2) *
-            ((weights_1d - weights)**2 + dm**2)
-            ) / (2 * dm)
+        return np.where(dm <= np.abs(weights**2 - weights_1d**2)**.5,
+                        np.maximum(weights, weights_1d),
+                        np.sqrt(
+                            ((weights_1d + weights)**2 + dm**2) *
+                            ((weights_1d - weights)**2 + dm**2)
+                            ) / (2 * dm))
     else:
         raise NotImplementedError(f"Weighting not supported for p = {p}")
 

--- a/gtda/externals/python/ripser_interface.py
+++ b/gtda/externals/python/ripser_interface.py
@@ -366,7 +366,7 @@ def ripser(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
             knn = kneighbors_graph(dm, **weight_params, metric="precomputed",
                                    mode="distance", include_self=False)
             weights = np.linalg.norm(knn, axis=1) / np.sqrt(n_neighbors)
-            dm = weigh_filtration_sparse(dm, weights, p=weights_p)
+            dm = weigh_filtration_dense(dm, weights, p=weights_p)
         if (dm.diagonal() != 0).any():
             # Convert to sparse format, because currently that's the only
             # one handling nonzero births

--- a/gtda/externals/python/ripser_interface.py
+++ b/gtda/externals/python/ripser_interface.py
@@ -164,9 +164,8 @@ def _compute_dtm_weights(dm, n_neighbors, weights_r):
                            metric="precomputed", mode="distance",
                            include_self=False)
 
-    return 2 * np.asarray(
-        (np.sum(knn ** weights_r, axis=1) / n_neighbors) ** (1 / weights_r)
-        )
+    return 2 * np.asarray(knn.power(weights_r).sum(axis=1) /
+                          n_neighbors) ** (1 / weights_r)
 
 
 def _weigh_filtration(weights_x, weights_y, distances, p):

--- a/gtda/externals/python/ripser_interface.py
+++ b/gtda/externals/python/ripser_interface.py
@@ -310,7 +310,12 @@ def ripser(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
         if metric == 'precomputed':
             dm = X
         else:
-            dm = pairwise_distances(X, metric=metric, **metric_params)
+            if metric_params is None:
+                effective_metric_params = {}
+            else:
+                effective_metric_params = metric_params.copy()
+            dm = pairwise_distances(X, metric=metric,
+                                    **effective_metric_params)
         dperm2all = None
 
     n_points = max(dm.shape)

--- a/gtda/externals/python/ripser_interface.py
+++ b/gtda/externals/python/ripser_interface.py
@@ -384,7 +384,8 @@ def ripser(X, maxdim=1, thresh=np.inf, coeff=2, metric="euclidean",
         if (dm.diagonal() != 0).any():
             # Convert to sparse format, because currently that's the only
             # one handling nonzero births
-            (row, col), data = np.triu_indices_from(dm), np.triu(dm)
+            (row, col) = np.triu_indices_from(dm)
+            data = dm[(row, col)]
             if collapse_edges:
                 warn("Edge collapses are not supported when any of the "
                      "diagonal entries are non-zero. Computing persistent "

--- a/gtda/homology/__init__.py
+++ b/gtda/homology/__init__.py
@@ -2,12 +2,14 @@
 persistence diagrams."""
 # License: GNU AGPLv3
 
-from .simplicial import VietorisRipsPersistence, SparseRipsPersistence, \
-    WeakAlphaPersistence, EuclideanCechPersistence, FlagserPersistence
+from .simplicial import VietorisRipsPersistence, WeightedRipsPersistence, \
+    SparseRipsPersistence, WeakAlphaPersistence, EuclideanCechPersistence, \
+    FlagserPersistence
 from .cubical import CubicalPersistence
 
 __all__ = [
     'VietorisRipsPersistence',
+    'WeightedRipsPersistence',
     'SparseRipsPersistence',
     'WeakAlphaPersistence',
     'EuclideanCechPersistence',

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -375,7 +375,7 @@ class WeightedRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
     diagonal entries are the :math:`\\{w_i\\}_i`, and whose edge weights are
 
     .. math:: w_{ij} = \\begin{cases} \\max\\{ w_i, w_j \\} &\\text{if }
-       2\\mathrm{dist}_{ij} \\leq |w_i^p - w_j^p|^{\\frac{1}{p}} \\
+       2\\mathrm{dist}_{ij} \\leq |w_i^p - w_j^p|^{\\frac{1}{p}}, \\\\
        t &\\text{otherwise} \\end{cases}
 
     where :math:`t` is the only positive root of
@@ -425,15 +425,15 @@ class WeightedRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         adjacency matrices. The default ``"DTM"`` denotes the empirical
         distance-to-measure function defined, following [3]_, by
 
-        .. math:: w(x) = 2\\left\\(\\frac{1}{n+1} \\sum_{k=1}^n
-           \\mathrm{dist}(x, x_k)^r \\right)^{1/r}.
+        .. math:: w(x) = 2\\left(\\frac{1}{n+1} \\sum_{k=1}^n
+           \\mathrm{dist}(x, x_k)^r\\right)^{1/r}.
 
         Here, :math:`\\mathrm{dist}` is the distance metric used, :math:`x_k`
         is the :math:`k`-th :math:`\\mathrm{dist}`-nearest neighbour of
         :math:`x` (:math:`x` is not considered a neighbour of itself),
         :math:`n` is the number of nearest neighbors to include, and :math:`r`
         is a parameter (see `weight_params`).
-        :math:`w(x) = 2\\left\\(\\frac{1}{n+1} \\sum_{i=1}^n
+        :math:`w(x) = 2 \\left(\\frac{1}{n+1} \\sum_{i=1}^n
         \\mathrm{dist}(x, x_i)^r \\right)^{1/r}`, where :math:`\\mathrm{dist}`
         is the distance metric used and :math:`x_i` is the :math:`i`-th
         :math:`\\mathrm{dist}`-nearest neighbour of :math:`x` (:math:`x` is not

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -453,10 +453,9 @@ class WeightedRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         large.
 
     max_edge_length : float, optional, default: ``numpy.inf``
-        Maximum value of the Vietoris–Rips filtration parameter. Points whose
-        distance is greater than this value will never be connected by an edge,
-        and topological features at scales larger than this value will not be
-        detected.
+        Maximum value of the filtration parameter in the modified adjacency
+        matrix. Edges with weight greater than this value will be considered
+        absent.
 
     infinity_values : float or None, default: ``None``
         Which death value to assign to features which are still alive at
@@ -536,7 +535,7 @@ class WeightedRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         }
 
     def __init__(self, metric="euclidean", metric_params={},
-                 homology_dimensions=(0, 1), weights=None, weight_params=None,
+                 homology_dimensions=(0, 1), weights="DTM", weight_params=None,
                  collapse_edges=False, coeff=2, max_edge_length=np.inf,
                  infinity_values=None, reduced_homology=True, n_jobs=None):
         self.metric = metric

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -433,11 +433,6 @@ class WeightedRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         :math:`x` (:math:`x` is not considered a neighbour of itself),
         :math:`n` is the number of nearest neighbors to include, and :math:`r`
         is a parameter (see `weight_params`).
-        :math:`w(x) = 2 \\left(\\frac{1}{n+1} \\sum_{i=1}^n
-        \\mathrm{dist}(x, x_i)^r \\right)^{1/r}`, where :math:`\\mathrm{dist}`
-        is the distance metric used and :math:`x_i` is the :math:`i`-th
-        :math:`\\mathrm{dist}`-nearest neighbour of :math:`x` (:math:`x` is not
-        considered a neighbour of itself).
 
     weight_params : dict, optional, default: ``None``
         Additional parameters for the weighted filtration. ``"p"`` determines

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -452,15 +452,15 @@ class WeightedRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         dramatically when the data or the maximum homology dimensions are
         large.
 
-    max_edge_length : float, optional, default: ``numpy.inf``
+    max_edge_weight : float, optional, default: ``numpy.inf``
         Maximum value of the filtration parameter in the modified adjacency
         matrix. Edges with weight greater than this value will be considered
         absent.
 
     infinity_values : float or None, default: ``None``
         Which death value to assign to features which are still alive at
-        filtration value `max_edge_length`. ``None`` means that this death
-        value is declared to be equal to `max_edge_length`.
+        filtration value `max_edge_weight`. ``None`` means that this death
+        value is declared to be equal to `max_edge_weight`.
 
     reduced_homology : bool, optional, default: ``True``
        If ``True``, the earliest-born triple in homology dimension 0 which has
@@ -476,7 +476,7 @@ class WeightedRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
     ----------
     infinity_values_ : float
         Effective death value to assign to features which are still alive at
-        filtration value `max_edge_length`.
+        filtration value `max_edge_weight`.
 
     effective_weight_params_ : dict
         Effective parameters involved in computing the weighted Rips
@@ -529,14 +529,14 @@ class WeightedRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         "weight_params": {"type": (dict, type(None))},
         "collapse_edges": {"type": bool},
         "coeff": {"type": int, "in": Interval(2, np.inf, closed="left")},
-        "max_edge_length": {"type": Real},
+        "max_edge_weight": {"type": Real},
         "infinity_values": {"type": (Real, type(None))},
         "reduced_homology": {"type": bool}
         }
 
     def __init__(self, metric="euclidean", metric_params={},
                  homology_dimensions=(0, 1), weights="DTM", weight_params=None,
-                 collapse_edges=False, coeff=2, max_edge_length=np.inf,
+                 collapse_edges=False, coeff=2, max_edge_weight=np.inf,
                  infinity_values=None, reduced_homology=True, n_jobs=None):
         self.metric = metric
         self.metric_params = metric_params
@@ -545,7 +545,7 @@ class WeightedRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         self.weight_params = weight_params
         self.collapse_edges = collapse_edges
         self.coeff = coeff
-        self.max_edge_length = max_edge_length
+        self.max_edge_weight = max_edge_weight
         self.infinity_values = infinity_values
         self.reduced_homology = reduced_homology
         self.n_jobs = n_jobs
@@ -557,7 +557,7 @@ class WeightedRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             weights = self.weights
         Xdgms = ripser(
             X, maxdim=self._max_homology_dimension,
-            thresh=self.max_edge_length, coeff=self.coeff, metric=self.metric,
+            thresh=self.max_edge_weight, coeff=self.coeff, metric=self.metric,
             metric_params=self.metric_params, weights=weights,
             weight_params=self.effective_weight_params_,
             collapse_edges=self.collapse_edges
@@ -623,7 +623,7 @@ class WeightedRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
                            distance_matrices=self._is_precomputed)
 
         if self.infinity_values is None:
-            self.infinity_values_ = self.max_edge_length
+            self.infinity_values_ = self.max_edge_weight
         else:
             self.infinity_values_ = self.infinity_values
 

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -170,7 +170,7 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
                  collapse_edges=False, coeff=2, max_edge_length=np.inf,
                  infinity_values=None, reduced_homology=True, n_jobs=None):
         self.metric = metric
-        self.metric_params = metric_params,
+        self.metric_params = metric_params
         self.homology_dimensions = homology_dimensions
         self.weights = weights
         self.weight_params = weight_params

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -353,8 +353,7 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 @adapt_fit_transform_docs
 class WeightedRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
     """:ref:`Persistence diagrams <persistence_diagram>` resulting from
-    :ref:`weighted Vietoris–Rips filtrations
-    <TODO>` as in [3]_.
+    :ref:`weighted Vietoris–Rips filtrations <TODO>` as in [3]_.
 
     Given a :ref:`point cloud <distance_matrices_and_point_clouds>` in
     Euclidean space, an abstract :ref:`metric space

--- a/gtda/homology/tests/test_simplicial.py
+++ b/gtda/homology/tests/test_simplicial.py
@@ -159,8 +159,7 @@ def test_wrp_notimplemented_p():
 def test_wrp_same_as_vrp_when_zero_weights(X, metric, weight_params,
                                            collapse_edges, max_edge_weight,
                                            infinity_values):
-    weights = lambda x: np.zeros(x.shape[0])
-    wrp = WeightedRipsPersistence(weights=weights,
+    wrp = WeightedRipsPersistence(weights=lambda x: np.zeros(x.shape[0]),
                                   weight_params=weight_params,
                                   metric=metric,
                                   collapse_edges=collapse_edges,


### PR DESCRIPTION
**Reference issues/PRs**
None

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
Implements weighted Rips filtrations, as described in https://drops.dagstuhl.de/opus/volltexte/2019/10462/pdf/LIPIcs-SoCG-2019-58.pdf. In particular, implements the DTM-weighted Rips filtration.  This is done via a new ``WeightedRipsFiltration`` class.  Additionally, the docstrings for ``VietorisRipsPersistence`` have been improved.

**Any other comments?**

**Checklist**
<!--
Go over all the following points, and put an `x` in all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.

<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
