### PR TITLE
Don't display returned diagrams in `plotting_api` notebook

### DIFF
--- a/examples/plotting_api.ipynb
+++ b/examples/plotting_api.ipynb
@@ -174,7 +174,7 @@
    "source": [
     "VR = VietorisRipsPersistence()\n",
     "VR.fit(X)\n",
-    "VR.transform_plot(X, sample=i);"
+    "Xt = VR.transform_plot(X, sample=i);"
    ]
   },
   {
@@ -195,7 +195,7 @@
    "outputs": [],
    "source": [
     "VR = VietorisRipsPersistence()\n",
-    "VR.fit_transform_plot(X, sample=i);"
+    "Xt = VR.fit_transform_plot(X, sample=i);"
    ]
   }
  ],
@@ -215,7 +215,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
**Reference issues/PRs**
None.

**Types of changes**
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
In [section 2 of `examples/plotting_api.ipynb` notebook](https://giotto-ai.github.io/gtda-docs/0.3.1/notebooks/plotting_api.html#transform-plot), the huge diagrams are returned. This is a suggestion for compactifying the output. I am not sure if we prefer it (over keeping the notebook as is), so what this pr really does is ask a question :smile: .

**Screenshots (if appropriate)**
![image](https://user-images.githubusercontent.com/32167173/111675875-e3ab1000-881d-11eb-9b91-4791a1246f24.png)

**Any other comments?**

**Checklist**
<!--
Go over all the following points, and put an `x` in all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [X] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [X] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. I used `pytest` to check this on Python tests.