### PR TITLE
Make Mapper visualization tests compatible with ipywidgets 8.0.0

### DIFF
--- a/gtda/mapper/tests/test_visualization.py
+++ b/gtda/mapper/tests/test_visualization.py
@@ -2,12 +2,12 @@
 # License: GNU AGPLv3
 
 from packaging.version import parse
-from importlib.metadata import version
 
 from unittest import TestCase
 
 import numpy as np
 import pandas as pd
+import ipywidgets
 import plotly.io as pio
 import pytest
 from numpy.testing import assert_almost_equal
@@ -18,7 +18,7 @@ from gtda.mapper import FirstSimpleGap, CubicalCover, make_mapper_pipeline, \
     MapperInteractivePlotter
 
 
-ipywidgets_vers = version("ipywidgets")
+ipywidgets_vers = ipywidgets.__version__
 # Needed as the "widgets" attribute was privatised in ipywidgets 8.0.0
 # (see https://github.com/jupyter-widgets/ipywidgets/pull/3122/files)
 if parse(ipywidgets_vers) < parse("8.0.0"):

--- a/gtda/mapper/tests/test_visualization.py
+++ b/gtda/mapper/tests/test_visualization.py
@@ -3,13 +3,6 @@
 
 from packaging.version import parse
 from importlib.metadata import version
-ipywidgets_vers = version("ipywidgets")
-# Needed as the "widgets" attribute was privatised in ipywidgets 8.0.0
-# (see https://github.com/jupyter-widgets/ipywidgets/pull/3122/files)
-if parse(ipywidgets_vers) < parse("8.0.0"):
-    widgets_attr = "widgets"
-else:
-    widgets_attr = "_active_widgets"
 
 from unittest import TestCase
 
@@ -23,6 +16,15 @@ from sklearn.decomposition import PCA
 from gtda.mapper import FirstSimpleGap, CubicalCover, make_mapper_pipeline, \
     plot_static_mapper_graph, plot_interactive_mapper_graph, \
     MapperInteractivePlotter
+
+
+ipywidgets_vers = version("ipywidgets")
+# Needed as the "widgets" attribute was privatised in ipywidgets 8.0.0
+# (see https://github.com/jupyter-widgets/ipywidgets/pull/3122/files)
+if parse(ipywidgets_vers) < parse("8.0.0"):
+    widgets_attr = "widgets"
+else:
+    widgets_attr = "_active_widgets"
 
 
 class TestCaseNoTemplate(TestCase):

--- a/gtda/mapper/tests/test_visualization.py
+++ b/gtda/mapper/tests/test_visualization.py
@@ -2,8 +2,8 @@
 # License: GNU AGPLv3
 
 from packaging import version
-from importlib import metadata
-ipywidgets_vers = metadata.version("ipywidgets")
+import importlib
+ipywidgets_vers = importlib.metadata.version("ipywidgets")
 # Needed as the "widgets" attribute was privatised in ipywidgets 8.0.0
 # (see https://github.com/jupyter-widgets/ipywidgets/pull/3122/files)
 if version.parse(ipywidgets_vers) < version.parse("8.0.0"):

--- a/gtda/mapper/tests/test_visualization.py
+++ b/gtda/mapper/tests/test_visualization.py
@@ -1,6 +1,16 @@
 """Testing for Mapper plotting functions."""
 # License: GNU AGPLv3
 
+from packaging import version
+from importlib import metadata
+ipywidgets_vers = metadata.version("ipywidgets")
+# Needed as the "widgets" attribute was privatised in ipywidgets 8.0.0
+# (see https://github.com/jupyter-widgets/ipywidgets/pull/3122/files)
+if version.parse(ipywidgets_vers) < version.parse("8.0.0"):
+    widgets_attr = "widgets"
+else:
+    widgets_attr = "_active_widgets"
+
 from unittest import TestCase
 
 import numpy as np
@@ -321,7 +331,7 @@ def _get_widgets_by_trait(fig, key, val=None):
     """Returns a list of widgets containing attribute `key` which currently
     evaluates to the value `val`."""
     widgets = []
-    for k, v in fig.widgets.items():
+    for k, v in fig.getattr(widgets_attr).items():
         try:
             b = getattr(v, key) == val if val is not None else getattr(v, key)
             if b:

--- a/gtda/mapper/tests/test_visualization.py
+++ b/gtda/mapper/tests/test_visualization.py
@@ -1,12 +1,12 @@
 """Testing for Mapper plotting functions."""
 # License: GNU AGPLv3
 
-from packaging import version
-import importlib
-ipywidgets_vers = importlib.metadata.version("ipywidgets")
+from packaging.version import parse
+from importlib.metadata import version
+ipywidgets_vers = version("ipywidgets")
 # Needed as the "widgets" attribute was privatised in ipywidgets 8.0.0
 # (see https://github.com/jupyter-widgets/ipywidgets/pull/3122/files)
-if version.parse(ipywidgets_vers) < version.parse("8.0.0"):
+if parse(ipywidgets_vers) < parse("8.0.0"):
     widgets_attr = "widgets"
 else:
     widgets_attr = "_active_widgets"

--- a/gtda/mapper/tests/test_visualization.py
+++ b/gtda/mapper/tests/test_visualization.py
@@ -331,7 +331,7 @@ def _get_widgets_by_trait(fig, key, val=None):
     """Returns a list of widgets containing attribute `key` which currently
     evaluates to the value `val`."""
     widgets = []
-    for k, v in fig.getattr(widgets_attr).items():
+    for k, v in getattr(fig, widgets_attr).items():
         try:
             b = getattr(v, key) == val if val is not None else getattr(v, key)
             if b:


### PR DESCRIPTION
Needed as the "widgets" attribute was privatised in ipywidgets 8.0.0 (see https://github.com/jupyter-widgets/ipywidgets/pull/3122/files)