### PR TITLE
Fix: replace deprecated force_all_finite with ensure_all_finite for sklearn>=1.6

### DIFF
--- a/gtda/homology/cubical.py
+++ b/gtda/homology/cubical.py
@@ -149,7 +149,7 @@ class CubicalPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
         self : object
 
         """
-        X = check_collection(X, force_all_finite=False)
+        X = check_collection(X, ensure_all_finite=False)
         validate_params(
             self.get_params(), self._hyperparameters, exclude=['n_jobs'])
 
@@ -210,7 +210,7 @@ class CubicalPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         """
         check_is_fitted(self)
-        Xt = check_collection(X, force_all_finite=False)
+        Xt = check_collection(X, ensure_all_finite=False)
 
         Xt = Parallel(n_jobs=self.n_jobs)(delayed(self._gudhi_diagram)(x)
                                           for x in Xt)

--- a/gtda/homology/simplicial.py
+++ b/gtda/homology/simplicial.py
@@ -615,7 +615,7 @@ class WeightedRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
                             _AVAILABLE_RIPS_WEIGHTS[key])
 
         self._is_precomputed = self.metric == "precomputed"
-        check_point_clouds(X, accept_sparse=True, force_all_finite=True,
+        check_point_clouds(X, accept_sparse=True, ensure_all_finite=True,
                            distance_matrices=self._is_precomputed)
 
         if self.infinity_values is None:
@@ -681,7 +681,7 @@ class WeightedRipsPersistence(BaseEstimator, TransformerMixin, PlotterMixin):
 
         """
         check_is_fitted(self)
-        X = check_point_clouds(X, accept_sparse=True, force_all_finite=True,
+        X = check_point_clouds(X, accept_sparse=True, ensure_all_finite=True,
                                distance_matrices=self._is_precomputed)
 
         Xt = Parallel(n_jobs=self.n_jobs)(

--- a/gtda/metaestimators/collection_transformer.py
+++ b/gtda/metaestimators/collection_transformer.py
@@ -129,7 +129,7 @@ class CollectionTransformer(BaseEstimator, TransformerMixin):
 
         """
         check_collection(X, accept_sparse=True, accept_large_sparse=True,
-                         force_all_finite=False)
+                         ensure_all_finite=False)
         self._validate_transformer()
 
         self._is_fitted = True
