### PR TITLE
Allow NumPy functions to pass type checks

### DIFF
--- a/gtda/curves/features.py
+++ b/gtda/curves/features.py
@@ -2,7 +2,7 @@
 # License: GNU AGPLv3
 
 from copy import deepcopy
-from types import FunctionType
+from typing import Callable
 
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted, check_array
@@ -79,9 +79,9 @@ class StandardFeatures(BaseEstimator, TransformerMixin):
 
     """
     _hyperparameters = {
-        "function": {"type": (str, FunctionType, list, tuple),
+        "function": {"type": (str, Callable, list, tuple),
                      "in": tuple(_AVAILABLE_FUNCTIONS.keys()),
-                     "of": {"type": (str, FunctionType, type(None)),
+                     "of": {"type": (str, Callable, type(None)),
                             "in": tuple(_AVAILABLE_FUNCTIONS.keys())}},
         "function_params": {"type": (dict, type(None), list, tuple)},
         }
@@ -99,7 +99,7 @@ class StandardFeatures(BaseEstimator, TransformerMixin):
         try:
             validate_params(params, _hyperparameters, exclude=["n_jobs"])
         # Another go if we fail because function is a list/tuple containing
-        # instances of FunctionType and the "in" key checks fail
+        # callables and the "in" key checks fail
         except ValueError as ve:
             end_string = f"which is not in " \
                          f"{tuple(_AVAILABLE_FUNCTIONS.keys())}."
@@ -117,7 +117,7 @@ class StandardFeatures(BaseEstimator, TransformerMixin):
             raise TypeError("If `function` is a list/tuple then "
                             "`function_params` must be a list/tuple of dict, "
                             "or None.")
-        elif isinstance(self.function, (str, FunctionType)) \
+        elif isinstance(self.function, (str, Callable)) \
                 and isinstance(self.function_params, (list, tuple)):
             raise TypeError("If `function` is a string or a callable "
                             "function then `function_params` must be a dict "
@@ -162,7 +162,7 @@ class StandardFeatures(BaseEstimator, TransformerMixin):
                                 _AVAILABLE_FUNCTIONS[self.function])
                 self.effective_function_params_ = self.function_params.copy()
 
-        elif isinstance(self.function, FunctionType):
+        elif isinstance(self.function, Callable):
             self.effective_function_ = \
                 tuple([self.function] * self.n_channels_)
 

--- a/gtda/diagrams/_metrics.py
+++ b/gtda/diagrams/_metrics.py
@@ -1,7 +1,7 @@
 # License: GNU AGPLv3
 
 from numbers import Real
-from types import FunctionType
+from typing import Callable
 
 import numpy as np
 from joblib import Parallel, delayed, effective_n_jobs
@@ -41,7 +41,7 @@ _AVAILABLE_METRICS = {
         'p': {'type': Real, 'in': Interval(1, np.inf, closed='both')},
         'n_bins': {'type': int, 'in': Interval(1, np.inf, closed='left')},
         'sigma': {'type': Real, 'in': Interval(0, np.inf, closed='neither')},
-        'weight_function': {'type': (FunctionType, type(None))}
+        'weight_function': {'type': (Callable, type(None))}
         },
     'silhouette': {
         'power': {'type': Real, 'in': Interval(0, np.inf, closed='right')},

--- a/gtda/diagrams/preprocessing.py
+++ b/gtda/diagrams/preprocessing.py
@@ -2,7 +2,7 @@
 # License: GNU AGPLv3
 
 from numbers import Real
-from types import FunctionType
+from typing import Callable
 
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
@@ -195,7 +195,7 @@ class Scaler(BaseEstimator, TransformerMixin, PlotterMixin):
     _hyperparameters = {
         'metric': {'type': str, 'in': _AVAILABLE_AMPLITUDE_METRICS.keys()},
         'metric_params': {'type': (dict, type(None))},
-        'function': {'type': (FunctionType, type(None))}
+        'function': {'type': (Callable, type(None))}
         }
 
     def __init__(self, metric='bottleneck', metric_params=None,

--- a/gtda/diagrams/representations.py
+++ b/gtda/diagrams/representations.py
@@ -1,7 +1,7 @@
 """Vector representations of persistence diagrams."""
 # License: GNU AGPLv3
 
-import types
+from typing import Callable
 from numbers import Real
 
 import numpy as np
@@ -813,7 +813,7 @@ class PersistenceImage(BaseEstimator, TransformerMixin, PlotterMixin):
     _hyperparameters = {
         "n_bins": {"type": int, "in": Interval(1, np.inf, closed="left")},
         "sigma": {"type": Real, "in": Interval(0, np.inf, closed="neither")},
-        "weight_function": {"type": (types.FunctionType, type(None))}
+        "weight_function": {"type": (Callable, type(None))}
         }
 
     def __init__(self, sigma=0.1, n_bins=100, weight_function=None,

--- a/gtda/graphs/transition.py
+++ b/gtda/graphs/transition.py
@@ -1,7 +1,7 @@
 """Construct transition graphs from dynamical systems."""
 # License: GNU AGPLv3
 
-from types import FunctionType
+from typing import Callable
 
 import numpy as np
 from joblib import Parallel, delayed
@@ -106,7 +106,7 @@ class TransitionGraph(BaseEstimator, TransformerMixin):
 
     """
 
