### PR TITLE
[MNT] Remove support for Python 3.6, update Windows & macOS VMs, bump manylinux image to manylinux2014

### DIFF
--- a/.azure-ci/build_manylinux2014.sh
+++ b/.azure-ci/build_manylinux2014.sh
@@ -3,5 +3,5 @@ set -e
 docker run -t --rm -e python_ver=$PYTHON_VER \
 	-v `pwd`:/io \
 	-v "${CCACHE_DIR}":/root/.ccache/  \
-	quay.io/pypa/manylinux2010_x86_64 \
+	quay.io/pypa/manylinux2014_x86_64 \
 	/bin/bash -c "bash /io/.azure-ci/docker_scripts.sh"

--- a/.azure-ci/docker_scripts.sh
+++ b/.azure-ci/docker_scripts.sh
@@ -35,6 +35,7 @@ export BOOST_ROOT=/boost
 export Boost_INCLUDE_DIR=/boost/include
 
 # Install dev environment
+git config --global --add safe.directory /io
 cd /io
 pip install wheel
 pip install -e ".[dev]"

--- a/.azure-ci/docker_scripts.sh
+++ b/.azure-ci/docker_scripts.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 set -x
-echo "Start manylinux2010 docker build"
+echo "Start manylinux2014 docker build"
 
 # Upgrade pip and setuptools. TODO: Monitor status of pip versions
 PYTHON_PATH=$(eval find "/opt/python/*cp${python_ver}*" -print)