@@ -157,7 +157,7 @@ class CollectionTransformer(BaseEstimator, TransformerMixin):
 
         """
         Xt = check_collection(X, accept_sparse=True, accept_large_sparse=True,
-                              force_all_finite=False)
+                              ensure_all_finite=False)
         self._validate_transformer()
 
         Xt = Parallel(n_jobs=self.n_jobs, prefer=self.parallel_backend_prefer,

--- a/gtda/utils/tests/test_validation.py
+++ b/gtda/utils/tests/test_validation.py
@@ -246,8 +246,8 @@ def test_check_point_clouds_regular_inf():
 
     check_point_clouds(ex.X, distance_matrices=True)
     check_point_clouds(ex.X_list, distance_matrices=True)
-    check_point_clouds(ex.X_rectang, force_all_finite=False)
-    check_point_clouds(ex.X_list_rectang, force_all_finite=False)
+    check_point_clouds(ex.X_rectang, ensure_all_finite=False)
+    check_point_clouds(ex.X_list_rectang, ensure_all_finite=False)
 
 
 def test_check_point_clouds_value_err_inf():
@@ -267,14 +267,16 @@ def test_check_point_clouds_value_err_inf():
     with pytest.raises(ValueError):
         check_point_clouds(ex.X_list_rectang)
 
-    # Check that we error if we explicitly set force_all_finite to True
+    # Check that we error if we explicitly set ensure_all_finite to True
     # 1) Array input
     with pytest.raises(ValueError):
-        check_point_clouds(ex.X, distance_matrices=True, force_all_finite=True)
+        check_point_clouds(
+            ex.X, distance_matrices=True, ensure_all_finite=True
+        )
     # 2) List input
     with pytest.raises(ValueError):
         check_point_clouds(
-            ex.X_list, distance_matrices=True, force_all_finite=True)
+            ex.X_list, distance_matrices=True, ensure_all_finite=True)
 
 
 def test_check_point_clouds_regular_nan():
@@ -286,15 +288,15 @@ def test_check_point_clouds_regular_nan():
         insert_nan()
 
     check_point_clouds(ex.X, distance_matrices=True,
-                       force_all_finite='allow-nan')
+                       ensure_all_finite='allow-nan')
     check_point_clouds(
-        ex.X_list, distance_matrices=True, force_all_finite='allow-nan')
-    check_point_clouds(ex.X_rectang, force_all_finite='allow-nan')
-    check_point_clouds(ex.X_list_rectang, force_all_finite='allow-nan')
+        ex.X_list, distance_matrices=True, ensure_all_finite='allow-nan')
+    check_point_clouds(ex.X_rectang, ensure_all_finite='allow-nan')
+    check_point_clouds(ex.X_list_rectang, ensure_all_finite='allow-nan')
 
 
-@pytest.mark.parametrize("force_all_finite", [True, False])
-def test_check_point_clouds_value_err_nan(force_all_finite):
+@pytest.mark.parametrize("ensure_all_finite", [True, False])
+def test_check_point_clouds_value_err_nan(ensure_all_finite):
     """Cases in which part of the input is NaN and we throw a
     ValueError."""
 
@@ -302,20 +304,20 @@ def test_check_point_clouds_value_err_nan(force_all_finite):
         n_samples, n_1, n_2, n_samples_extra, n_1_extra, n_2_extra).\
         insert_nan()
 
-    # Check that we error when force_all_finite is True or False
+    # Check that we error when ensure_all_finite is True or False
     # 1) Array input
     with pytest.raises(ValueError):
         check_point_clouds(
-            ex.X, distance_matrices=True, force_all_finite=force_all_finite)
+            ex.X, distance_matrices=True, ensure_all_finite=ensure_all_finite)
     with pytest.raises(ValueError):
-        check_point_clouds(ex.X_rectang, force_all_finite=force_all_finite)
+        check_point_clouds(ex.X_rectang, ensure_all_finite=ensure_all_finite)
     # 2) List input
     with pytest.raises(ValueError):
         check_point_clouds(ex.X_list, distance_matrices=True,
-                           force_all_finite=force_all_finite)
+                           ensure_all_finite=ensure_all_finite)
     with pytest.raises(ValueError):
         check_point_clouds(
-            ex.X_list_rectang, force_all_finite=force_all_finite)
+            ex.X_list_rectang, ensure_all_finite=ensure_all_finite)
 
 
 def test_check_collection_ragged_array():

--- a/gtda/utils/validation.py
+++ b/gtda/utils/validation.py
@@ -13,14 +13,14 @@ from sklearn.utils.validation import check_array
 
 def _check_array_mod(X, **kwargs):
     """Modified version of :func:`sklearn.utils.validation.check_array. When
-    keyword parameter `force_all_finite` is set to False, NaNs are not
+    keyword parameter `ensure_all_finite` is set to False, NaNs are not
     accepted but infinity is."""
-    if not kwargs.get('force_all_finite', True):
+    if not kwargs.get('ensure_all_finite', True):
         Xnew = check_array(X, **kwargs)
         if np.isnan(Xnew if not issparse(Xnew) else Xnew.data).any():
             raise ValueError("Input contains NaNs. Only finite values and "
                              "infinity are allowed when parameter "
-                             "`force_all_finite` is False.")
+                             "`ensure_all_finite` is False.")
         return Xnew
     return check_array(X, **kwargs)
 
@@ -48,7 +48,7 @@ def check_diagrams(X, copy=False):
 
     """
     X_array = _check_array_mod(X, ensure_2d=False, allow_nd=True,
-                               force_all_finite=False, copy=copy)
+                               ensure_all_finite=False, copy=copy)
     if X_array.ndim != 3:
         raise ValueError(
             f"Input should be a 3D ndarray, the shape is {X_array.shape}."
@@ -224,8 +224,8 @@ def check_point_clouds(X, distance_matrices=False, **kwargs):
         Keyword arguments accepted by
         :func:`sklearn.utils.validation.check_array`, with the following
         caveats: 1) `ensure_2d` and `allow_nd` are ignored; 2) if not passed
-        explicitly, `force_all_finite` is set to be the boolean negation of
-        `distance_matrices`; 3) when `force_all_finite` is set to ``False``,
+        explicitly, `ensure_all_finite` is set to be the boolean negation of
+        `distance_matrices`; 3) when `ensure_all_finite` is set to ``False``,
         NaN inputs are not allowed; 4) `accept_sparse` and
         `accept_large_sparse` are only meaningful in the case of lists of 2D
         arrays, in which case they are passed to individual instances of
@@ -238,7 +238,7 @@ def check_point_clouds(X, distance_matrices=False, **kwargs):
         The converted and validated object.
 
     """
-    kwargs_ = {'force_all_finite': not distance_matrices}
+    kwargs_ = {'ensure_all_finite': not distance_matrices}
     kwargs_.update(kwargs)
     kwargs_.pop('allow_nd', None)
     kwargs_.pop('ensure_2d', None)
@@ -321,7 +321,7 @@ def check_collection(X, **kwargs):
         Keyword arguments accepted by
         :func:`sklearn.utils.validation.check_array`, with the following
         caveats: 1) `ensure_2d` and `allow_nd` are ignored; 2) when
-        `force_all_finite` is set to ``False``, NaN inputs are not allowed.
+        `ensure_all_finite` is set to ``False``, NaN inputs are not allowed.
 
     Returns
     -------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy >= 1.19.1
 scipy >= 1.5.0
 joblib >= 0.16.0
-scikit-learn == 1.3.2
+scikit-learn >= 1.6
 giotto-ph >= 0.2.1
 pyflagser >= 0.4.3
 igraph >= 0.9.8


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the guidelines for contributing: https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines
-->

**Reference issues/PRs**
Fixes #719 
This PR updates giotto‑tda’s use of `sklearn.utils.check_array` to maintain compatibility with scikit‑learn ≥ 1.6, which removed the `force_all_finite` parameter. The new parameter `ensure_all_finite` is now used instead.

**Types of changes**
- Replaced all occurrences of `force_all_finite` with `ensure_all_finite`
- The change is **not** backward‑compatible with scikit‑learn < 1.6

**Description**
Replaced all occurrences of `force_all_finite` with `ensure_all_finite` occurring in 5 files `homology\cubical.py`, `homology\simplicial.py`, `metaestimators\collection_transformer.py`, `test_validation.py` and `utils\validation.py`.

**Any other comments?**
This is a minimal, safe compatibility patch.
No functional behavior of giotto‑tda is changed beyond restoring compatibility.

**Checklist**
<!--
Go over all the following points, and put an `x` in all the boxes that apply. 
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. I used `pytest` to check this on Python tests.
- [x] Amended `requirements.txt` with `scikit-learn >= 1.6`.

<!--
We value all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
