### PR TITLE
Replace np.int, np.bool and np.float with python builtins following deprecation in numpy 1.20

### DIFF
--- a/gtda/diagrams/_utils.py
+++ b/gtda/diagrams/_utils.py
@@ -56,7 +56,7 @@ def _sample_image(image, diagram_pixel_coords):
     # WARNING: Modifies `image` in-place
     unique, counts = \
         np.unique(diagram_pixel_coords, axis=0, return_counts=True)
-    unique = tuple(tuple(row) for row in unique.astype(np.int).T)
+    unique = tuple(tuple(row) for row in unique.astype(int).T)
     image[unique] = counts
 
 
@@ -66,7 +66,7 @@ def _multirange(counts):
     memory-efficient way."""
     cumsum = np.cumsum(counts)
     reset_index = cumsum[:-1]
-    incr = np.ones(cumsum[-1], dtype=np.int32)
+    incr = np.ones(cumsum[-1], dtype=int)
     incr[0] = 0
 
     # For each index in reset_index, we insert the negative value necessary

--- a/gtda/diagrams/tests/test_features_representations.py
+++ b/gtda/diagrams/tests/test_features_representations.py
@@ -150,7 +150,7 @@ def test_pi_zero_weight_function(n_jobs):
     assert np.array_equal(X_res, np.zeros_like(X_res))
 
 
-@given(X=arrays(dtype=np.float, unique=True,
+@given(X=arrays(dtype=float, unique=True,
                 elements=floats(min_value=-10, max_value=10),
                 shape=array_shapes(min_dims=1, max_dims=1, min_side=11)))
 def test_pi_null(X):
@@ -170,7 +170,7 @@ def test_pi_null(X):
     assert_almost_equal(pi.fit_transform(diagrams)[0], 0)
 
 
-@given(pts=arrays(dtype=np.float, unique=True,
+@given(pts=arrays(dtype=float, unique=True,
                   elements=floats(allow_nan=False,
                                   allow_infinity=False,
                                   min_value=-10,
@@ -238,7 +238,7 @@ def test_all_pts_the_same(transformer_cls, n_jobs):
 
 
 pts_gen = arrays(
-    dtype=np.float,
+    dtype=float,
     elements=floats(allow_nan=False,
                     allow_infinity=False,
                     min_value=1.,
@@ -246,7 +246,7 @@ pts_gen = arrays(
     shape=(1, 20, 2), unique=True
     )
 dims_gen = arrays(
-    dtype=np.int,
+    dtype=int,
     elements=integers(min_value=0,
                       max_value=3),
     shape=(1, 20, 1)

--- a/gtda/externals/python/tests/test_ripser.py
+++ b/gtda/externals/python/tests/test_ripser.py
@@ -14,7 +14,7 @@ def get_dense_distance_matrices(draw):
     """Generate 2d dense square arrays of floats, with zero along the
     diagonal."""
     shapes = draw(integers(min_value=2, max_value=30))
-    dm = draw(arrays(dtype=np.float,
+    dm = draw(arrays(dtype=float,
                      elements=floats(allow_nan=False,
                                      allow_infinity=True,
                                      min_value=0),
@@ -28,7 +28,7 @@ def get_sparse_distance_matrices(draw):
     """Generate 2d upper triangular sparse matrices of floats, with zero along
     the diagonal."""
     shapes = draw(integers(min_value=2, max_value=40))
-    dm = draw(arrays(dtype=np.float,
+    dm = draw(arrays(dtype=float,
                      elements=floats(allow_nan=False,
                                      allow_infinity=True,
                                      min_value=0),
@@ -160,7 +160,7 @@ def test_coo_results_independent_of_order():
                           [0., 2.],
                           [0., 5.],
                           [0., np.inf]]),
-                np.array([], dtype=np.float64).reshape(0, 2)]
+                np.array([], dtype=float).reshape(0, 2)]
     for i in range(2):
         assert np.array_equal(diagrams[i], expected[i])
         assert np.array_equal(diagrams_csr[i], expected[i])

--- a/gtda/graphs/tests/test_geodesic_distance.py
+++ b/gtda/graphs/tests/test_geodesic_distance.py
@@ -30,7 +30,7 @@ X_ggd_float = np.array([
               [np.inf, np.inf, np.inf, np.inf, 0.]])
     ])
 X_ggd_float_res = np.array([
-    np.zeros(X_ggd_float[0].shape, dtype=np.float),
+    np.zeros(X_ggd_float[0].shape, dtype=float),
     np.array([[0., 0., 1., 0., np.inf],
               [0., 0., 1., 0., np.inf],
               [1., 1., 0., 1., np.inf],
@@ -51,10 +51,10 @@ X_ggd_bool_res = np.array([[[0., 1., np.inf],
 X_ggd.append((X_ggd_bool, X_ggd_bool_res))
 
 X_ggd_int = [X_ggd_bool[0].astype(int)]
-X_ggd_int_res = np.zeros((1, *X_ggd_int[0].shape), dtype=np.float)
+X_ggd_int_res = np.zeros((1, *X_ggd_int[0].shape), dtype=float)
 X_ggd.append((X_ggd_int, X_ggd_int_res))
 
-x_ggd_float = X_ggd_bool[0].astype(np.float)
+x_ggd_float = X_ggd_bool[0].astype(float)
 X_ggd.append(([x_ggd_float], X_ggd_int_res))
 
 X_ggd.append(

--- a/gtda/homology/cubical.py
+++ b/gtda/homology/cubical.py
@@ -48,8 +48,8 @@ class CubicalPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         ``n_dimensions`` is the dimension of the images of the collection. The
         boolean in the `d`th position expresses whether the boundaries along
         the `d`th axis are periodic. The default ``None`` is equivalent to
-        passing ``numpy.zeros((n_dimensions,), dtype=np.bool)``, i.e. none of
-        the boundaries are periodic.
+        passing ``numpy.zeros((n_dimensions,), dtype=bool)``, i.e. none of the
+        boundaries are periodic.
 
     infinity_values : float or None, default: ``None``
         Which death value to assign to features which are still alive at
@@ -157,11 +157,11 @@ class CubicalPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         if self.periodic_dimensions is None or \
            np.sum(self.periodic_dimensions) == 0:
             self._filtration = CubicalComplex
-            self.periodic_dimensions_ = np.zeros(len(X) - 1, dtype=np.bool)
+            self.periodic_dimensions_ = np.zeros(len(X) - 1, dtype=bool)
         else:
             self._filtration = PeriodicCubicalComplex
             self.periodic_dimensions_ = np.array(self.periodic_dimensions,
-                                                 dtype=np.bool)
+                                                 dtype=bool)
             self._filtration_kwargs['periodic_dimensions'] = \
                 self.periodic_dimensions_
 

--- a/gtda/images/filtrations.py
+++ b/gtda/images/filtrations.py
@@ -1169,7 +1169,7 @@ class DensityFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
             ))
         # The mask is always 3D but not the iterator.
         self.mask_ = np.ones(tuple(2 * self._size + 1 for _ in range(3)),
-                             dtype=np.bool)
+                             dtype=bool)
 
         # Create an iterator for applying the mask to every pixel at once
         iterator_size_list = \

--- a/gtda/images/preprocessing.py
+++ b/gtda/images/preprocessing.py
@@ -267,7 +267,7 @@ class Inverter(BaseEstimator, TransformerMixin, PlotterMixin):
                         exclude=['n_jobs'])
 
         if self.max_value is None:
-            if X.dtype == np.bool:
+            if np.issubdtype(X.dtype, bool):
                 self.max_value_ = True
             else:
                 self.max_value_ = np.max(X)
@@ -431,7 +431,7 @@ class Padder(BaseEstimator, TransformerMixin, PlotterMixin):
                         exclude=['value', 'n_jobs'])
 
         if self.padding is None:
-            self.padding_ = np.ones((self.n_dimensions_,), dtype=np.int)
+            self.padding_ = np.ones((self.n_dimensions_,), dtype=int)
         elif len(self.padding) != self.n_dimensions_:
             raise ValueError(
                 f"`padding` has length {self.padding} while the input "

--- a/gtda/images/tests/test_preprocessing.py
+++ b/gtda/images/tests/test_preprocessing.py
@@ -103,11 +103,11 @@ def test_padder_not_fitted():
 
 
 @pytest.mark.parametrize("images, padding",
-                         [(images_2D, np.array([1, 1], dtype=np.int)),
+                         [(images_2D, np.array([1, 1], dtype=int)),
                           (images_2D, None),
-                          (images_3D, np.array([2, 2, 2], dtype=np.int)),
+                          (images_3D, np.array([2, 2, 2], dtype=int)),
                           (images_3D_float,
-                           np.array([2, 2, 2], dtype=np.int))])
+                           np.array([2, 2, 2], dtype=int))])
 def test_padder_transform(images, padding):
     padder = Padder(padding=padding)
 

--- a/gtda/mapper/cluster.py
+++ b/gtda/mapper/cluster.py
@@ -120,7 +120,7 @@ class ParallelClustering(BaseEstimator):
         X_tot, masks = X
         check_array(X_tot, ensure_2d=True)
         check_array(masks, ensure_2d=True)
-        if masks.dtype != np.bool_:
+        if not np.issubdtype(masks.dtype, bool):
             raise TypeError("`masks` must be a boolean array.")
         if len(X_tot) != len(masks):
             raise ValueError("`X_tot` and `masks` must have the same number "

--- a/gtda/mapper/tests/test_cluster.py
+++ b/gtda/mapper/tests/test_cluster.py
@@ -95,7 +95,7 @@ def test_parallel_clustering_precomputed(n_jobs):
 def get_one_cluster(draw, n_points, dim):
     """Get an array of n_points in a dim-dimensional space, in the
     [-1, 1]-hypercube."""
-    return draw(arrays(dtype=np.float,
+    return draw(arrays(dtype=float,
                        elements=floats(allow_nan=False,
                                        allow_infinity=False,
                                        min_value=-1.,
@@ -107,7 +107,7 @@ def get_one_cluster(draw, n_points, dim):
 def get_clusters(draw, n_clusters, n_points_per_cluster, dim, std=1):
     """Get n_clusters clusters, with n_points_per_cluster points per cluster
     embedded in dim."""
-    positions = np.repeat(draw(arrays(dtype=np.float,
+    positions = np.repeat(draw(arrays(dtype=float,
                                       elements=integers(min_value=-100,
                                                         max_value=100),
                                       shape=(1, dim),

--- a/gtda/mapper/tests/test_cover.py
+++ b/gtda/mapper/tests/test_cover.py
@@ -21,7 +21,7 @@ def get_filter_values(draw, shape=None):
     given, generate a shape of at least (4,)."""
     if shape is None:
         shape = array_shapes(min_dims=1, max_dims=1, min_side=4)
