### PR TITLE
Enable edge collapser for non-zero vertex weights

### DIFF
--- a/doc/release.rst
+++ b/doc/release.rst
@@ -14,6 +14,7 @@ Major Features and Improvements
 - Wheels for Python 3.9 have been added (`#528 <https://github.com/giotto-ai/giotto-tda/pull/528>`_).
 - Weighted Rips filtrations, and in particular distance-to-measure (DTM) based filtrations, are now supported in ``ripser`` and by the new ``WeightedRipsPersistence`` transformer (`#541 <https://github.com/giotto-ai/giotto-tda/pull/541>`_).
 - See "Backwards-Incompatible Changes" for major improvements to ``ParallelClustering`` and therefore ``make_mapper_pipeline`` which are also major breaking changes.
+- GUDHI's edge collapser can now be used with arbitrary vertex and edge weights (`#558 <https://github.com/giotto-ai/giotto-tda/pull/558>`_).
 - ``GraphGeodesicDistance`` can now take rectangular input (the number of vertices is inferred to be ``max(x.shape)``), and ``KNeighborsGraph`` can now take sparse input (`#537 <https://github.com/giotto-ai/giotto-tda/pull/537>`_).
 - ``VietorisRipsPersistence`` now takes a ``metric_params`` parameter (`#541 <https://github.com/giotto-ai/giotto-tda/pull/541>`_).
 

--- a/gtda/externals/python/tests/test_ripser.py
+++ b/gtda/externals/python/tests/test_ripser.py
@@ -14,13 +14,13 @@ def get_dense_distance_matrices(draw):
     """Generate 2d dense square arrays of floats, with zero along the
     diagonal."""
     shapes = draw(integers(min_value=2, max_value=30))
-    distance_matrix = draw(arrays(dtype=np.float,
-                                  elements=floats(allow_nan=False,
-                                                  allow_infinity=True,
-                                                  min_value=0),
-                                  shape=(shapes, shapes), unique=False))
-    np.fill_diagonal(distance_matrix, 0)
-    return distance_matrix
+    dm = draw(arrays(dtype=np.float,
+                     elements=floats(allow_nan=False,
+                                     allow_infinity=True,
+                                     min_value=0),
+                     shape=(shapes, shapes), unique=False))
+    np.fill_diagonal(dm, 0)
+    return dm
 
 
 @composite
@@ -28,27 +28,26 @@ def get_sparse_distance_matrices(draw):
     """Generate 2d upper triangular sparse matrices of floats, with zero along
     the diagonal."""
     shapes = draw(integers(min_value=2, max_value=40))
-    distance_matrix = draw(arrays(dtype=np.float,
-                                  elements=floats(allow_nan=False,
-                                                  allow_infinity=True,
-                                                  min_value=0),
-                                  shape=(shapes, shapes), unique=False))
-    distance_matrix = np.triu(distance_matrix, k=1)
-    distance_matrix = coo_matrix(distance_matrix)
-    row, col, data = \
-        distance_matrix.row, distance_matrix.col, distance_matrix.data
+    dm = draw(arrays(dtype=np.float,
+                     elements=floats(allow_nan=False,
+                                     allow_infinity=True,
+                                     min_value=0),
+                     shape=(shapes, shapes), unique=False))
+    dm = np.triu(dm, k=1)
+    dm = coo_matrix(dm)
+    row, col, data = dm.row, dm.col, dm.data
     not_inf_idx = data != np.inf
     row = row[not_inf_idx]
     col = col[not_inf_idx]
     data = data[not_inf_idx]
     shape_kwargs = {} if data.size else {"shape": (0, 0)}
-    distance_matrix = coo_matrix((data, (row, col)), **shape_kwargs)
-    return distance_matrix
+    dm = coo_matrix((data, (row, col)), **shape_kwargs)
+    return dm
 
 
 @settings(deadline=500)
-@given(distance_matrix=get_sparse_distance_matrices())
-def test_coo_below_diagonal_and_mixed_same_as_above(distance_matrix):
+@given(dm=get_sparse_distance_matrices())
+def test_coo_below_diagonal_and_mixed_same_as_above(dm):
     """Test that if we feed sparse matrices representing the same undirected
     weighted graph we obtain the same results regardless of whether all entries
     are above the diagonal, all are below the diagonal, or neither.
@@ -56,12 +55,11 @@ def test_coo_below_diagonal_and_mixed_same_as_above(distance_matrix):
     triangle are resolved in favour of the upper triangle."""
     ripser_kwargs = {"maxdim": 2, "metric": "precomputed"}
 
