### PR TITLE
[CI] Remove workarounds for solved Homebrew issues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '"ccache-wheels-v2021.07.09" | $(Agent.OS) | "$(python.version)"'
+      key: '"ccache-wheels-v2021.07.27" | $(Agent.OS) | "$(python.version)"'
       path: $(CCACHE_DIR)
     displayName: ccache
 
@@ -146,7 +146,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '"ccache-v2021.07.09" | $(Agent.OS) | "$(python.version)"'
+      key: '"ccache-v2021.07.27" | $(Agent.OS) | "$(python.version)"'
       path: $(CCACHE_DIR)
     displayName: ccache
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -152,11 +152,7 @@ jobs:
 
   # Python and gcc hotfixes following https://github.com/actions/virtual-environments/issues/2322 and https://github.com/actions/virtual-environments/issues/2391
   - script: |
-      set -e
-      brew update
-      rm '/usr/local/bin/2to3'
-      brew unlink gcc@8 && brew unlink gcc@9
-      brew upgrade      
+      set -e      
       brew install boost ccache
     displayName: 'Install system dependencies'
 


### PR DESCRIPTION
Thanks to issues with brew and Azure now solved in [brew upgrade fails on gcc actions/virtual-environments#2391](https://github.com/actions/virtual-environments/issues/2391) and in [brew upgrade fails for Python's 2to3 conflict  actions/virtual-environments#2322](https://github.com/actions/virtual-environments/issues/2322), we no longer needs some of the workarounds used in the macOS jobs.

See #554, and related issues therein.