### PR TITLE
Change the default weight_params in WeightedRips

### DIFF
--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -432,7 +432,7 @@ class WeightedRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         is a parameter (see `weight_params`). If a callable, it must return
         non-negative 1D arrays.
 
-    weight_params : dict, optional, default: ``None``
+    weight_params : dict, optional, default: ``{}``
         Additional parameters for the weighted filtration. ``"p"`` determines
         the power to be used in computing edge weights from vertex weights. It
         can be one of ``1``, ``2`` or ``np.inf`` and defaults to ``1``. If
@@ -525,7 +525,7 @@ class WeightedRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             "of": {"type": int, "in": Interval(0, np.inf, closed="left")}
             },
         "weights": {"type": (str, FunctionType)},
-        "weight_params": {"type": (dict, type(None))},
+        "weight_params": {"type": dict},
         "collapse_edges": {"type": bool},
         "coeff": {"type": int, "in": Interval(2, np.inf, closed="left")},
         "max_edge_weight": {"type": Real},
@@ -534,7 +534,7 @@ class WeightedRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         }
 
     def __init__(self, metric="euclidean", metric_params={},
-                 homology_dimensions=(0, 1), weights="DTM", weight_params=None,
+                 homology_dimensions=(0, 1), weights="DTM", weight_params={},
                  collapse_edges=False, coeff=2, max_edge_weight=np.inf,
                  infinity_values=None, reduced_homology=True, n_jobs=None):
         self.metric = metric

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -616,7 +616,7 @@ class WeightedRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
             self.effective_weight_params_.update({"n_neighbors": 3, "r": 2})
         else:
             key = "general"
-        if self.weight_params is not None:
+        if self.weight_params:
             self.effective_weight_params_.update(self.weight_params)
             validate_params(self.effective_weight_params_,
                             _AVAILABLE_RIPS_WEIGHTS[key])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the guidelines for contributing: https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines
-->

**Reference issues/PRs**
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.

Pull requests which are not related to open issues may be rejected!
If suggesting a new feature or change, please discuss it in an issue first.
If fixing a bug, there should be an issue describing it with steps to reproduce.
-->

**Types of changes**
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
<!--
Describe your changes in detail.
-->
Close #594 
**Screenshots (if appropriate)**

**Any other comments?**

**Checklist**
<!--
Go over all the following points, and put an `x` in all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. I used `pytest` to check this on Python tests.

<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
