### PR TITLE
[CI] Fix broken CI after update of images to remove boost

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -268,6 +268,13 @@ jobs:
     condition: eq(variables.nightlyRelease, true)
     displayName: 'Change name to giotto-tda-nightly'
 
+  - name: install boost
+    run: |
+      # Use the boost_1_72_0-msvc-14.1-64.exe for Windows 2016
+      $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe"
+      (New-Object System.Net.WebClient).DownloadFile($Url, "$env:TEMP\boost.exe")
+      Start-Process -Wait -FilePath "$env:TEMP\boost.exe" "/SILENT","/SP-","/SUPPRESSMSGBOXES","/DIR=C:\hostedtoolcache\windows\Boost\1.72.0\x86_64"
+
   # Set BOOST_ROOT_PIPELINE to the version used in the pipeline
   # See https://github.com/actions/virtual-environments/issues/687#issuecomment-616345933
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -276,7 +276,7 @@ jobs:
       $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe"
       (New-Object System.Net.WebClient).DownloadFile($Url, "$env:TEMP\boost.exe")
       Start-Process -Wait -FilePath "$env:TEMP\boost.exe" "/SILENT","/SP-","/SUPPRESSMSGBOXES","/DIR=C:\hostedtoolcache\windows\Boost\1.72.0\x86_64"
-    displayName: 'install boost'
+    displayName: 'Install boost'
 
   # Set BOOST_ROOT_PIPELINE to the version used in the pipeline
   # See https://github.com/actions/virtual-environments/issues/687#issuecomment-616345933

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -270,7 +270,7 @@ jobs:
 
   # Use the boost_1_72_0-msvc-14.1-64.exe for Windows 2016
   # Following issue https://github.com/actions/virtual-environments/issues/2667
-  # Now it necessary to download manually Boost, great work ! ...
+  # As of March 2021, it is necessary to download Boost manually
   # DIR: installation dir, this value need to be forwarded to BOOST_ROOT_PIPELINE
   - powershell: |
       $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -268,8 +268,8 @@ jobs:
     condition: eq(variables.nightlyRelease, true)
     displayName: 'Change name to giotto-tda-nightly'
 
-  - script: |
-      # Use the boost_1_72_0-msvc-14.1-64.exe for Windows 2016
+  # Use the boost_1_72_0-msvc-14.1-64.exe for Windows 2016
+  - powershell: |
       $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe"
       (New-Object System.Net.WebClient).DownloadFile($Url, "$env:TEMP\boost.exe")
       Start-Process -Wait -FilePath "$env:TEMP\boost.exe" "/SILENT","/SP-","/SUPPRESSMSGBOXES","/DIR=C:\hostedtoolcache\windows\Boost\1.72.0\x86_64"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -268,12 +268,12 @@ jobs:
     condition: eq(variables.nightlyRelease, true)
     displayName: 'Change name to giotto-tda-nightly'
 
-  - name: install boost
-    run: |
+  - script: |
       # Use the boost_1_72_0-msvc-14.1-64.exe for Windows 2016
       $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe"
       (New-Object System.Net.WebClient).DownloadFile($Url, "$env:TEMP\boost.exe")
       Start-Process -Wait -FilePath "$env:TEMP\boost.exe" "/SILENT","/SP-","/SUPPRESSMSGBOXES","/DIR=C:\hostedtoolcache\windows\Boost\1.72.0\x86_64"
+    displayName: 'install boost'
 
   # Set BOOST_ROOT_PIPELINE to the version used in the pipeline
   # See https://github.com/actions/virtual-environments/issues/687#issuecomment-616345933

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -269,6 +269,9 @@ jobs:
     displayName: 'Change name to giotto-tda-nightly'
 
   # Use the boost_1_72_0-msvc-14.1-64.exe for Windows 2016
+  # Following issue https://github.com/actions/virtual-environments/issues/2667
+  # Now it necessary to download manually Boost, great work ! ...
+  # DIR: installation dir, this value need to be forwarded to BOOST_ROOT_PIPELINE
   - powershell: |
       $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe"
       (New-Object System.Net.WebClient).DownloadFile($Url, "$env:TEMP\boost.exe")

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -278,7 +278,7 @@ jobs:
   # Set BOOST_ROOT_PIPELINE to the version used in the pipeline
   # See https://github.com/actions/virtual-environments/issues/687#issuecomment-616345933
   - script: |
-      echo "##vso[task.setvariable variable=BOOST_ROOT_PIPELINE]%BOOST_ROOT_1_72_0%"
+      echo "##vso[task.setvariable variable=BOOST_ROOT_PIPELINE]C:\hostedtoolcache\windows\Boost\1.72.0\x86_64"
     displayName: 'Set env variable for boost version'
 
   - script: |


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the guidelines for contributing: https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines
-->

**Reference issues/PRs**
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.

Pull requests which are not related to open issues may be rejected!
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

No issue created, but CI reported fails on Windows.
See See https://github.com/actions/virtual-environments/issues/2667

**Types of changes**
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
<!--
Describe your changes in detail.
-->

See https://github.com/actions/virtual-environments/issues/2667
Azure pipeline removed embedded support to Boost.
Right now our Windows pipelines are failing, this PR fixes the issue by downloading a local version

**Screenshots (if appropriate)**

**Any other comments?**

**Checklist**
<!--
Go over all the following points, and put an `x` in all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [ ] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. I used `pytest` to check this on Python tests.

<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
