### PR TITLE
Replace python-igraph requirement with igraph >= 0.9.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ joblib >= 0.16.0
 scikit-learn >= 0.23.1
 giotto-ph >= 0.2.1
 pyflagser >= 0.4.3
-python-igraph >= 0.8.2
+igraph >= 0.9.8
 plotly >= 4.8.2
 ipywidgets >= 7.5.1


### PR DESCRIPTION
`python-igraph` is deprecated as described in https://pypi.org/project/python-igraph/, so we should attempt to depend on `igraph` as described there.  Hopefully this is OK in all Python versions we support.

