### PR TITLE
Use defaultdict in mapper's Nerve

### DIFF
--- a/gtda/mapper/nerve.py
+++ b/gtda/mapper/nerve.py
@@ -1,6 +1,7 @@
 """Construct the nerve of a refined Mapper cover."""
 # License: GNU AGPLv3
 
+from collections import defaultdict
 from itertools import combinations, filterfalse
 
 import igraph as ig
@@ -122,10 +123,10 @@ class Nerve(BaseEstimator, TransformerMixin):
         """
         # TODO: Include a validation step for X
         # Graph construction -- vertices with their metadata
-        labels_to_indices = {}
+        labels_to_indices = defaultdict(list)
         for i, sample in enumerate(X):
             for node_id_pair in sample:
-                labels_to_indices.setdefault(node_id_pair, []).append(i)
+                labels_to_indices[node_id_pair].append(i)
         labels_to_indices = {key: np.array(value)
                              for key, value in labels_to_indices.items()}
         n_nodes = len(labels_to_indices)

--- a/gtda/mapper/nerve.py
+++ b/gtda/mapper/nerve.py
@@ -4,8 +4,8 @@
 from collections import defaultdict
 from itertools import combinations, filterfalse
 
-import igraph as ig
 import numpy as np
+from igraph import Graph
 from sklearn.base import BaseEstimator, TransformerMixin
 
 
@@ -130,7 +130,7 @@ class Nerve(BaseEstimator, TransformerMixin):
         labels_to_indices = {key: np.array(value)
                              for key, value in labels_to_indices.items()}
         n_nodes = len(labels_to_indices)
-        graph = ig.Graph(n_nodes)
+        graph = Graph(n_nodes)
 
         # labels_to_indices is a dictionary of, say, N key-value pairs of the
         # form (pullback_set_label, partial_cluster_label): node_elements.


### PR DESCRIPTION
**Types of changes**
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
Small enhancement to the internals of ``Nerve.fit``.  ``collections.defaultdict`` is used instead of a vanilla Python ``dict`` as suggested in the Python documentation for such cases (see https://docs.python.org/3/library/collections.html#collections.defaultdict, under "defaultdict Examples").

**Checklist**
<!--
Go over all the following points, and put an `x` in all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.