### PR TITLE
Add Python 3.10 (to Azure pipelines)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '"ccache-wheels-v2022.7.29" | $(Agent.OS) | "$(python.version)"'
+      key: '"ccache-wheels-v2022.8.25" | $(Agent.OS) | "$(python.version)"'
       path: $(CCACHE_DIR)
     displayName: ccache
 
@@ -148,7 +148,7 @@ jobs:
 
   - task: Cache@2
     inputs:
-      key: '"ccache-v2022.7.29" | $(Agent.OS) | "$(python.version)"'
+      key: '"ccache-v2022.8.25" | $(Agent.OS) | "$(python.version)"'
       path: $(CCACHE_DIR)
     displayName: ccache
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,6 +31,11 @@ jobs:
         plat: manylinux2014_x86_64
         python_ver: '39'
         python.version: '3.9'
+      Python310:
+        arch: x86_64
+        plat: manylinux2014_x86_64
+        python_ver: '310'
+        python.version: '3.10'
   variables:
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
 
@@ -121,6 +126,8 @@ jobs:
         python.version: '3.8'
       Python39:
         python.version: '3.9'
+      Python310:
+        python.version: '3.10'
   variables:
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
 
@@ -244,6 +251,8 @@ jobs:
         python.version: '3.8'
       Python39:
         python.version: '3.9'
+      Python310:
+        python.version: '3.10'
 
   steps:
   - task: UsePythonVersion@0

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,8 @@ MAINTAINER = "Umberto Lupo, Wojciech Reise"
 MAINTAINER_EMAIL = "maintainers@giotto.ai"
 URL = "https://github.com/giotto-ai/giotto-tda"
 LICENSE = "GNU AGPLv3"
-DOWNLOAD_URL = "https://github.com/giotto-ai/giotto-tda/tarball/v0.5.1"
 VERSION = __version__  # noqa
+DOWNLOAD_URL = f"https://github.com/giotto-ai/giotto-tda/tarball/v{VERSION}"
 CLASSIFIERS = ["Intended Audience :: Science/Research",
                "Intended Audience :: Developers",
                "License :: OSI Approved",
@@ -44,7 +44,8 @@ CLASSIFIERS = ["Intended Audience :: Science/Research",
                "Operating System :: MacOS",
                "Programming Language :: Python :: 3.7",
                "Programming Language :: Python :: 3.8",
-               "Programming Language :: Python :: 3.9"]
+               "Programming Language :: Python :: 3.9",
+               "Programming Language :: Python :: 3.10"]
 KEYWORDS = "machine learning, topological data analysis, persistent " \
            "homology, persistence diagrams, Mapper"
 INSTALL_REQUIRES = requirements


### PR DESCRIPTION
This can now be done thanks to the latest `giotto-ph` and `pyflagser` releases.

Adding Python 3.10 to Azure is just a temporary solution while we wait for #615 and/or other sibling PRs to fully migrate to GitHub actions.