### PR TITLE
[CI] Migrate to ubuntu-latest Azure environment

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ jobs:
 
 - job: 'manylinux2010'
   pool:
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-latest'
   strategy:
     matrix:
       Python36:


### PR DESCRIPTION
Following deprecation notice and announcement of removal in September 2021. See https://github.com/actions/virtual-environments/issues/3287