-    return draw(arrays(dtype=np.float,
+    return draw(arrays(dtype=float,
                        elements=floats(allow_nan=False,
                                        allow_infinity=False,
                                        min_value=-1e10,

--- a/gtda/mapper/tests/test_filter.py
+++ b/gtda/mapper/tests/test_filter.py
@@ -16,7 +16,7 @@ from gtda.mapper.utils._list_feature_union import ListFeatureUnion
 from gtda.mapper.utils.decorators import method_to_transform
 
 
-@given(X=arrays(dtype=np.float,
+@given(X=arrays(dtype=float,
                 elements=floats(allow_nan=False,
                                 allow_infinity=False,
                                 min_value=-1e3,
@@ -30,7 +30,7 @@ def test_eccentricity_shape_equals_number_of_samples(X, exponent):
     assert Xt.shape == (len(X), 1)
 
 
-@given(X=arrays(dtype=np.float,
+@given(X=arrays(dtype=float,
                 elements=floats(allow_nan=False,
                                 allow_infinity=False,
                                 min_value=-1e3,
@@ -43,7 +43,7 @@ def test_eccentricity_values_with_infinity_norm_equals_max_row_values(X):
     assert_almost_equal(Xt, np.max(distance_matrix, axis=1).reshape(-1, 1))
 
 
-@given(X=arrays(dtype=np.float,
+@given(X=arrays(dtype=float,
                 elements=floats(allow_nan=False,
                                 allow_infinity=False,
                                 min_value=-1e3,
@@ -62,7 +62,7 @@ def test_entropy_values_for_negative_inputs(X):
     assert_almost_equal(Xt, entropies[:, None])
 
 
-@given(X=arrays(dtype=np.float,
+@given(X=arrays(dtype=float,
                 elements=floats(allow_nan=False,
                                 allow_infinity=False,
                                 min_value=1,
@@ -79,7 +79,7 @@ def test_entropy_values_for_positive_inputs(X):
     assert_almost_equal(Xt, entropies[:, None])
 
 
-@given(X=arrays(dtype=np.float,
+@given(X=arrays(dtype=float,
                 elements=floats(allow_nan=False,
                                 allow_infinity=False,
                                 min_value=-1e3,
@@ -93,7 +93,7 @@ def test_projection_values_equal_slice(X):
     assert_almost_equal(Xt, X[:, columns])
 
 
-@given(X=arrays(dtype=np.float,
+@given(X=arrays(dtype=float,
                 elements=floats(allow_nan=False,
                                 allow_infinity=False,
                                 min_value=1,
@@ -111,7 +111,7 @@ def test_gaussian_density_values(X):
     assert_almost_equal(Xt_actual, Xt_desired)
 
 
-@given(X=arrays(dtype=np.float,
+@given(X=arrays(dtype=float,
                 elements=floats(allow_nan=False,
                                 allow_infinity=False,
                                 min_value=1,
@@ -133,7 +133,7 @@ def test_list_feature_union_transform(X):
     assert_almost_equal(x_12, x_1_2)
 
 
-@given(X=arrays(dtype=np.float,
+@given(X=arrays(dtype=float,
                 elements=floats(allow_nan=False,
                                 allow_infinity=False,
                                 min_value=1,

--- a/gtda/mapper/tests/test_nerve.py
+++ b/gtda/mapper/tests/test_nerve.py
@@ -13,7 +13,7 @@ from gtda.mapper import Projection, OneDimensionalCover, make_mapper_pipeline
 
 
 @settings(deadline=5000)
-@given(X=arrays(dtype=np.float, unique=True,
+@given(X=arrays(dtype=float, unique=True,
                 elements=floats(allow_nan=False,
                                 allow_infinity=False,
                                 min_value=-1e6,
@@ -38,7 +38,7 @@ def test_node_intersection(X):
 
 
 @settings(deadline=5000)
-@given(X=arrays(dtype=np.float, unique=True,
+@given(X=arrays(dtype=float, unique=True,
                 elements=floats(allow_nan=False,
                                 allow_infinity=False,
                                 min_value=-1e6,
@@ -91,7 +91,7 @@ def test_edge_elements(X):
 
 @settings(deadline=5000)
 @pytest.mark.parametrize("min_intersection", [1, 2, 3, 10])
-@given(X=arrays(dtype=np.float, unique=True,
+@given(X=arrays(dtype=float, unique=True,
                 elements=floats(allow_nan=False,
                                 allow_infinity=False,
                                 min_value=-1e6,

--- a/gtda/mapper/utils/_visualization.py
+++ b/gtda/mapper/utils/_visualization.py
@@ -365,9 +365,9 @@ def _get_colors_for_vals(vals, vmin, vmax, colorscale, return_hex=True):
 
     if colors[0][:3] == "rgb":
         colors = np.asarray([literal_eval(color[3:]) for color in colors],
-                            dtype=np.float_)
+                            dtype=float)
     elif colors[0][0] == "#":
-        colors = np.asarray(list(map(_hex_to_rgb, colors)), dtype=np.float_)
+        colors = np.asarray(list(map(_hex_to_rgb, colors)), dtype=float)
     else:
         raise ValueError("This colorscale is not supported.")
 


### PR DESCRIPTION
**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
Starting with `numpy` 1.20, `np.int`, `np.float` and `np.bool` should be replaced by the Python builtin counterparts.

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.