### PR TITLE
Update parameter validation to treat the case where "of" is None

### DIFF
--- a/gtda/homology/tests/test_simplicial.py
+++ b/gtda/homology/tests/test_simplicial.py
@@ -132,8 +132,8 @@ def test_wrp_params():
 
 
 def test_wrp_metric_params():
-    def metric(x, y, parameter):
-        return np.linalg.norm(x-y)
+    def metric(x, y, **kwargs):
+        return np.linalg.norm(x - y)
 
     metric_params = {"parameter": 0.}
     wrp = WeightedRipsPersistence(metric=metric, metric_params=metric_params)

--- a/gtda/homology/tests/test_simplicial.py
+++ b/gtda/homology/tests/test_simplicial.py
@@ -134,7 +134,7 @@ def test_wrp_params():
 def test_wrp_metric_params():
     def metric(x, y, parameter):
         return np.linalg.norm(x-y)
-    
+
     metric_params = {"parameter": 0.}
     wrp = WeightedRipsPersistence(metric=metric, metric_params=metric_params)
     wrp.fit_transform(X_pc)

--- a/gtda/homology/tests/test_simplicial.py
+++ b/gtda/homology/tests/test_simplicial.py
@@ -131,6 +131,15 @@ def test_wrp_params():
         wrp.fit_transform(X_pc)
 
 
+def test_wrp_metric_params():
+    def metric(x, y, parameter):
+        return np.linalg.norm(x-y)
+    
+    metric_params = {"parameter": 0.}
+    wrp = WeightedRipsPersistence(metric=metric, metric_params=metric_params)
+    wrp.fit_transform(X_pc)
+
+
 def test_wrp_not_fitted():
     wrp = WeightedRipsPersistence()
 

--- a/gtda/utils/validation.py
+++ b/gtda/utils/validation.py
@@ -138,7 +138,8 @@ def _validate_params(parameters, references, rec_name=None):
         ref_type = _validate_params_single(parameter, reference, name)
         if ref_type:
             ref_of = reference.get('of', None)
-            if ref_of is None:  # if ref_of is None, the elements are not to be validated
+            if ref_of is None:
+                # if ref_of is None, the elements are not to be validated
                 continue
             elif ref_type == dict:
                 _validate_params(parameter, ref_of, rec_name=name)

--- a/gtda/utils/validation.py
+++ b/gtda/utils/validation.py
@@ -138,7 +138,9 @@ def _validate_params(parameters, references, rec_name=None):
         ref_type = _validate_params_single(parameter, reference, name)
         if ref_type:
             ref_of = reference.get('of', None)
-            if ref_type == dict:
+            if ref_of is None:  # if ref_of is None, the elements are not to be validated
+                continue
+            elif ref_type == dict:
                 _validate_params(parameter, ref_of, rec_name=name)
             else:  # List, tuple or ndarray type
                 for i, parameter_elem in enumerate(parameter):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the guidelines for contributing: https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines
-->

**Reference issues/PRs**
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.

Pull requests which are not related to open issues may be rejected!
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

**Types of changes**
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
The bug #589 is caused by the fact that the validation is attempted, even thought `ref_of` is `None`.

**Screenshots (if appropriate)**

**Any other comments?**

**Checklist**
<!--
Go over all the following points, and put an `x` in all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. I used `pytest` to check this on Python tests.

<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
