### PR TITLE
Fix brew symlinking in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -152,8 +152,6 @@ jobs:
 
   - script: |
       set -e
-      brew pin python
-      export HOMEBREW_NO_INSTALL_CLEANUP=1
       brew update
       brew install boost ccache
     displayName: 'Install system dependencies'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -152,7 +152,7 @@ jobs:
 
   - script: |
       set -e
-      brew update
+      brew update && brew upgrade
       brew install boost ccache
     displayName: 'Install system dependencies'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -152,7 +152,8 @@ jobs:
 
   - script: |
       set -e
-      brew update && brew upgrade
+      brew update
+      rm '/usr/local/bin/2to3'
       brew install boost ccache
     displayName: 'Install system dependencies'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -152,6 +152,7 @@ jobs:
 
   - script: |
       set -e
+      brew unlink python@2
       export HOMEBREW_NO_INSTALL_CLEANUP=1
       brew update
       brew install boost ccache

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -152,7 +152,7 @@ jobs:
 
   - script: |
       set -e
-      brew unlink python@2
+      brew pin python
       export HOMEBREW_NO_INSTALL_CLEANUP=1
       brew update
       brew install boost ccache

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -150,10 +150,13 @@ jobs:
       path: $(CCACHE_DIR)
     displayName: ccache
 
+  # Python and gcc hotfixes following https://github.com/actions/virtual-environments/issues/2322 and https://github.com/actions/virtual-environments/issues/2391
   - script: |
       set -e
       brew update
       rm '/usr/local/bin/2to3'
+      brew unlink gcc@8 && brew unlink gcc@9
+      brew upgrade      
       brew install boost ccache
     displayName: 'Install system dependencies'
 


### PR DESCRIPTION
**Reference issues/PRs**
Vaguely related to #527, #514, #513.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
The macOS Azure pipelines have beginning to fail as `brew` fails to create symlinks when upgrading python. This appears identical to the issue opened in https://github.com/actions/virtual-environments/issues/2322 (GitHub actions).  As a hotfix, the line `rm '/usr/local/bin/2to3'` has been added.  Furthermore, a `brew upgrade` step has been reinstated.  However, this also initially failed due to another symlink issue on `gcc@8` and `gcc@9`, as described in https://github.com/actions/virtual-environments/issues/2391.  As a hotfix to this, the line `brew unlink gcc@8 && brew unlink gcc@9` has been added.

The status of the causing issue should be monitored and this hotfix might become unnecessary in the future.

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.