-    pd_above = ripser(distance_matrix, **ripser_kwargs)['dgms']
+    pd_above = ripser(dm, **ripser_kwargs)['dgms']
 
-    pd_below = ripser(distance_matrix.T, **ripser_kwargs)['dgms']
+    pd_below = ripser(dm.T, **ripser_kwargs)['dgms']
 
-    _row, _col, _data = (distance_matrix.row, distance_matrix.col,
-                         distance_matrix.data)
+    _row, _col, _data = dm.row, dm.col, dm.data
     coo_shape_kwargs = {} if _data.size else {"shape": (0, 0)}
     to_transpose_mask = np.full(len(_row), False)
     to_transpose_mask[np.random.choice(np.arange(len(_row)),
@@ -69,16 +67,15 @@ def test_coo_below_diagonal_and_mixed_same_as_above(distance_matrix):
                                        replace=False)] = True
     row = np.concatenate([_col[to_transpose_mask], _row[~to_transpose_mask]])
     col = np.concatenate([_row[to_transpose_mask], _col[~to_transpose_mask]])
-    distance_matrix_mixed = coo_matrix((_data, (row, col)), **coo_shape_kwargs)
-    pd_mixed = ripser(distance_matrix_mixed, **ripser_kwargs)['dgms']
+    dm_mixed = coo_matrix((_data, (row, col)), **coo_shape_kwargs)
+    pd_mixed = ripser(dm_mixed, **ripser_kwargs)['dgms']
 
     row = np.concatenate([row, _row[to_transpose_mask]])
     col = np.concatenate([col, _col[to_transpose_mask]])
     data = np.random.random(len(row))
     data[:len(_row)] = _data
-    distance_matrix_conflicts = coo_matrix((data, (row, col)),
-                                           **coo_shape_kwargs)
-    pd_conflicts = ripser(distance_matrix_conflicts, **ripser_kwargs)['dgms']
+    dm_conflicts = coo_matrix((data, (row, col)), **coo_shape_kwargs)
+    pd_conflicts = ripser(dm_conflicts, **ripser_kwargs)['dgms']
 
     for i in range(ripser_kwargs["maxdim"] + 1):
         pd_above[i] = np.sort(pd_above[i], axis=0)
@@ -91,17 +88,14 @@ def test_coo_below_diagonal_and_mixed_same_as_above(distance_matrix):
 @pytest.mark.parametrize('thresh', [False, True])
 @pytest.mark.parametrize('coeff', [2, 7])
 @settings(deadline=500)
-@given(distance_matrix=get_dense_distance_matrices())
-def test_collapse_consistent_with_no_collapse_dense(thresh,
-                                                    coeff, distance_matrix):
-    thresh = np.max(distance_matrix) / 2 if thresh else np.inf
+@given(dm=get_dense_distance_matrices())
+def test_collapse_consistent_with_no_collapse_dense(thresh, coeff, dm):
+    thresh = np.max(dm) / 2 if thresh else np.inf
     maxdim = 3
-    pd_collapse = ripser(distance_matrix, thresh=thresh, maxdim=maxdim,
-                         coeff=coeff, metric='precomputed',
-                         collapse_edges=True)['dgms']
-    pd_no_collapse = ripser(distance_matrix, thresh=thresh, maxdim=maxdim,
-                            coeff=coeff, metric='precomputed',
-                            collapse_edges=False)['dgms']
+    pd_collapse = ripser(dm, thresh=thresh, maxdim=maxdim, coeff=coeff,
+                         metric='precomputed', collapse_edges=True)['dgms']
+    pd_no_collapse = ripser(dm, thresh=thresh, maxdim=maxdim, coeff=coeff,
+                            metric='precomputed', collapse_edges=False)['dgms']
     for i in range(maxdim + 1):
         pd_collapse[i] = np.sort(pd_collapse[i], axis=0)
         pd_no_collapse[i] = np.sort(pd_no_collapse[i], axis=0)