-    _hyperparameters = {'func': {'type': (FunctionType, type(None))},
+    _hyperparameters = {'func': {'type': (Callable, type(None))},
                         'func_params': {'type': (dict, type(None))}}
 
     def __init__(self, func=np.argsort, func_params=None, n_jobs=None):

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -2,7 +2,7 @@
 # License: GNU AGPLv3
 
 from numbers import Real, Integral
-from types import FunctionType
+from typing import Callable
 
 import numpy as np
 from gph import ripser_parallel as ripser
@@ -146,7 +146,7 @@ class VietorisRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
     """
 
     _hyperparameters = {
-        "metric": {"type": (str, FunctionType)},
+        "metric": {"type": (str, Callable)},
         "metric_params": {"type": dict},
         "homology_dimensions": {
             "type": (list, tuple),
@@ -511,13 +511,13 @@ class WeightedRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
     """
 
     _hyperparameters = {
-        "metric": {"type": (str, FunctionType)},
+        "metric": {"type": (str, Callable)},
         "metric_params": {"type": dict},
         "homology_dimensions": {
             "type": (list, tuple),
             "of": {"type": int, "in": Interval(0, np.inf, closed="left")}
             },
-        "weights": {"type": (str, FunctionType)},
+        "weights": {"type": (str, Callable)},
         "weight_params": {"type": dict},
         "collapse_edges": {"type": bool},
         "coeff": {"type": int, "in": Interval(2, np.inf, closed="left")},
@@ -543,7 +543,7 @@ class WeightedRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         self.n_jobs = n_jobs
 
     def _ripser_diagram(self, X):
-        if isinstance(self.weights, FunctionType):
+        if isinstance(self.weights, Callable):
             weights = self.weights(X)
         else:
             weights = self.weights
@@ -828,7 +828,7 @@ class SparseRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
     """
 
     _hyperparameters = {
-        "metric": {"type": (str, FunctionType)},
+        "metric": {"type": (str, Callable)},
         "homology_dimensions": {
             "type": (list, tuple),
             "of": {"type": int, "in": Interval(0, np.inf, closed="left")}

--- a/gtda/images/filtrations.py
+++ b/gtda/images/filtrations.py
@@ -2,7 +2,7 @@
 # License: GNU AGPLv3
 
 from numbers import Real, Integral
-from types import FunctionType
+from typing import Callable
 import itertools
 
 import numpy as np
@@ -306,7 +306,7 @@ class RadialFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
     _hyperparameters = {
         'center': {'type': (np.ndarray, type(None)), 'of': {'type': Integral}},
         'radius': {'type': Real, 'in': Interval(0, np.inf, closed='right')},
-        'metric': {'type': (str, FunctionType)},
+        'metric': {'type': (str, Callable)},
         'metric_params': {'type': dict}
         }
 
@@ -1109,7 +1109,7 @@ class DensityFiltration(BaseEstimator, TransformerMixin, PlotterMixin):
 
     _hyperparameters = {
         'radius': {'type': Real, 'in': Interval(0, np.inf, closed='right')},
-        'metric': {'type': (str, FunctionType)},
+        'metric': {'type': (str, Callable)},
         'metric_params': {'type': dict},
         }
 

--- a/gtda/local_homology/simplicial.py
+++ b/gtda/local_homology/simplicial.py
@@ -1,5 +1,5 @@
 from numbers import Real
-from types import FunctionType
+from typing import Callable
 
 import numpy as np
 import warnings
@@ -250,7 +250,7 @@ class KNeighborsLocalVietorisRips(LocalVietorisRipsBase):
     """
 
     _hyperparameters = {
-        "metric": {"type": (str, FunctionType)},
+        "metric": {"type": (str, Callable)},
         "n_neighbors": {"type": (tuple, list),
                         "of": {type: int,
                                "in": Interval(1, np.inf, closed="left")}
@@ -388,7 +388,7 @@ class RadiusLocalVietorisRips(LocalVietorisRipsBase):
     """
 
     _hyperparameters = {
-        "metric": {"type": (str, FunctionType)},
+        "metric": {"type": (str, Callable)},
         "radii": {"type": (tuple, list),
                   "of": {type: Real, "in": Interval(0, np.inf, closed="left")}
                   },

--- a/gtda/point_clouds/rescaling.py
+++ b/gtda/point_clouds/rescaling.py
@@ -3,7 +3,7 @@
 
 import itertools
 from numbers import Real
-from types import FunctionType
+from typing import Callable
 
 import numpy as np
 from joblib import Parallel, delayed
@@ -92,7 +92,7 @@ class ConsistentRescaling(BaseEstimator, TransformerMixin, PlotterMixin):
     """
 
     _hyperparameters = {
-        'metric': {'type': (str, FunctionType)},
+        'metric': {'type': (str, Callable)},
         'metric_params': {'type': (dict, type(None))},
         'neighbor_rank': {'type': int,
                           'in': Interval(1, np.inf, closed='left')}
@@ -293,7 +293,7 @@ class ConsecutiveRescaling(BaseEstimator, TransformerMixin, PlotterMixin):
     """
 
     _hyperparameters = {
-        'metric': {'type': (str, FunctionType)},
+        'metric': {'type': (str, Callable)},
         'metric_params': {'type': (dict, type(None))},
         'factor': {'type': Real, 'in': Interval(0, np.inf, closed='both')}
         }

--- a/gtda/time_series/target.py
+++ b/gtda/time_series/target.py
@@ -2,7 +2,7 @@
 # License: GNU AGPLv3
 
 from numbers import Real
-from types import FunctionType
+from typing import Callable
 
 import numpy as np
 from sklearn.base import BaseEstimator
@@ -67,7 +67,7 @@ class Labeller(BaseEstimator, TransformerResamplerMixin):
 
     _hyperparameters = {
         'size': {'type': int, 'in': Interval(1, np.inf, closed='left')},
-        'func': {'type': FunctionType},
+        'func': {'type': Callable},
         'func_params': {'type': (dict, type(None))},
         'percentiles': {
             'type': (list, type(None)),


### PR DESCRIPTION
**Reference issues/PRs**
Fixes #682. Fixes #683.


**Types of changes**
<!--
What types of changes does your code introduce? Put an `x` in all the boxes that apply.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
As of NumPy 1.25, functions like `np.mean` are no longer instances of `types.FunctionType` (because they are C, rather than Python, functions). See [this discussion](https://github.com/numpy/numpy/issues/24019). This was leading to the error in #683 and #682, and causing a number of tests to fail.

This PR fixes the issue by replacing `types.FunctionType` with `typing.Callable`. (If this is considered too broad, an alternative solution would be to add `type(np.mean)` to the relevant type checks; I'd be happy to write this up instead.)

Tests on the files I updated are passing; some other tests are failing for me for reasons having to do with a behavior change in `sklearn`, unrelated to this PR.

**Checklist**
<!--
Go over all the following points, and put an `x` in all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. I used `pytest` to check this on Python tests.