### PR TITLE
Replace sklearn.utils.metaestimators.if_delegate_has_method with available_if

### DIFF
--- a/gtda/metaestimators/collection_transformer.py
+++ b/gtda/metaestimators/collection_transformer.py
@@ -9,7 +9,7 @@ import numpy as np
 from joblib import Parallel, delayed
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.base import clone
-from sklearn.utils.metaestimators import if_delegate_has_method
+from sklearn.utils.metaestimators import available_if
 
 from gtda.utils import check_collection
 
@@ -102,6 +102,12 @@ class CollectionTransformer(BaseEstimator, TransformerMixin):
                  "sklearn.base.BaseEstimator. This will lead to limited "
                  "functionality in a scikit-learn context.", UserWarning)
 
+    def _transformer_has(attr):
+        def check(self):
+            return hasattr(self.transformer, attr)
+ 
+        return check
+
     def fit(self, X, y=None):
         """Do nothing and return the estimator unchanged.
 
@@ -129,7 +135,7 @@ class CollectionTransformer(BaseEstimator, TransformerMixin):
         self._is_fitted = True
         return self
 
-    @if_delegate_has_method(delegate="transformer")
+    @available_if(_transformer_has("fit_transform"))
     def fit_transform(self, X, y=None):
         """Fit-transform a clone of `transformer` to each element in the
         collection `X`.

--- a/gtda/pipeline.py
+++ b/gtda/pipeline.py
@@ -4,7 +4,7 @@ Pipelines that include TransformerResamplers."""
 
 from sklearn import pipeline
 from sklearn.base import clone
-from sklearn.utils.metaestimators import if_delegate_has_method
+from sklearn.utils.metaestimators import available_if
 from sklearn.utils.validation import check_memory
 
 __all__ = ['Pipeline', 'make_pipeline']
@@ -94,6 +94,12 @@ class Pipeline(pipeline.Pipeline):
     >>> print(X_train_final.shape, y_train_final.shape)
     (389, 2) (389,)
     """
+
+    def _final_estimator_has(attr):
+        def check(self):
+            return hasattr(self._final_estimator, attr)
+
+        return check
 
     def _fit(self, X, y=None, **fit_params):
         self.steps = list(self.steps)
@@ -251,7 +257,7 @@ class Pipeline(pipeline.Pipeline):
         elif hasattr(last_step, 'fit_transform'):
             return last_step.fit_transform(Xt, yr, **fit_params), yr
 
-    @if_delegate_has_method(delegate='_final_estimator')
+    @available_if(_final_estimator_has('fit_predict'))
     def fit_predict(self, X, y=None, **fit_params):
         """Applies fit_predict of last step in pipeline after transforms.
 
@@ -407,7 +413,7 @@ class Pipeline(pipeline.Pipeline):
             Xt = transform.inverse_transform(Xt, yr)
         return Xt
 
-    @if_delegate_has_method(delegate='_final_estimator')
+    @available_if(_final_estimator_has('score'))
     def score(self, X, y=None, sample_weight=None):
         """Apply transformers/samplers, and score with the final estimator
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy >= 1.19.1
 scipy >= 1.5.0
 joblib >= 0.16.0
-scikit-learn >= 0.23.1
+scikit-learn >= 1.1.0
 giotto-ph >= 0.2.1
 pyflagser >= 0.4.3
 igraph >= 0.9.8


### PR DESCRIPTION
**Reference issues/PRs**
Fixes #680.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
This replaces occurrences of the deprecated `sklearn.utils.metaestimators.if_delegate_has_method`, which was removed in scikit-learn version 1.3, with `sklearn.utils.metaestimators.available_if`. Before this change, the pytest tests were throwing errors for me. This is a breaking change because the minimum version of scikit-learn has to be increased from 0.23.1 to 1.1.0.

**Screenshots (if appropriate)**

**Any other comments?**
I am still not passing all of the tests, but I think the failing tests are related to other issues.

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. I used `pytest` to check this on Python tests.