@@ -52,5 +52,5 @@ python setup.py bdist_wheel
 # Repair wheels with auditwheel
 pip install auditwheel
 auditwheel repair dist/*whl -w dist/
-# remove wheels that are not manylinux2010
+# remove wheels that are not manylinux2014
 rm -rf dist/*-linux*.whl

--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Dependencies
 
 The latest stable version of ``giotto-tda`` requires:
 
-- Python (>= 3.6)
+- Python (>= 3.7)
 - NumPy (>= 1.19.1)
 - SciPy (>= 1.5.0)
 - joblib (>= 0.16.0)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '"ccache-wheels-v2021.12.29" | $(Agent.OS) | "$(python.version)"'
+      key: '"ccache-wheels-v2022.7.22" | $(Agent.OS) | "$(python.version)"'
       path: $(CCACHE_DIR)
     displayName: ccache
 
@@ -139,7 +139,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '"ccache-v2021.12.29" | $(Agent.OS) | "$(python.version)"'
+      key: '"ccache-v2022.7.22" | $(Agent.OS) | "$(python.version)"'
       path: $(CCACHE_DIR)
     displayName: ccache
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,11 +16,6 @@ jobs:
     vmImage: 'ubuntu-latest'
   strategy:
     matrix:
-      Python36:
-        arch: x86_64
-        plat: manylinux2010_x86_64
-        python_ver: '36'
-        python.version: '3.6'
       Python37:
         arch: x86_64
         plat: manylinux2010_x86_64
@@ -118,8 +113,6 @@ jobs:
     vmImage: 'macOS-10.15'
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
       Python37:
         python.version: '3.7'
       Python38:
@@ -239,9 +232,6 @@ jobs:
     vmImage: 'vs2017-win2016'
   strategy:
     matrix:
-      Python36:
-        python_ver: '36'
-        python.version: '3.6'
       Python37:
         python_ver: '37'
         python.version: '3.7'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -227,9 +227,9 @@ jobs:
     displayName: 'Upload nightly wheels to PyPI'
 
 
-- job: 'win2016'
+- job: 'windows'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-latest'
   strategy:
     matrix:
       Python37:
@@ -254,7 +254,7 @@ jobs:
     condition: eq(variables.nightlyRelease, true)
     displayName: 'Change name to giotto-tda-nightly'
 
-  # Use the boost_1_72_0-msvc-14.1-64.exe for Windows 2016
+  # Use the boost_1_72_0-msvc-14.1-64.exe for windows-latest
   # Following issue https://github.com/actions/virtual-environments/issues/2667
   # As of March 2021, it is necessary to download Boost manually
   # DIR: installation dir, this value need to be forwarded to BOOST_ROOT_PIPELINE

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,9 +108,9 @@ jobs:
     displayName: 'Upload nightly wheels to PyPI'
 
 
-- job: 'macOS1015'
+- job: 'macOS11'
   pool:
-    vmImage: 'macOS-10.15'
+    vmImage: 'macOS-11'
   strategy:
     matrix:
       Python37:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '"ccache-wheels-v2022.7.22" | $(Agent.OS) | "$(python.version)"'
+      key: '"ccache-wheels-v2022.7.29" | $(Agent.OS) | "$(python.version)"'
       path: $(CCACHE_DIR)
     displayName: ccache
 
@@ -139,7 +139,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '"ccache-v2022.7.22" | $(Agent.OS) | "$(python.version)"'
+      key: '"ccache-v2022.7.29" | $(Agent.OS) | "$(python.version)"'
       path: $(CCACHE_DIR)
     displayName: ccache
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,24 +11,24 @@ pr:
 
 jobs:
 
-- job: 'manylinux2010'
+- job: 'manylinux2014'
   pool:
     vmImage: 'ubuntu-latest'
   strategy:
     matrix:
       Python37:
         arch: x86_64
-        plat: manylinux2010_x86_64
+        plat: manylinux2014_x86_64
         python_ver: '37'
         python.version: '3.7'
       Python38:
         arch: x86_64
-        plat: manylinux2010_x86_64
+        plat: manylinux2014_x86_64
         python_ver: '38'
         python.version: '3.8'
       Python39:
         arch: x86_64
-        plat: manylinux2010_x86_64
+        plat: manylinux2014_x86_64
         python_ver: '39'
         python.version: '3.9'
   variables:
@@ -55,7 +55,7 @@ jobs:
 
   - task: Bash@3
     inputs:
-      filePath: .azure-ci/build_manylinux2010.sh
+      filePath: .azure-ci/build_manylinux2014.sh
     env:
       python_ver: $(python_ver)
       CCACHE_DIR: $(CCACHE_DIR)
@@ -64,7 +64,7 @@ jobs:
   - script: |
       set -e
       python -m pip install --upgrade pip
-      python -m pip install dist/*manylinux2010*.whl
+      python -m pip install dist/*manylinux2014*.whl
     displayName: 'Install the wheels'
 
   - script: |
@@ -103,7 +103,7 @@ jobs:
   - bash: |
       set -e
       python -m pip install twine
-      twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*manylinux2010*.whl
+      twine upload -u giotto-learn -p $(pypi_psw) --skip-existing dist/*manylinux2014*.whl
     condition: eq(variables.nightlyRelease, true)
     displayName: 'Upload nightly wheels to PyPI'
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -10,7 +10,7 @@ Dependencies
 
 The latest stable version of ``giotto-tda`` requires:
 
-- Python (>= 3.6)
+- Python (>= 3.7)
 - NumPy (>= 1.19.1)
 - SciPy (>= 1.5.0)
 - joblib (>= 0.16.0)

--- a/gtda/homology/tests/test_simplicial.py
+++ b/gtda/homology/tests/test_simplicial.py
@@ -7,7 +7,7 @@ import pytest
 from numpy.testing import assert_almost_equal
 from scipy.sparse import csr_matrix
 from scipy.spatial.distance import pdist, squareform
-from scipy.spatial.qhull import QhullError
+from scipy.spatial import QhullError
 from sklearn.exceptions import NotFittedError
 
 from gtda.homology import VietorisRipsPersistence, WeightedRipsPersistence, \

--- a/gtda/homology/tests/test_simplicial.py
+++ b/gtda/homology/tests/test_simplicial.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_almost_equal
 from scipy.sparse import csr_matrix
 from scipy.spatial.distance import pdist, squareform
 try:
-    from scipy.spatial import QhullError
+    from scipy.spatial import QHullError
 except ImportError:
     from scipy.spatial.qhull import QHullError
 from sklearn.exceptions import NotFittedError

--- a/gtda/homology/tests/test_simplicial.py
+++ b/gtda/homology/tests/test_simplicial.py
@@ -8,9 +8,9 @@ from numpy.testing import assert_almost_equal
 from scipy.sparse import csr_matrix
 from scipy.spatial.distance import pdist, squareform
 try:
-    from scipy.spatial import QHullError
+    from scipy.spatial import QhullError
 except ImportError:
-    from scipy.spatial.qhull import QHullError
+    from scipy.spatial.qhull import QhullError
 from sklearn.exceptions import NotFittedError
 
 from gtda.homology import VietorisRipsPersistence, WeightedRipsPersistence, \

--- a/gtda/homology/tests/test_simplicial.py
+++ b/gtda/homology/tests/test_simplicial.py
@@ -7,7 +7,10 @@ import pytest
 from numpy.testing import assert_almost_equal
 from scipy.sparse import csr_matrix
 from scipy.spatial.distance import pdist, squareform
-from scipy.spatial import QhullError
+try:
+    from scipy.spatial import QhullError
+except ImportError:
+    from scipy.spatial.qhull import QHullError
 from sklearn.exceptions import NotFittedError
 
 from gtda.homology import VietorisRipsPersistence, WeightedRipsPersistence, \

--- a/gtda/tests/test_common.py
+++ b/gtda/tests/test_common.py
@@ -9,8 +9,8 @@ from gtda.images.preprocessing import Binarizer, Inverter
 
 # mark checks to skip
 SKIP_TESTS = {
-    "Binarizer":  ["check_transformer_preserve_dtypes"],
-    "Inverter":  [],
+    "Binarizer":  ["check_transformer_preserve_dtypes", "check_n_features_in"],
+    "Inverter":  ["check_n_features_in"],
     }
 
 # mark tests as a known failure

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ CLASSIFIERS = ["Intended Audience :: Science/Research",
                "Operating System :: POSIX",
                "Operating System :: Unix",
                "Operating System :: MacOS",
-               "Programming Language :: Python :: 3.6",
                "Programming Language :: Python :: 3.7",
                "Programming Language :: Python :: 3.8",
                "Programming Language :: Python :: 3.9"]


### PR DESCRIPTION
The time has come to end support for Python 3.6.  In fact, this was long overdue.  The userbase still on Python 3.6 is almost surely insignificant, and we need to concentrate efforts on shipping for Python 3.10 and ARM architectures, which will considerably increase the CI burden.

In passing, I am updating the Windows and macOS VMs on Azure as follows:
- [[MNT] Replace vs2017-win2016 VM with windows-latest](https://github.com/giotto-ai/giotto-tda/pull/636/commits/8608d37ec4957d38bc66f1388e6de55d9f55c56e) as win2016 is deprecated
- [[MNT] Migrate to macOS 11 VM as macOS 10.5 is deprecated](https://github.com/giotto-ai/giotto-tda/pull/636/commits/76e48ac2269914f82693562a75a5fbe6f62c7c3b)
- [[CI] Replace manylinux2010 with manylinux2014](https://github.com/giotto-ai/giotto-tda/pull/636/commits/5fdda8cb47db66a9bf81d8899ed4f2f56481bdc6) since SciPy does not support manylinux2010 in 1.8 (see https://github.com/scikit-learn/scikit-learn/pull/23121)
- [[Tests] Skip "check_n_features_in" in test_common](https://github.com/giotto-ai/giotto-tda/pull/636/commits/b44799a48bed29ef87b8e89da4861075ec6833cc) -- recent versions of `scikit-learn` require that the `n_features_in_` be defined in the `fit` method, but `Binarizer` and `Inverter` do not (and they shouldn't necessarily do so).