### PR TITLE
Fix linting problem in mapper/cover.py

### DIFF
--- a/gtda/mapper/cover.py
+++ b/gtda/mapper/cover.py
@@ -213,7 +213,8 @@ class OneDimensionalCover(BaseEstimator, TransformerMixin):
             X_rank, self.n_intervals, self.overlap_frac, is_uniform=False)
         X_rank = np.broadcast_to(X_rank[:, None],
                                  (X.shape[0], self.n_intervals))
-        Xt = np.logical_and(X_rank > self._left_limits, X_rank < self._right_limits)
+        Xt = np.logical_and(X_rank > self._left_limits,
+                            X_rank < self._right_limits)
         return Xt
 
     def _fit_transform(self, X):


### PR DESCRIPTION
Fixes a linting problem (line too long) in mapper/cover.py, introduced in #543 