### PR TITLE
Update scikit-learn dependency to allow newer versions (Fixes #706)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy >= 1.19.1
 scipy >= 1.5.0
 joblib >= 0.16.0
-scikit-learn == 1.3.2
+scikit-learn >= 1.3.2
 giotto-ph >= 0.2.1
 pyflagser >= 0.4.3
 igraph >= 0.9.8


### PR DESCRIPTION
# Pull Request Description

**Title:** Fix scikit-learn dependency to allow newer versions

**Description:**

This pull request addresses the dependency issue related to `scikit-learn` that was identified in issue #706. The previous dependency specification required `scikit-learn` to be exactly version `1.3.2`. This restriction caused problems for users who had newer versions of `scikit-learn` installed, particularly for those using Python 3.12 and above, as it forced the installation of giotto-tda from source due to compatibility issues. 

**Changes Made:**
- Updated the dependency specification for `scikit-learn` in the project setup:
  - Changed from:
    ```
    scikit-learn == 1.3.2
    ```
  - To:
    ```
    scikit-learn >= 1.3.2
    ```
  
This modification allows users to install giotto-tda without unnecessary complications and without the need to rely on building from source, significantly improving the installation process.

**Impact:**
- Users can now install giotto-tda smoothly without facing build issues when they have newer versions of `scikit-learn` installed.
- This change ensures compatibility with the latest versions of the library while maintaining the necessary minimum version for functionality.

**Related Issue:**
- Fixes #706

Please review the changes, and feel free to reach out if you have any questions or need further clarification on this update. Thank you for your attention to this matter!