@@ -111,24 +105,46 @@ def test_collapse_consistent_with_no_collapse_dense(thresh,
 @pytest.mark.parametrize('thresh', [False, True])
 @pytest.mark.parametrize('coeff', [2, 7])
 @settings(deadline=500)
-@given(distance_matrix=get_sparse_distance_matrices())
-def test_collapse_consistent_with_no_collapse_coo(thresh,
-                                                  coeff, distance_matrix):
-    if thresh and distance_matrix.nnz:
-        thresh = np.max(distance_matrix) / 2
+@given(dm=get_sparse_distance_matrices())
+def test_collapse_consistent_with_no_collapse_coo(thresh, coeff, dm):
+    if thresh and dm.nnz:
+        thresh = np.max(dm) / 2
     else:
         thresh = np.inf
     maxdim = 3
-    pd_collapse = ripser(distance_matrix, thresh=thresh, maxdim=maxdim,
-                         coeff=coeff, metric='precomputed',
-                         collapse_edges=True)['dgms']
-    pd_no_collapse = ripser(distance_matrix, thresh=thresh, maxdim=maxdim,
-                            coeff=coeff, metric='precomputed',
-                            collapse_edges=False)['dgms']
+    pd_collapse = ripser(dm, thresh=thresh, maxdim=maxdim, coeff=coeff,
+                         metric='precomputed', collapse_edges=True)['dgms']
+    pd_no_collapse = ripser(dm, thresh=thresh, maxdim=maxdim, coeff=coeff,
+                            metric='precomputed', collapse_edges=False)['dgms']
     for i in range(maxdim + 1):
         pd_collapse[i] = np.sort(pd_collapse[i], axis=0)
         pd_no_collapse[i] = np.sort(pd_no_collapse[i], axis=0)
         assert_almost_equal(pd_collapse[i], pd_no_collapse[i])
+
+
+def test_collapser_with_negative_weights():
+    """Test that collapser works as expected when some of the vertex and edge
+    weights are negative."""
+    n_points = 20
+    dm = np.random.random((n_points, n_points))
+    np.fill_diagonal(dm, -np.random.random(n_points))
+    dm -= 0.2
+    dm_sparse = coo_matrix(dm)
+
+    maxdim = 2
+    pd_collapse_dense = ripser(dm, metric='precomputed', maxdim=maxdim,
+                               collapse_edges=True)['dgms']
+    pd_collapse_sparse = ripser(dm_sparse, metric='precomputed',
+                                maxdim=maxdim, collapse_edges=True)['dgms']
+    pd_no_collapse = ripser(dm, metric='precomputed', maxdim=maxdim,
+                            collapse_edges=False)['dgms']
+
+    for i in range(maxdim + 1):
+        pd_collapse_dense[i] = np.sort(pd_collapse_dense[i], axis=0)
+        pd_collapse_sparse[i] = np.sort(pd_collapse_dense[i], axis=0)
+        pd_no_collapse[i] = np.sort(pd_no_collapse[i], axis=0)
+        assert_almost_equal(pd_collapse_dense[i], pd_no_collapse[i])
+        assert_almost_equal(pd_collapse_sparse[i], pd_no_collapse[i])
 
 
 def test_coo_results_independent_of_order():

--- a/gtda/homology/tests/test_simplicial.py
+++ b/gtda/homology/tests/test_simplicial.py
@@ -195,7 +195,6 @@ X_wrp_exp = {1: np.array([[[0.95338798, 1.474913, 0.],
                                        (X_dist_sparse, 'precomputed')])
 @pytest.mark.parametrize('weight_params', [{'p': 1}, {'p': 2}, {'p': np.inf}])
 @pytest.mark.parametrize('collapse_edges', [True, False])
-@pytest.mark.filterwarnings('ignore:Edge collapses are not supported')
 def test_wrp_transform(X, metric, weight_params, collapse_edges):
     wrp = WeightedRipsPersistence(weight_params=weight_params,
                                   metric=metric,


### PR DESCRIPTION
**Reference issues/PRs**
None

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
An analysis of the edge collapse algorithm reveals that although it operates only on the edges of a weighted graph, under the assumption that the user passes data for a genuine filtration it is not necessary to impose that the vertex weights are zero. One can use edge collapse with non-zero vertex weights by simply appending them to the data for the weighted edges after collapse. This also enables edge collapse to be user for negative vertex and edge weights.

Thanks @matteocao and Siddharth Pritam!

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.